### PR TITLE
feat: add bulk delete hint to footer

### DIFF
--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -332,7 +332,7 @@ fn render_footer(f: &mut Frame, area: Rect, app: &App) {
 
     parts.push(Span::styled(
         format!(
-            " │ sort:{} │ tab agent │ ↑↓ nav │ → detail │ enter select │ ^s sort │ esc quit",
+            " │ sort:{} │ tab agent │ ↑↓ nav │ → detail │ enter select │ ^s sort │ ^d bulk del │ esc quit",
             app.sort_mode.label()
         ),
         Style::new().fg(GRAY_500),


### PR DESCRIPTION
## Summary
- Added `^d bulk del` shortcut hint to the footer status bar
- Helps users discover the bulk delete feature more easily

## Changes
- `src/tui/render.rs`: Added bulk delete keybinding hint to footer format string

🤖 Generated with [Claude Code](https://claude.ai/code)