### PR TITLE
chore: release v0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agf"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "agf"
-version = "0.7.3"
+version = "0.8.0"
 edition = "2021"
-description = "AI Agent Session Finder TUI — unified launcher for Claude Code, Codex, and OpenCode sessions"
+description = "AI Agent Session Finder TUI — find, resume, and manage Claude Code, Codex, OpenCode, Gemini, Kiro, pi, and Cursor CLI sessions"
 license = "MIT"
 repository = "https://github.com/subinium/agf"
 keywords = ["tui", "cli", "ai", "agent", "claude"]

--- a/src/action.rs
+++ b/src/action.rs
@@ -17,8 +17,12 @@ pub fn generate_command(
             let cmd = agent.new_session_cmd();
             Some(format!("cd {escaped_path} && {cmd}"))
         }
+        Action::Open => {
+            let editor = detect_editor();
+            Some(format!("cd {escaped_path} && {editor} ."))
+        }
         Action::Cd => Some(format!("cd {escaped_path}")),
-        Action::Delete | Action::Back => None,
+        Action::Delete | Action::Back | Action::Pin => None,
     }
 }
 
@@ -26,10 +30,33 @@ pub fn action_preview(session: &Session, action: Action) -> String {
     match action {
         Action::Resume => session.agent.resume_cmd(&session.session_id),
         Action::NewSession => "choose agent CLI...".to_string(),
+        Action::Open => format!("{} .", detect_editor()),
         Action::Cd => format!("cd {}", session.display_path()),
+        Action::Pin => "toggle pin".to_string(),
         Action::Delete => "remove session data".to_string(),
         Action::Back => "return to session list".to_string(),
     }
+}
+
+/// Detect editor from config, then $EDITOR, then $VISUAL, fallback to "vim".
+pub fn detect_editor() -> String {
+    let config = crate::settings::Settings::load();
+    if let Some(ref editor) = config.editor {
+        if !editor.is_empty() {
+            return editor.clone();
+        }
+    }
+    if let Ok(editor) = std::env::var("EDITOR") {
+        if !editor.is_empty() {
+            return editor;
+        }
+    }
+    if let Ok(editor) = std::env::var("VISUAL") {
+        if !editor.is_empty() {
+            return editor;
+        }
+    }
+    "vim".to_string()
 }
 
 pub fn resume_with_flags(session: &Session, flags: &str) -> String {

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,0 +1,216 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+use std::time::SystemTime;
+
+use serde::{Deserialize, Serialize};
+
+use crate::model::{Agent, Session};
+use crate::plugin;
+
+const CACHE_VERSION: u32 = 1;
+
+#[derive(Serialize, Deserialize)]
+struct CacheFile {
+    version: u32,
+    agents: HashMap<String, AgentCache>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct AgentCache {
+    mtime: u64, // Unix seconds of data source last modification
+    sessions: Vec<CachedSession>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct CachedSession {
+    agent: String,
+    session_id: String,
+    project_name: String,
+    project_path: String,
+    summaries: Vec<String>,
+    timestamp: i64,
+    git_branch: Option<String>,
+    worktree: Option<String>,
+}
+
+fn cache_path() -> PathBuf {
+    dirs::cache_dir()
+        .unwrap_or_else(|| dirs::home_dir().unwrap_or_default().join(".cache"))
+        .join("agf")
+        .join("sessions.json")
+}
+
+fn agent_from_str(s: &str) -> Option<Agent> {
+    match s {
+        "ClaudeCode" => Some(Agent::ClaudeCode),
+        "Codex" => Some(Agent::Codex),
+        "OpenCode" => Some(Agent::OpenCode),
+        "Pi" => Some(Agent::Pi),
+        "Kiro" => Some(Agent::Kiro),
+        "CursorAgent" => Some(Agent::CursorAgent),
+        "Gemini" => Some(Agent::Gemini),
+        _ => None,
+    }
+}
+
+fn agent_to_str(a: Agent) -> &'static str {
+    match a {
+        Agent::ClaudeCode => "ClaudeCode",
+        Agent::Codex => "Codex",
+        Agent::OpenCode => "OpenCode",
+        Agent::Pi => "Pi",
+        Agent::Kiro => "Kiro",
+        Agent::CursorAgent => "CursorAgent",
+        Agent::Gemini => "Gemini",
+    }
+}
+
+fn to_cached(s: &Session) -> CachedSession {
+    CachedSession {
+        agent: agent_to_str(s.agent).to_string(),
+        session_id: s.session_id.clone(),
+        project_name: s.project_name.clone(),
+        project_path: s.project_path.clone(),
+        summaries: s.summaries.iter().take(10).cloned().collect(),
+        timestamp: s.timestamp,
+        git_branch: s.git_branch.clone(),
+        worktree: s.worktree.clone(),
+    }
+}
+
+fn from_cached(c: &CachedSession) -> Option<Session> {
+    let agent = agent_from_str(&c.agent)?;
+    Some(Session {
+        agent,
+        session_id: c.session_id.clone(),
+        project_name: c.project_name.clone(),
+        project_path: c.project_path.clone(),
+        summaries: c.summaries.clone(),
+        timestamp: c.timestamp,
+        git_branch: c.git_branch.clone(),
+        worktree: c.worktree.clone(),
+    })
+}
+
+fn get_max_mtime(paths: &[PathBuf]) -> u64 {
+    paths
+        .iter()
+        .filter_map(|p| fs::metadata(p).ok())
+        .filter_map(|m| m.modified().ok())
+        .filter_map(|t| t.duration_since(SystemTime::UNIX_EPOCH).ok())
+        .map(|d| d.as_secs())
+        .max()
+        .unwrap_or(0)
+}
+
+/// Load cached sessions. Returns (sessions, stale_agents).
+/// stale_agents are agents whose data sources have changed since cache was written.
+pub fn load_cache() -> (Vec<Session>, Vec<Agent>) {
+    let path = cache_path();
+    let content = match fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(_) => return (Vec::new(), Agent::all().to_vec()),
+    };
+
+    let cache: CacheFile = match serde_json::from_str::<CacheFile>(&content) {
+        Ok(c) if c.version == CACHE_VERSION => c,
+        _ => return (Vec::new(), Agent::all().to_vec()),
+    };
+
+    let plugins = plugin::all_plugins();
+    let mut sessions = Vec::new();
+    let mut stale = Vec::new();
+
+    for p in &plugins {
+        let key = agent_to_str(p.agent());
+        let current_mtime = get_max_mtime(&p.data_sources());
+
+        match cache.agents.get(key) {
+            Some(ac) if ac.mtime >= current_mtime && current_mtime > 0 => {
+                // Cache is fresh
+                for cs in &ac.sessions {
+                    if let Some(s) = from_cached(cs) {
+                        sessions.push(s);
+                    }
+                }
+            }
+            _ => {
+                stale.push(p.agent());
+            }
+        }
+    }
+
+    sessions.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+    (sessions, stale)
+}
+
+/// Write all sessions to cache, grouped by agent.
+pub fn write_cache(sessions: &[Session]) {
+    let path = cache_path();
+    if let Some(parent) = path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+
+    let plugins = plugin::all_plugins();
+    let mut agents: HashMap<String, AgentCache> = HashMap::new();
+
+    for p in &plugins {
+        let key = agent_to_str(p.agent()).to_string();
+        let agent_sessions: Vec<CachedSession> = sessions
+            .iter()
+            .filter(|s| s.agent == p.agent())
+            .map(to_cached)
+            .collect();
+        let mtime = get_max_mtime(&p.data_sources());
+        agents.insert(
+            key,
+            AgentCache {
+                mtime,
+                sessions: agent_sessions,
+            },
+        );
+    }
+
+    let cache = CacheFile {
+        version: CACHE_VERSION,
+        agents,
+    };
+
+    if let Ok(json) = serde_json::to_string(&cache) {
+        let _ = fs::write(&path, json);
+    }
+}
+
+/// Scan only the specified agents and merge with existing sessions.
+pub fn scan_stale_agents(stale: &[Agent], existing: &mut Vec<Session>) {
+    use std::thread;
+
+    let handles: Vec<_> = stale
+        .iter()
+        .map(|agent| {
+            let agent = *agent;
+            thread::spawn(move || {
+                let plugins = plugin::all_plugins();
+                for p in &plugins {
+                    if p.agent() == agent {
+                        return p.scan();
+                    }
+                }
+                Vec::new()
+            })
+        })
+        .collect();
+
+    // Remove old sessions for stale agents
+    existing.retain(|s| !stale.contains(&s.agent));
+
+    // Add fresh sessions
+    for h in handles {
+        if let Ok(new_sessions) = h.join() {
+            existing.extend(new_sessions);
+        }
+    }
+
+    existing.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+}

--- a/src/list.rs
+++ b/src/list.rs
@@ -1,0 +1,211 @@
+use std::io::{self, IsTerminal, Write};
+
+use crate::model::Session;
+
+pub enum OutputFormat {
+    Table,
+    Json,
+    Csv,
+}
+
+impl OutputFormat {
+    pub fn parse(s: &str) -> Self {
+        match s.to_lowercase().as_str() {
+            "json" => Self::Json,
+            "csv" => Self::Csv,
+            _ => Self::Table,
+        }
+    }
+}
+
+pub fn list_sessions(sessions: &[Session], format: OutputFormat) {
+    match format {
+        OutputFormat::Table => print_table(sessions),
+        OutputFormat::Json => print_json(sessions),
+        OutputFormat::Csv => print_csv(sessions),
+    }
+}
+
+struct Ansi {
+    enabled: bool,
+}
+
+impl Ansi {
+    fn new() -> Self {
+        Self {
+            enabled: io::stdout().is_terminal(),
+        }
+    }
+    fn rgb(&self, r: u8, g: u8, b: u8, text: &str) -> String {
+        if self.enabled {
+            format!("\x1b[38;2;{r};{g};{b}m{text}\x1b[0m")
+        } else {
+            text.to_string()
+        }
+    }
+    fn bold(&self, text: &str) -> String {
+        if self.enabled {
+            format!("\x1b[1m{text}\x1b[0m")
+        } else {
+            text.to_string()
+        }
+    }
+    fn dim(&self, text: &str) -> String {
+        if self.enabled {
+            format!("\x1b[2m{text}\x1b[0m")
+        } else {
+            text.to_string()
+        }
+    }
+    fn bold_rgb(&self, r: u8, g: u8, b: u8, text: &str) -> String {
+        if self.enabled {
+            format!("\x1b[1;38;2;{r};{g};{b}m{text}\x1b[0m")
+        } else {
+            text.to_string()
+        }
+    }
+}
+
+fn print_table(sessions: &[Session]) {
+    if sessions.is_empty() {
+        return;
+    }
+
+    let a = Ansi::new();
+    let mut out = io::stdout().lock();
+
+    let max_project = sessions
+        .iter()
+        .map(|s| s.project_name.len())
+        .max()
+        .unwrap_or(7)
+        .clamp(7, 25);
+    let max_agent = 12;
+
+    // Title
+    let _ = writeln!(out);
+    let _ = writeln!(
+        out,
+        "  {} {}",
+        a.bold("agf"),
+        a.dim(&format!("— {} sessions", sessions.len()))
+    );
+    let _ = writeln!(out);
+
+    // Header
+    let _ = writeln!(
+        out,
+        "  {}",
+        a.dim(&format!(
+            " {:<3}  {:<max_project$}  {:<max_agent$}  {:<14}  {:<10}  {}",
+            "#", "PROJECT", "AGENT", "TIME", "BRANCH", "PATH"
+        ))
+    );
+    let _ = writeln!(
+        out,
+        "  {}",
+        a.dim(&format!(
+            " {}  {}  {}  {}  {}  {}",
+            "─".repeat(3),
+            "─".repeat(max_project),
+            "─".repeat(max_agent),
+            "─".repeat(14),
+            "─".repeat(10),
+            "─".repeat(20)
+        ))
+    );
+
+    for (i, s) in sessions.iter().enumerate() {
+        let path = s.display_path();
+        let (r, g, b_val) = s.agent.color();
+        let project = format!("{:<max_project$}", truncate(&s.project_name, max_project));
+        let agent = format!("{:<max_agent$}", truncate(&s.agent.to_string(), max_agent));
+        let time = format!("{:<14}", s.time_display());
+        let branch = format!(
+            "{:<10}",
+            truncate(s.git_branch.as_deref().unwrap_or("—"), 10)
+        );
+        let num = format!("{:>3}", i + 1);
+
+        let _ = writeln!(
+            out,
+            "   {}  {}  {}  {}  {}  {}",
+            a.dim(&num),
+            a.bold(&project),
+            a.bold_rgb(r, g, b_val, &agent),
+            a.dim(&time),
+            a.rgb(52, 211, 153, &branch),
+            a.dim(&path),
+        );
+    }
+    let _ = writeln!(out);
+}
+
+fn print_json(sessions: &[Session]) {
+    let items: Vec<serde_json::Value> = sessions
+        .iter()
+        .map(|s| {
+            serde_json::json!({
+                "agent": s.agent.to_string(),
+                "session_id": s.session_id,
+                "project_name": s.project_name,
+                "project_path": s.project_path,
+                "timestamp": s.timestamp,
+                "time": s.time_display(),
+                "git_branch": s.git_branch,
+                "worktree": s.worktree,
+                "summaries": s.summaries,
+            })
+        })
+        .collect();
+    if let Ok(json) = serde_json::to_string_pretty(&items) {
+        println!("{json}");
+    }
+}
+
+fn print_csv(sessions: &[Session]) {
+    println!("project,agent,time,path,session_id,branch");
+    for s in sessions {
+        println!(
+            "{},{},{},{},{},{}",
+            csv_escape(&s.project_name),
+            s.agent,
+            s.time_display(),
+            csv_escape(&s.project_path),
+            s.session_id,
+            s.git_branch.as_deref().unwrap_or(""),
+        );
+    }
+}
+
+fn csv_escape(s: &str) -> String {
+    if s.contains(',') || s.contains('"') || s.contains('\n') {
+        format!("\"{}\"", s.replace('"', "\"\""))
+    } else {
+        s.to_string()
+    }
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        format!("{}…", &s[..max.saturating_sub(1)])
+    }
+}
+
+pub fn filter_by_agent(sessions: Vec<Session>, agent_name: &str) -> Vec<Session> {
+    let agent_lower = agent_name.to_lowercase();
+    sessions
+        .into_iter()
+        .filter(|s| {
+            s.agent.cli_name().to_lowercase() == agent_lower
+                || s.agent.to_string().to_lowercase() == agent_lower
+                || s.agent
+                    .to_string()
+                    .to_lowercase()
+                    .replace(' ', "")
+                    .contains(&agent_lower)
+        })
+        .collect()
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,18 @@
 mod action;
+mod cache;
 mod config;
 mod delete;
 mod error;
 mod fuzzy;
+mod list;
 mod model;
+mod plugin;
 mod scanner;
 mod settings;
 mod shell;
+mod stats;
 mod tui;
+mod watch;
 
 use clap::{Parser, Subcommand};
 
@@ -38,6 +43,39 @@ enum Commands {
     Resume {
         /// Fuzzy query to match a session (project name, path, summary)
         query: Vec<String>,
+        /// Filter by agent name (e.g. claude, codex, gemini)
+        #[arg(long)]
+        agent: Option<String>,
+        /// Show top N matches interactively instead of picking the best
+        #[arg(long)]
+        list: Option<usize>,
+        /// Permission/approval mode (e.g. acceptEdits, yolo, full-auto)
+        #[arg(long)]
+        mode: Option<String>,
+    },
+    /// List sessions as plain text (for scripting)
+    List {
+        /// Filter by agent name (e.g. claude, codex, gemini)
+        #[arg(long)]
+        agent: Option<String>,
+        /// Maximum number of sessions to show
+        #[arg(long, default_value = "20")]
+        limit: usize,
+        /// Output format: table, json, csv
+        #[arg(long, default_value = "table")]
+        format: String,
+    },
+    /// Show session statistics
+    Stats {
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+    /// Live dashboard showing agent sessions with auto-refresh
+    Watch {
+        /// Refresh interval in seconds
+        #[arg(long, default_value = "5")]
+        interval: u64,
     },
 }
 
@@ -62,9 +100,17 @@ fn main() -> anyhow::Result<()> {
             shell::setup()?;
             return Ok(());
         }
-        Some(Commands::Resume { query }) => {
+        Some(Commands::Resume {
+            query,
+            agent,
+            list: list_count,
+            mode,
+        }) => {
             let query = query.join(" ");
-            let sessions = scanner::scan_all();
+            let mut sessions = scanner::scan_all();
+            if let Some(ref agent_name) = agent {
+                sessions = list::filter_by_agent(sessions, agent_name);
+            }
             let mut fuzzy = fuzzy::FuzzyMatcher::new();
             let results = fuzzy.filter(&sessions, &query, 5, false);
 
@@ -73,21 +119,86 @@ fn main() -> anyhow::Result<()> {
                 std::process::exit(1);
             }
 
-            let best = &sessions[results[0].index];
-            if let Some(cmd) = action::generate_command(best, model::Action::Resume, None) {
-                if let Ok(file) = std::env::var("AGF_CMD_FILE") {
-                    std::fs::write(&file, &cmd)?;
-                } else {
-                    println!("{cmd}");
+            let chosen = if let Some(n) = list_count {
+                // Interactive: show top N and let user pick
+                let top_n = results.iter().take(n).collect::<Vec<_>>();
+                for (i, r) in top_n.iter().enumerate() {
+                    let s = &sessions[r.index];
+                    eprintln!(
+                        "  {}) {} | {} | {}",
+                        i + 1,
+                        s.agent,
+                        s.project_name,
+                        s.time_display()
+                    );
                 }
+                eprint!("Select [1-{}]: ", top_n.len());
+                let mut input = String::new();
+                std::io::stdin().read_line(&mut input)?;
+                let pick: usize = input.trim().parse().unwrap_or(1);
+                let idx = pick.saturating_sub(1).min(top_n.len() - 1);
+                &sessions[top_n[idx].index]
+            } else {
+                &sessions[results[0].index]
+            };
+
+            // Build resume command with optional mode flags
+            let flags = mode
+                .as_deref()
+                .and_then(|m| {
+                    chosen
+                        .agent
+                        .resume_mode_options()
+                        .iter()
+                        .find(|(label, _)| label.to_lowercase().contains(&m.to_lowercase()))
+                        .map(|(_, f)| *f)
+                })
+                .unwrap_or("");
+
+            let cmd = action::resume_with_flags(chosen, flags);
+            if let Ok(file) = std::env::var("AGF_CMD_FILE") {
+                std::fs::write(&file, &cmd)?;
+            } else {
+                println!("{cmd}");
             }
+            return Ok(());
+        }
+        Some(Commands::List {
+            agent,
+            limit,
+            format,
+        }) => {
+            let mut sessions = scanner::scan_all();
+            if let Some(ref agent_name) = agent {
+                sessions = list::filter_by_agent(sessions, agent_name);
+            }
+            sessions.truncate(limit);
+            if sessions.is_empty() {
+                eprintln!("No sessions found.");
+                std::process::exit(1);
+            }
+            list::list_sessions(&sessions, list::OutputFormat::parse(&format));
+            return Ok(());
+        }
+        Some(Commands::Stats { json }) => {
+            let sessions = scanner::scan_all();
+            stats::print_stats(&sessions, json);
+            return Ok(());
+        }
+        Some(Commands::Watch { interval }) => {
+            watch::run_watch(interval)?;
             return Ok(());
         }
         None => {}
     }
 
     let config = settings::Settings::load();
-    let mut sessions = scanner::scan_all();
+    // Use cache for faster TUI startup
+    let (mut sessions, stale_agents) = cache::load_cache();
+    if !stale_agents.is_empty() {
+        cache::scan_stale_agents(&stale_agents, &mut sessions);
+        cache::write_cache(&sessions);
+    }
 
     // Apply max_sessions limit from config
     if let Some(max) = config.max_sessions {
@@ -99,12 +210,17 @@ fn main() -> anyhow::Result<()> {
         return Ok(());
     }
 
+    let cwd = std::env::current_dir()
+        .ok()
+        .and_then(|p| p.to_str().map(|s| s.to_string()));
     let include_summaries = config.search_scope == "all";
     let mut app = tui::App::new(
         sessions,
         cli.query,
         config.summary_search_count,
         include_summaries,
+        cwd,
+        config.pinned_sessions.clone(),
     );
 
     // Apply sort_by from config

--- a/src/model.rs
+++ b/src/model.rs
@@ -225,28 +225,33 @@ impl Session {
 pub enum Action {
     Resume,
     NewSession,
+    Open,
     Cd,
+    Pin,
     Delete,
     Back,
 }
 
 impl Action {
-    pub const MENU: [Action; 5] = [
+    pub const MENU: [Action; 6] = [
         Action::Resume,
         Action::NewSession,
+        Action::Open,
         Action::Cd,
+        Action::Pin,
         Action::Delete,
-        Action::Back,
     ];
 }
 
 impl fmt::Display for Action {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Action::Resume => write!(f, "Resume session"),
-            Action::NewSession => write!(f, "New session"),
-            Action::Cd => write!(f, "cd to directory"),
-            Action::Delete => write!(f, "Delete session"),
+            Action::Resume => write!(f, "Resume Session"),
+            Action::NewSession => write!(f, "New Session"),
+            Action::Open => write!(f, "Open in Editor"),
+            Action::Cd => write!(f, "Go to Directory"),
+            Action::Pin => write!(f, "Pin Session"),
+            Action::Delete => write!(f, "Delete Session"),
             Action::Back => write!(f, "← Back"),
         }
     }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,0 +1,120 @@
+use std::io;
+use std::path::PathBuf;
+
+use crate::model::{Agent, Session};
+
+/// Trait for agent plugins. Each AI agent scanner implements this.
+/// Some methods are reserved for future use (e.g., direct dispatch instead of match on Agent).
+#[allow(dead_code)]
+pub trait AgentPlugin: Send + Sync {
+    fn agent(&self) -> Agent;
+    fn name(&self) -> &str;
+    fn cli_name(&self) -> &str;
+    fn color(&self) -> (u8, u8, u8);
+    fn scan(&self) -> Vec<Session>;
+    fn delete(&self, session: &Session) -> Result<(), io::Error>;
+    fn resume_cmd(&self, session_id: &str) -> String;
+    fn new_session_cmd(&self) -> &str;
+    fn resume_mode_options(&self) -> &[(&str, &str)] {
+        &[("default", "")]
+    }
+    /// Paths to check for mtime-based cache invalidation.
+    fn data_sources(&self) -> Vec<PathBuf>;
+}
+
+/// Return all registered agent plugins.
+pub fn all_plugins() -> Vec<Box<dyn AgentPlugin>> {
+    vec![
+        Box::new(PluginAdapter(Agent::ClaudeCode)),
+        Box::new(PluginAdapter(Agent::Codex)),
+        Box::new(PluginAdapter(Agent::OpenCode)),
+        Box::new(PluginAdapter(Agent::Pi)),
+        Box::new(PluginAdapter(Agent::Kiro)),
+        Box::new(PluginAdapter(Agent::CursorAgent)),
+        Box::new(PluginAdapter(Agent::Gemini)),
+    ]
+}
+
+/// Adapter that bridges the existing Agent enum methods to the AgentPlugin trait.
+/// This allows incremental migration — scanners can be moved to direct trait impls later.
+struct PluginAdapter(Agent);
+
+impl AgentPlugin for PluginAdapter {
+    fn agent(&self) -> Agent {
+        self.0
+    }
+
+    fn name(&self) -> &str {
+        match self.0 {
+            Agent::ClaudeCode => "Claude Code",
+            Agent::Codex => "Codex",
+            Agent::OpenCode => "OpenCode",
+            Agent::Pi => "pi",
+            Agent::Kiro => "Kiro",
+            Agent::CursorAgent => "Cursor CLI",
+            Agent::Gemini => "Gemini",
+        }
+    }
+
+    fn cli_name(&self) -> &str {
+        self.0.cli_name()
+    }
+
+    fn color(&self) -> (u8, u8, u8) {
+        self.0.color()
+    }
+
+    fn scan(&self) -> Vec<Session> {
+        use crate::scanner;
+        match self.0 {
+            Agent::ClaudeCode => scanner::claude::scan().unwrap_or_default(),
+            Agent::Codex => scanner::codex::scan().unwrap_or_default(),
+            Agent::OpenCode => scanner::opencode::scan().unwrap_or_default(),
+            Agent::Pi => scanner::pi::scan().unwrap_or_default(),
+            Agent::Kiro => scanner::kiro::scan().unwrap_or_default(),
+            Agent::CursorAgent => scanner::cursor_agent::scan().unwrap_or_default(),
+            Agent::Gemini => scanner::gemini::scan().unwrap_or_default(),
+        }
+    }
+
+    fn delete(&self, session: &Session) -> Result<(), io::Error> {
+        crate::delete::delete_session(session)
+    }
+
+    fn resume_cmd(&self, session_id: &str) -> String {
+        self.0.resume_cmd(session_id)
+    }
+
+    fn new_session_cmd(&self) -> &str {
+        self.0.new_session_cmd()
+    }
+
+    fn resume_mode_options(&self) -> &[(&str, &str)] {
+        self.0.resume_mode_options()
+    }
+
+    fn data_sources(&self) -> Vec<PathBuf> {
+        use crate::config;
+        match self.0 {
+            Agent::ClaudeCode => config::claude_dir()
+                .map(|d| vec![d.join("history.jsonl")])
+                .unwrap_or_default(),
+            Agent::Codex => config::codex_dir().map(|d| vec![d]).unwrap_or_default(),
+            Agent::OpenCode => config::opencode_data_dir()
+                .map(|d| vec![d.join("opencode.db")])
+                .unwrap_or_default(),
+            Agent::Pi => config::pi_sessions_dir()
+                .map(|d| vec![d])
+                .unwrap_or_default(),
+            Agent::Kiro => config::kiro_data_dir()
+                .map(|d| vec![d.join("data.sqlite3")])
+                .unwrap_or_default(),
+            Agent::CursorAgent => config::cursor_dir()
+                .map(|d| vec![d.join("chats"), d.join("projects")])
+                .unwrap_or_default(),
+            Agent::Gemini => config::gemini_dir()
+                .map(|d| vec![d.join("tmp")])
+                .unwrap_or_default(),
+        }
+    }
+}

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,8 +1,8 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::PathBuf;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Settings {
     #[serde(default)]
     pub sort_by: Option<String>, // "time", "name", "agent"
@@ -12,6 +12,10 @@ pub struct Settings {
     pub summary_search_count: usize, // number of summaries included in fuzzy search (default 5)
     #[serde(default = "default_search_scope")]
     pub search_scope: String, // "name_path" (default) | "all"
+    #[serde(default)]
+    pub editor: Option<String>, // editor command (e.g. "code", "cursor"). Falls back to $EDITOR/$VISUAL
+    #[serde(default)]
+    pub pinned_sessions: Vec<String>, // session IDs pinned to top of list
 }
 
 fn default_summary_search_count() -> usize {
@@ -29,6 +33,8 @@ impl Default for Settings {
             max_sessions: None,
             summary_search_count: default_summary_search_count(),
             search_scope: default_search_scope(),
+            editor: None,
+            pinned_sessions: Vec::new(),
         }
     }
 }
@@ -48,31 +54,42 @@ impl Settings {
         }
     }
 
-    /// Persist editable fields to config.toml, preserving unrelated keys.
+    /// Persist settings to config.toml.
     pub fn save_editable(&self) {
         let path = config_path();
         if let Some(parent) = path.parent() {
             let _ = fs::create_dir_all(parent);
         }
 
-        // Re-parse existing file line by line, replacing or appending the two keys
-        let existing = fs::read_to_string(&path).unwrap_or_default();
-        let mut lines: Vec<String> = existing
-            .lines()
-            .filter(|l| {
-                let t = l.trim_start();
-                !t.starts_with("search_scope") && !t.starts_with("summary_search_count")
-            })
-            .map(|l| l.to_string())
-            .collect();
+        // Load existing config and merge editable fields
+        let mut existing: toml::Table = fs::read_to_string(&path)
+            .ok()
+            .and_then(|c| c.parse().ok())
+            .unwrap_or_default();
 
-        lines.push(format!("search_scope = {:?}", self.search_scope));
-        lines.push(format!(
-            "summary_search_count = {}",
-            self.summary_search_count
-        ));
+        existing.insert(
+            "search_scope".to_string(),
+            toml::Value::String(self.search_scope.clone()),
+        );
+        existing.insert(
+            "summary_search_count".to_string(),
+            toml::Value::Integer(self.summary_search_count as i64),
+        );
+        if !self.pinned_sessions.is_empty() {
+            existing.insert(
+                "pinned_sessions".to_string(),
+                toml::Value::Array(
+                    self.pinned_sessions
+                        .iter()
+                        .map(|s| toml::Value::String(s.clone()))
+                        .collect(),
+                ),
+            );
+        } else {
+            existing.remove("pinned_sessions");
+        }
 
-        let _ = fs::write(&path, lines.join("\n") + "\n");
+        let _ = fs::write(&path, existing.to_string());
     }
 }
 

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,0 +1,274 @@
+use std::collections::HashMap;
+use std::io::{self, IsTerminal, Write};
+
+use crate::model::{Agent, Session};
+
+pub fn print_stats(sessions: &[Session], json: bool) {
+    if json {
+        print_json(sessions);
+    } else {
+        print_text(sessions);
+    }
+}
+
+struct Ansi {
+    enabled: bool,
+}
+
+impl Ansi {
+    fn new() -> Self {
+        Self {
+            enabled: io::stdout().is_terminal(),
+        }
+    }
+    fn rgb(&self, r: u8, g: u8, b: u8, text: &str) -> String {
+        if self.enabled {
+            format!("\x1b[38;2;{r};{g};{b}m{text}\x1b[0m")
+        } else {
+            text.to_string()
+        }
+    }
+    fn bold(&self, text: &str) -> String {
+        if self.enabled {
+            format!("\x1b[1m{text}\x1b[0m")
+        } else {
+            text.to_string()
+        }
+    }
+    fn dim(&self, text: &str) -> String {
+        if self.enabled {
+            format!("\x1b[2m{text}\x1b[0m")
+        } else {
+            text.to_string()
+        }
+    }
+    fn bar_rgb(&self, r: u8, g: u8, b: u8, filled: usize, empty: usize) -> String {
+        let bar = "\u{2588}".repeat(filled);
+        let space = "\u{2591}".repeat(empty);
+        if self.enabled {
+            format!("\x1b[38;2;{r};{g};{b}m{bar}\x1b[38;2;60;60;60m{space}\x1b[0m")
+        } else {
+            format!("{bar}{space}")
+        }
+    }
+}
+
+fn print_text(sessions: &[Session]) {
+    if sessions.is_empty() {
+        eprintln!("No sessions found.");
+        return;
+    }
+
+    let a = Ansi::new();
+    let mut out = io::stdout().lock();
+    let total = sessions.len();
+    let bar_width = 25;
+
+    // Title
+    let _ = writeln!(out);
+    let _ = writeln!(
+        out,
+        "  {} {}",
+        a.bold("agf stats"),
+        a.dim(&format!("— {total} sessions total"))
+    );
+
+    // Sessions per agent
+    let _ = writeln!(out);
+    let _ = writeln!(out, "  {}", a.bold("Sessions by Agent"));
+    let _ = writeln!(out);
+
+    let mut by_agent: Vec<(Agent, usize)> = Vec::new();
+    let mut agent_map: HashMap<Agent, usize> = HashMap::new();
+    for s in sessions {
+        *agent_map.entry(s.agent).or_insert(0) += 1;
+    }
+    for a_type in Agent::all() {
+        if let Some(&count) = agent_map.get(a_type) {
+            by_agent.push((*a_type, count));
+        }
+    }
+    by_agent.sort_by(|x, y| y.1.cmp(&x.1));
+    let max_agent_count = by_agent.first().map(|(_, c)| *c).unwrap_or(1);
+
+    let col_width: usize = 14; // fixed column for agent names
+    for (agent, count) in &by_agent {
+        let (r, g, b) = agent.color();
+        let filled = (count * bar_width) / max_agent_count;
+        let filled = filled.max(if *count > 0 { 1 } else { 0 });
+        let empty = bar_width.saturating_sub(filled);
+        let pct = (*count as f64 / total as f64 * 100.0) as u32;
+        let name = agent.to_string();
+        let pad = col_width.saturating_sub(name.len());
+        let _ = writeln!(
+            out,
+            "   {}{} {} {:>3} {:>3}%",
+            a.rgb(r, g, b, &name),
+            " ".repeat(pad),
+            a.bar_rgb(r, g, b, filled, empty),
+            a.bold(&count.to_string()),
+            pct,
+        );
+    }
+
+    // Top projects
+    let _ = writeln!(out);
+    let _ = writeln!(out, "  {}", a.bold("Top Projects"));
+    let _ = writeln!(out);
+
+    let mut by_project: HashMap<String, (usize, Option<Agent>)> = HashMap::new();
+    for s in sessions {
+        let entry = by_project
+            .entry(s.project_name.clone())
+            .or_insert((0, None));
+        entry.0 += 1;
+        // Keep most common agent for color
+        if entry.1.is_none() {
+            entry.1 = Some(s.agent);
+        }
+    }
+    let mut project_list: Vec<(String, usize, Agent)> = by_project
+        .into_iter()
+        .map(|(name, (count, agent))| (name, count, agent.unwrap_or(Agent::ClaudeCode)))
+        .collect();
+    project_list.sort_by(|x, y| y.1.cmp(&x.1));
+    project_list.truncate(10);
+    let max_proj_count = project_list.first().map(|(_, c, _)| *c).unwrap_or(1);
+
+    let max_name_len = project_list
+        .iter()
+        .map(|(n, _, _)| n.len())
+        .max()
+        .unwrap_or(10)
+        .min(22);
+
+    for (name, count, agent) in &project_list {
+        let (r, g, b) = agent.color();
+        let display = if name.len() > max_name_len {
+            format!("{}…", &name[..max_name_len - 1])
+        } else {
+            name.clone()
+        };
+        let filled = (count * bar_width) / max_proj_count;
+        let filled = filled.max(if *count > 0 { 1 } else { 0 });
+        let empty = bar_width.saturating_sub(filled);
+        let pad = max_name_len.saturating_sub(display.len());
+        let _ = writeln!(
+            out,
+            "   {}{} {} {:>3}",
+            a.bold(&display),
+            " ".repeat(pad),
+            a.bar_rgb(r, g, b, filled, empty),
+            count,
+        );
+    }
+
+    // Activity timeline
+    let now = chrono::Utc::now().timestamp_millis();
+    let day_ms: i64 = 86_400_000;
+    let week_ms: i64 = 7 * day_ms;
+    let month_ms: i64 = 30 * day_ms;
+
+    let mut today = 0usize;
+    let mut this_week = 0usize;
+    let mut this_month = 0usize;
+    let mut older = 0usize;
+
+    for s in sessions {
+        let age = now - s.timestamp;
+        if age < day_ms {
+            today += 1;
+        } else if age < week_ms {
+            this_week += 1;
+        } else if age < month_ms {
+            this_month += 1;
+        } else {
+            older += 1;
+        }
+    }
+
+    let _ = writeln!(out);
+    let _ = writeln!(out, "  {}", a.bold("Activity"));
+    let _ = writeln!(out);
+
+    let max_time = [today, this_week, this_month, older]
+        .into_iter()
+        .max()
+        .unwrap_or(1);
+
+    let time_items = [
+        ("Today", today, (52, 211, 153)),           // green
+        ("This week", this_week, (139, 92, 246)),   // violet
+        ("This month", this_month, (59, 130, 246)), // blue
+        ("Older", older, (107, 114, 128)),          // gray
+    ];
+    for (label, count, (r, g, b)) in &time_items {
+        let filled = if max_time > 0 {
+            (count * bar_width) / max_time
+        } else {
+            0
+        };
+        let filled = filled.max(if *count > 0 { 1 } else { 0 });
+        let empty = bar_width.saturating_sub(filled);
+        let pad = 12usize.saturating_sub(label.len());
+        let _ = writeln!(
+            out,
+            "   {}{} {} {:>3}",
+            a.dim(label),
+            " ".repeat(pad),
+            a.bar_rgb(*r, *g, *b, filled, empty),
+            count,
+        );
+    }
+    let _ = writeln!(out);
+}
+
+fn print_json(sessions: &[Session]) {
+    let mut by_agent: HashMap<String, usize> = HashMap::new();
+    for s in sessions {
+        *by_agent.entry(s.agent.to_string()).or_insert(0) += 1;
+    }
+
+    let mut by_project: HashMap<String, usize> = HashMap::new();
+    for s in sessions {
+        *by_project.entry(s.project_name.clone()).or_insert(0) += 1;
+    }
+
+    let now = chrono::Utc::now().timestamp_millis();
+    let day_ms: i64 = 86_400_000;
+    let week_ms: i64 = 7 * day_ms;
+    let month_ms: i64 = 30 * day_ms;
+
+    let mut today = 0usize;
+    let mut this_week = 0usize;
+    let mut this_month = 0usize;
+    let mut older = 0usize;
+
+    for s in sessions {
+        let age = now - s.timestamp;
+        if age < day_ms {
+            today += 1;
+        } else if age < week_ms {
+            this_week += 1;
+        } else if age < month_ms {
+            this_month += 1;
+        } else {
+            older += 1;
+        }
+    }
+
+    let json = serde_json::json!({
+        "total": sessions.len(),
+        "by_agent": by_agent,
+        "by_project": by_project,
+        "activity": {
+            "today": today,
+            "this_week": this_week,
+            "this_month": this_month,
+            "older": older,
+        }
+    });
+    if let Ok(s) = serde_json::to_string_pretty(&json) {
+        println!("{s}");
+    }
+}

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -22,6 +22,7 @@ const CYAN: slt::Color = slt::Color::Rgb(34, 211, 238);
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Mode {
     Browse,
+    GroupedBrowse,
     ActionSelect,
     AgentSelect,
     PermissionSelect,
@@ -30,6 +31,13 @@ pub enum Mode {
     BulkDelete,
     Preview,
     Help,
+}
+
+#[derive(Debug, Clone)]
+pub struct ProjectGroup {
+    pub project_path: String,
+    pub project_name: String,
+    pub sessions: Vec<usize>, // indices into App.sessions
 }
 
 #[derive(Debug, Clone)]
@@ -64,6 +72,14 @@ pub struct App {
     pub include_summaries: bool,
     pub help_selected: usize,
     pub search_textarea: slt::TextareaState,
+    pub cwd: Option<String>,
+    pub agent_counts: HashMap<Agent, usize>,
+    pub pinned_sessions: Vec<String>,
+    pub settings: crate::settings::Settings,
+    pub groups: Vec<ProjectGroup>,
+    pub group_expanded: HashSet<String>,
+    pub grouped_selected: usize,
+    pub grouped_scroll: usize,
     fuzzy: FuzzyMatcher,
 }
 
@@ -73,11 +89,12 @@ impl App {
         initial_query: Option<String>,
         summary_search_count: usize,
         include_summaries: bool,
+        cwd: Option<String>,
+        pinned_sessions: Vec<String>,
     ) -> Self {
         let agents = installed_agents();
 
-        let mut agent_counts: std::collections::HashMap<Agent, usize> =
-            std::collections::HashMap::new();
+        let mut agent_counts: HashMap<Agent, usize> = HashMap::new();
         for s in &sessions {
             *agent_counts.entry(s.agent).or_insert(0) += 1;
         }
@@ -108,6 +125,7 @@ impl App {
             }
             ta
         };
+        let settings = crate::settings::Settings::load();
         let mut app = Self {
             sessions,
             filtered_indices,
@@ -133,6 +151,14 @@ impl App {
             include_summaries,
             help_selected: 0,
             search_textarea,
+            cwd,
+            agent_counts,
+            pinned_sessions,
+            settings,
+            groups: Vec::new(),
+            group_expanded: HashSet::new(),
+            grouped_selected: 0,
+            grouped_scroll: 0,
             fuzzy: FuzzyMatcher::new(),
         };
         if !app.query.is_empty() {
@@ -156,6 +182,23 @@ impl App {
                     .then(b.timestamp.cmp(&a.timestamp))
             }),
         }
+
+        // Boost: pinned first, then $PWD matches (stable sort preserves primary order within groups)
+        let pinned = self.pinned_sessions.clone();
+        let cwd = self.cwd.clone();
+        self.sessions.sort_by(|a, b| {
+            let rank = |s: &Session| -> u8 {
+                if pinned.contains(&s.session_id) {
+                    0
+                } else if cwd.as_ref().is_some_and(|c| s.project_path == *c) {
+                    1
+                } else {
+                    2
+                }
+            };
+            rank(a).cmp(&rank(b))
+        });
+
         self.update_filter();
     }
 
@@ -230,16 +273,14 @@ impl App {
     }
 
     pub fn save_settings(&self) {
-        let settings = crate::settings::Settings {
-            sort_by: None,
-            max_sessions: None,
-            summary_search_count: self.summary_search_count,
-            search_scope: if self.include_summaries {
-                "all".to_string()
-            } else {
-                "name_path".to_string()
-            },
+        let mut settings = self.settings.clone();
+        settings.summary_search_count = self.summary_search_count;
+        settings.search_scope = if self.include_summaries {
+            "all".to_string()
+        } else {
+            "name_path".to_string()
         };
+        settings.pinned_sessions = self.pinned_sessions.clone();
         settings.save_editable();
     }
 
@@ -258,6 +299,78 @@ impl App {
         if self.scroll_offset > max_offset {
             self.scroll_offset = max_offset;
         }
+    }
+
+    pub fn build_groups(&mut self) {
+        let mut map: std::collections::BTreeMap<String, Vec<usize>> =
+            std::collections::BTreeMap::new();
+        for &idx in &self.filtered_indices {
+            let s = &self.sessions[idx];
+            map.entry(s.project_path.clone()).or_default().push(idx);
+        }
+        self.groups = map
+            .into_iter()
+            .map(|(path, sessions)| {
+                let name = std::path::Path::new(&path)
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or("unknown")
+                    .to_string();
+                ProjectGroup {
+                    project_path: path,
+                    project_name: name,
+                    sessions,
+                }
+            })
+            .collect();
+        // Sort groups: most recent session first
+        self.groups.sort_by(|a, b| {
+            let a_ts = a
+                .sessions
+                .first()
+                .map(|&i| self.sessions[i].timestamp)
+                .unwrap_or(0);
+            let b_ts = b
+                .sessions
+                .first()
+                .map(|&i| self.sessions[i].timestamp)
+                .unwrap_or(0);
+            b_ts.cmp(&a_ts)
+        });
+    }
+
+    /// Count total visible rows in grouped view (headers + expanded children)
+    fn grouped_row_count(&self) -> usize {
+        self.groups
+            .iter()
+            .map(|g| {
+                if self.group_expanded.contains(&g.project_path) {
+                    1 + g.sessions.len()
+                } else {
+                    1
+                }
+            })
+            .sum()
+    }
+
+    /// Map a flat row index to (group_index, None) for header or (group_index, Some(child_index))
+    fn grouped_row_at(&self, row: usize) -> Option<(usize, Option<usize>)> {
+        let mut current = 0;
+        for (gi, g) in self.groups.iter().enumerate() {
+            if current == row {
+                return Some((gi, None));
+            }
+            current += 1;
+            if self.group_expanded.contains(&g.project_path) {
+                for ci in 0..g.sessions.len() {
+                    if current == row {
+                        return Some((gi, Some(ci)));
+                    }
+                    current += 1;
+                }
+            }
+        }
+        None
     }
 
     fn agents_with_sessions(&self) -> Vec<Agent> {
@@ -312,6 +425,7 @@ impl App {
                 app.adjust_scroll();
                 match app.mode {
                     Mode::Browse => ui_browse(ui, app),
+                    Mode::GroupedBrowse => ui_grouped_browse(ui, app),
                     Mode::ActionSelect => ui_action_select(ui, app, &mut result),
                     Mode::AgentSelect => ui_agent_select(ui, app, &mut result),
                     Mode::PermissionSelect => ui_permission_select(ui, app, &mut result),
@@ -354,6 +468,7 @@ fn ui_browse(ui: &mut slt::Context, app: &mut App) {
     let ctrl_bulk = ui.key_mod('d', slt::KeyModifiers::CONTROL);
     let ctrl_clear = ui.key_mod('u', slt::KeyModifiers::CONTROL);
     let ctrl_right = ui.key_mod('l', slt::KeyModifiers::CONTROL);
+    let ctrl_group = ui.key_mod('g', slt::KeyModifiers::CONTROL);
     // Consume ctrl chars to prevent textarea insertion
     if ctrl_up {
         ui.consume_key('p');
@@ -374,6 +489,9 @@ fn ui_browse(ui: &mut slt::Context, app: &mut App) {
     }
     if ctrl_right {
         ui.consume_key('l');
+    }
+    if ctrl_group {
+        ui.consume_key('g');
     }
 
     // Consume special chars that have bindings
@@ -419,6 +537,12 @@ fn ui_browse(ui: &mut slt::Context, app: &mut App) {
     if ctrl_bulk {
         app.selected_set.clear();
         app.mode = Mode::BulkDelete;
+    }
+    if ctrl_group {
+        app.build_groups();
+        app.grouped_selected = 0;
+        app.grouped_scroll = 0;
+        app.mode = Mode::GroupedBrowse;
     }
     if tab {
         app.cycle_agent_filter(true);
@@ -474,10 +598,12 @@ fn ui_browse(ui: &mut slt::Context, app: &mut App) {
             });
             match app.agent_filter {
                 Some(agent) => {
-                    let _ = ui.badge_colored(&agent.to_string(), agent_color(agent));
+                    let count = app.agent_counts.get(&agent).copied().unwrap_or(0);
+                    let _ = ui.badge_colored(&format!("{agent} ({count})"), agent_color(agent));
                 }
                 None => {
-                    let _ = ui.badge("All");
+                    let total = app.sessions.len();
+                    let _ = ui.badge(&format!("All ({total})"));
                 }
             };
         });
@@ -527,6 +653,7 @@ fn ui_browse(ui: &mut slt::Context, app: &mut App) {
                     ("→", "detail"),
                     ("Enter", "select"),
                     ("^S", "sort"),
+                    ("^G", "group"),
                     ("^D", "delete"),
                     ("?", "help"),
                     ("Esc", "quit"),
@@ -557,6 +684,256 @@ fn ui_browse(ui: &mut slt::Context, app: &mut App) {
         app.search_textarea.cursor_row = 0;
         app.search_textarea.cursor_col = merged.chars().count();
     }
+}
+
+fn ui_grouped_browse(ui: &mut slt::Context, app: &mut App) {
+    let esc = ui.consume_key_code(slt::KeyCode::Esc);
+    let enter = ui.consume_key_code(slt::KeyCode::Enter);
+    let up = ui.consume_key_code(slt::KeyCode::Up);
+    let down = ui.consume_key_code(slt::KeyCode::Down);
+    let space = ui.consume_key(' ');
+    let ctrl_up =
+        ui.key_mod('p', slt::KeyModifiers::CONTROL) || ui.key_mod('k', slt::KeyModifiers::CONTROL);
+    let ctrl_down =
+        ui.key_mod('n', slt::KeyModifiers::CONTROL) || ui.key_mod('j', slt::KeyModifiers::CONTROL);
+    let ctrl_group = ui.key_mod('g', slt::KeyModifiers::CONTROL);
+    if ctrl_up {
+        ui.consume_key('p');
+        ui.consume_key('k');
+    }
+    if ctrl_down {
+        ui.consume_key('n');
+        ui.consume_key('j');
+    }
+    if ctrl_group {
+        ui.consume_key('g');
+    }
+
+    if esc || ctrl_group {
+        app.mode = Mode::Browse;
+        return;
+    }
+
+    let total_rows = app.grouped_row_count();
+    if (up || ctrl_up) && app.grouped_selected > 0 {
+        app.grouped_selected -= 1;
+    }
+    if (down || ctrl_down) && app.grouped_selected + 1 < total_rows {
+        app.grouped_selected += 1;
+    }
+
+    // Enter/Space on header: toggle expand. Enter on child: open action menu.
+    if enter || space {
+        if let Some((gi, child)) = app.grouped_row_at(app.grouped_selected) {
+            match child {
+                None => {
+                    let path = app.groups[gi].project_path.clone();
+                    if app.group_expanded.contains(&path) {
+                        app.group_expanded.remove(&path);
+                    } else {
+                        app.group_expanded.insert(path);
+                    }
+                }
+                Some(ci) => {
+                    let session_idx = app.groups[gi].sessions[ci];
+                    // Find this session in filtered_indices to set app.selected
+                    if let Some(vi) = app.filtered_indices.iter().position(|&i| i == session_idx) {
+                        app.selected = vi;
+                        app.action_index = 0;
+                        app.mode = Mode::ActionSelect;
+                    }
+                }
+            }
+        }
+    }
+
+    // Scroll
+    let visible = app.viewport_height.max(1);
+    if app.grouped_selected < app.grouped_scroll {
+        app.grouped_scroll = app.grouped_selected;
+    } else if app.grouped_selected >= app.grouped_scroll + visible {
+        app.grouped_scroll = app.grouped_selected - visible + 1;
+    }
+
+    // --- Render ---
+    let _ = ui.col(|ui| {
+        ui.text("");
+        let _ = ui.container().pl(2).pr(1).row(|ui| {
+            ui.text("Project View").fg(BRIGHT_WHITE).bold();
+            ui.spacer();
+            let total_projects = app.groups.len();
+            let total_sessions = app.filtered_indices.len();
+            ui.text(format!(
+                "{total_projects} projects, {total_sessions} sessions"
+            ))
+            .fg(GRAY_500);
+        });
+        ui.separator_colored(SEPARATOR);
+
+        let _ = ui.container().grow(1).pr(1).col(|ui| {
+            if app.groups.is_empty() {
+                let _ = ui.container().pl(2).col(|ui| {
+                    let _ = ui.empty_state("No projects", "Try a different filter");
+                });
+                return;
+            }
+
+            let total_width = ui.width() as usize;
+            let end = (app.grouped_scroll + visible).min(total_rows);
+            let mut row_idx = 0;
+            for group in app.groups.iter() {
+                let expanded = app.group_expanded.contains(&group.project_path);
+                let session_count = group.sessions.len();
+
+                // Get most recent timestamp for the group
+                let latest_time = group
+                    .sessions
+                    .first()
+                    .map(|&i| app.sessions[i].time_display())
+                    .unwrap_or_default();
+                // Agents in this group
+                let mut agent_set: Vec<Agent> = Vec::new();
+                for &idx in &group.sessions {
+                    let a = app.sessions[idx].agent;
+                    if !agent_set.contains(&a) {
+                        agent_set.push(a);
+                    }
+                }
+
+                // Header row
+                if row_idx >= app.grouped_scroll && row_idx < end {
+                    let is_selected = row_idx == app.grouped_selected;
+                    let bg = if is_selected {
+                        HIGHLIGHT_BG
+                    } else {
+                        slt::Color::Reset
+                    };
+                    let arrow = if expanded { "\u{25be}" } else { "\u{25b8}" };
+                    let display_path = if let Some(home) = dirs::home_dir() {
+                        if let Some(rest) =
+                            group.project_path.strip_prefix(home.to_str().unwrap_or(""))
+                        {
+                            format!("~{rest}")
+                        } else {
+                            group.project_path.clone()
+                        }
+                    } else {
+                        group.project_path.clone()
+                    };
+
+                    let _ = ui.row(|ui| {
+                        ui.styled(format!(" {arrow} "), slt::Style::new().fg(GRAY_400).bg(bg));
+                        ui.styled(
+                            group.project_name.clone(),
+                            slt::Style::new().fg(BRIGHT_WHITE).bold().bg(bg),
+                        );
+                        ui.styled(
+                            format!(" ({session_count})"),
+                            slt::Style::new().fg(YELLOW).bg(bg),
+                        );
+                        // Show agent badges inline
+                        for a in &agent_set {
+                            ui.styled(
+                                format!(" {a}"),
+                                slt::Style::new().fg(agent_color(*a)).bg(bg),
+                            );
+                        }
+                        ui.styled("  ".to_string(), slt::Style::new().bg(bg));
+                        ui.styled(display_path, slt::Style::new().fg(GRAY_500).bg(bg));
+                        ui.spacer();
+                        ui.styled(
+                            format!("  {latest_time} "),
+                            slt::Style::new().fg(VIOLET).bg(bg),
+                        );
+                    });
+                }
+                row_idx += 1;
+
+                // Child rows (if expanded)
+                if expanded {
+                    for (ci, &session_idx) in group.sessions.iter().enumerate() {
+                        if row_idx >= app.grouped_scroll && row_idx < end {
+                            let s = &app.sessions[session_idx];
+                            let is_selected = row_idx == app.grouped_selected;
+                            let bg = if is_selected {
+                                HIGHLIGHT_BG
+                            } else {
+                                slt::Color::Reset
+                            };
+                            let is_last = ci == group.sessions.len() - 1;
+                            let tree_char = if is_last { "  └─ " } else { "  ├─ " };
+                            let is_pinned = app.pinned_sessions.contains(&s.session_id);
+                            let pin_str = if is_pinned { "*" } else { " " };
+
+                            // Calculate available space for summary
+                            let fixed_width = 5 + 1 + 12 + 2 + 16; // tree + pin + agent + gap + time
+                            let git_width = s.git_branch.as_ref().map(|b| b.len() + 2).unwrap_or(0);
+                            let summary_max =
+                                total_width.saturating_sub(fixed_width + git_width + 2);
+
+                            let summary = s
+                                .summaries
+                                .first()
+                                .map(|t| truncate_str(t, summary_max.max(10)))
+                                .unwrap_or_default();
+
+                            let _ = ui.row(|ui| {
+                                ui.styled(
+                                    tree_char.to_string(),
+                                    slt::Style::new().fg(SEPARATOR).bg(bg),
+                                );
+                                if is_pinned {
+                                    ui.styled(
+                                        pin_str.to_string(),
+                                        slt::Style::new().fg(YELLOW).bold().bg(bg),
+                                    );
+                                } else {
+                                    ui.styled(pin_str.to_string(), slt::Style::new().bg(bg));
+                                }
+                                ui.styled(
+                                    format!("{:<12}", s.agent.to_string()),
+                                    slt::Style::new().fg(agent_color(s.agent)).bold().bg(bg),
+                                );
+                                if !summary.is_empty() {
+                                    ui.styled(
+                                        format!("  {summary}"),
+                                        slt::Style::new().fg(GRAY_400).bg(bg),
+                                    );
+                                }
+                                ui.spacer();
+                                if let Some(branch) = &s.git_branch {
+                                    ui.styled(
+                                        branch.to_string(),
+                                        slt::Style::new().fg(GREEN_400).bg(bg),
+                                    );
+                                }
+                                ui.styled(
+                                    format!("  {} ", s.time_display()),
+                                    slt::Style::new().fg(GRAY_500).bg(bg),
+                                );
+                            });
+                        }
+                        row_idx += 1;
+                    }
+                }
+            }
+        });
+
+        ui.separator_colored(SEPARATOR);
+        let _ = ui.container().pr(1).row(|ui| {
+            ui.spacer();
+            let _ = ui.help_colored(
+                &[
+                    ("↑↓", "nav"),
+                    ("Enter/Space", "expand"),
+                    ("^G", "flat view"),
+                    ("Esc", "back"),
+                ],
+                GRAY_500,
+                SEPARATOR,
+            );
+        });
+    });
 }
 
 fn ui_action_select(ui: &mut slt::Context, app: &mut App, result: &mut Option<String>) {
@@ -654,7 +1031,19 @@ fn ui_action_select(ui: &mut slt::Context, app: &mut App, result: &mut Option<St
                     slt::Color::Reset
                 };
                 let indicator = format!(" {}) ", i + 1);
-                let label = act.to_string();
+                let label = if *act == Action::Pin {
+                    let is_pinned = app
+                        .selected_session()
+                        .map(|s| app.pinned_sessions.contains(&s.session_id))
+                        .unwrap_or(false);
+                    if is_pinned {
+                        "Unpin Session".to_string()
+                    } else {
+                        "Pin Session".to_string()
+                    }
+                } else {
+                    act.to_string()
+                };
                 let base_style = if *act == Action::Delete {
                     slt::Style::new().fg(RED).bg(bg)
                 } else if *act == Action::Back {
@@ -733,6 +1122,19 @@ fn dispatch_action(
         Action::Delete => {
             app.delete_index = 1;
             app.mode = Mode::DeleteConfirm;
+        }
+        Action::Pin => {
+            if let Some(session) = app.selected_session() {
+                let id = session.session_id.clone();
+                if let Some(pos) = app.pinned_sessions.iter().position(|s| s == &id) {
+                    app.pinned_sessions.remove(pos);
+                } else {
+                    app.pinned_sessions.push(id);
+                }
+                app.save_settings();
+                app.apply_sort();
+            }
+            app.mode = Mode::Browse;
         }
         _ => {
             if let Some(session) = app.selected_session().cloned() {
@@ -1696,7 +2098,13 @@ fn render_session_list(ui: &mut slt::Context, app: &App, bulk_mode: bool) {
                 render_chunks(ui, &chunks);
             });
         } else {
-            let indicator = if is_selected { "> " } else { "  " };
+            let is_pinned = app.pinned_sessions.contains(&session.session_id);
+            let indicator = match (is_selected, is_pinned) {
+                (true, true) => ">*",
+                (true, false) => "> ",
+                (false, true) => " *",
+                (false, false) => "  ",
+            };
             let match_positions = app.match_positions.get(vi).map(Vec::as_slice);
             let summary_offset = app
                 .summary_offsets
@@ -1716,10 +2124,12 @@ fn render_session_list(ui: &mut slt::Context, app: &App, bulk_mode: bool) {
             );
 
             let _ = ui.row(|ui| {
-                ui.styled(
-                    indicator.to_string(),
-                    slt::Style::new().fg(slt::Color::White).bg(bg),
-                );
+                let ind_style = if is_pinned {
+                    slt::Style::new().fg(YELLOW).bold().bg(bg)
+                } else {
+                    slt::Style::new().fg(slt::Color::White).bg(bg)
+                };
+                ui.styled(indicator.to_string(), ind_style);
                 render_chunks(ui, &chunks);
             });
         }

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -1,0 +1,184 @@
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+use crate::model::{Agent, Session};
+use crate::scanner;
+
+struct WatchState {
+    sessions: Vec<Session>,
+    running_agents: Vec<Agent>,
+    last_refresh: Instant,
+    selected: usize,
+    scroll_offset: usize,
+}
+
+pub fn run_watch(interval_secs: u64) -> anyhow::Result<()> {
+    let sessions = scanner::scan_all();
+    let running_agents = detect_running_agents();
+
+    let mut state = WatchState {
+        sessions,
+        running_agents,
+        last_refresh: Instant::now(),
+        selected: 0,
+        scroll_offset: 0,
+    };
+
+    let (tx, rx) = mpsc::channel::<(Vec<Session>, Vec<Agent>)>();
+
+    slt::run_with(
+        slt::RunConfig::default().title("agf watch").mouse(true),
+        |ui: &mut slt::Context| {
+            // Check for background refresh results
+            if let Ok((new_sessions, new_running)) = rx.try_recv() {
+                state.sessions = new_sessions;
+                state.running_agents = new_running;
+                state.last_refresh = Instant::now();
+            }
+
+            // Trigger background refresh
+            if state.last_refresh.elapsed() >= Duration::from_secs(interval_secs) {
+                state.last_refresh = Instant::now();
+                let tx = tx.clone();
+                std::thread::spawn(move || {
+                    let sessions = scanner::scan_all();
+                    let running = detect_running_agents();
+                    let _ = tx.send((sessions, running));
+                });
+            }
+
+            // Input
+            if ui.key_code(slt::KeyCode::Esc) || ui.key('q') {
+                ui.quit();
+            }
+            if (ui.key_code(slt::KeyCode::Up) || ui.key_mod('k', slt::KeyModifiers::CONTROL))
+                && state.selected > 0
+            {
+                state.selected -= 1;
+            }
+            if (ui.key_code(slt::KeyCode::Down) || ui.key_mod('j', slt::KeyModifiers::CONTROL))
+                && state.selected + 1 < state.sessions.len()
+            {
+                state.selected += 1;
+            }
+
+            // Scroll
+            let viewport = (ui.height() as usize).saturating_sub(6).max(1);
+            if state.selected < state.scroll_offset {
+                state.scroll_offset = state.selected;
+            } else if state.selected >= state.scroll_offset + viewport {
+                state.scroll_offset = state.selected - viewport + 1;
+            }
+
+            // Render
+            let running_names: Vec<String> =
+                state.running_agents.iter().map(|a| a.to_string()).collect();
+            let elapsed = state.last_refresh.elapsed().as_secs();
+
+            let _ = ui.col(|ui| {
+                ui.text("");
+                let _ = ui.container().pl(2).pr(1).row(|ui| {
+                    ui.text("agf watch")
+                        .fg(slt::Color::Rgb(229, 229, 229))
+                        .bold();
+                    ui.spacer();
+                    if running_names.is_empty() {
+                        ui.text("no agents running")
+                            .fg(slt::Color::Rgb(107, 114, 128));
+                    } else {
+                        ui.text(format!("running: {}", running_names.join(", ")))
+                            .fg(slt::Color::Rgb(52, 211, 153));
+                    }
+                    ui.text(format!("  {elapsed}s ago"))
+                        .fg(slt::Color::Rgb(107, 114, 128));
+                });
+                ui.separator_colored(slt::Color::Rgb(64, 64, 64));
+
+                let _ = ui.container().grow(1).pr(1).col(|ui| {
+                    if state.sessions.is_empty() {
+                        let _ = ui.container().pl(2).col(|ui| {
+                            let _ = ui.empty_state("No sessions", "Waiting for agent sessions...");
+                        });
+                        return;
+                    }
+
+                    let end = (state.scroll_offset + viewport).min(state.sessions.len());
+                    for vi in state.scroll_offset..end {
+                        let s = &state.sessions[vi];
+                        let is_selected = vi == state.selected;
+                        let bg = if is_selected {
+                            slt::Color::Rgb(59, 59, 59)
+                        } else {
+                            slt::Color::Reset
+                        };
+
+                        let is_running = state.running_agents.contains(&s.agent);
+                        let status = if is_running {
+                            ("\u{25cf} ", slt::Color::Rgb(52, 211, 153))
+                        } else {
+                            ("\u{25cb} ", slt::Color::Rgb(107, 114, 128))
+                        };
+
+                        let (r, g, b) = s.agent.color();
+                        let agent_color = slt::Color::Rgb(r, g, b);
+
+                        let _ = ui.row(|ui| {
+                            ui.styled(status.0.to_string(), slt::Style::new().fg(status.1).bg(bg));
+                            ui.styled(
+                                format!("{:<14}", s.agent.to_string()),
+                                slt::Style::new().fg(agent_color).bold().bg(bg),
+                            );
+                            ui.styled(
+                                format!("{:<20}", truncate(&s.project_name, 20)),
+                                slt::Style::new().fg(slt::Color::Rgb(229, 229, 229)).bg(bg),
+                            );
+                            if let Some(branch) = &s.git_branch {
+                                ui.styled(
+                                    format!("  {branch}"),
+                                    slt::Style::new().fg(slt::Color::Rgb(52, 211, 153)).bg(bg),
+                                );
+                            }
+                            ui.styled(
+                                format!("  {}", s.time_display()),
+                                slt::Style::new().fg(slt::Color::Rgb(107, 114, 128)).bg(bg),
+                            );
+                        });
+                    }
+                });
+
+                ui.separator_colored(slt::Color::Rgb(64, 64, 64));
+                let _ = ui.container().pr(1).row(|ui| {
+                    ui.spacer();
+                    let _ = ui.help_colored(
+                        &[("↑↓", "nav"), ("q/Esc", "quit")],
+                        slt::Color::Rgb(107, 114, 128),
+                        slt::Color::Rgb(64, 64, 64),
+                    );
+                });
+            });
+        },
+    )?;
+    Ok(())
+}
+
+fn detect_running_agents() -> Vec<Agent> {
+    Agent::all()
+        .iter()
+        .copied()
+        .filter(|agent| {
+            std::process::Command::new("pgrep")
+                .args(["-f", agent.cli_name()])
+                .output()
+                .map(|o| o.status.success())
+                .unwrap_or(false)
+        })
+        .collect()
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        format!("{}…", &s[..max.saturating_sub(1)])
+    }
+}


### PR DESCRIPTION
## Summary

Major feature release adding new TUI views, CLI subcommands, and architectural improvements.

### New Features
- **PWD boost** — sessions matching `$PWD` automatically sorted to top
- **Open in Editor** — action menu item with `$EDITOR` / `$VISUAL` detection
- **Pin/bookmark** — pin sessions via action menu, `*` indicator, persisted in `config.toml`
- **Agent count badge** — Tab filter badge shows session count (e.g. `Claude Code (12)`)
- **Project grouped view** — `Ctrl+G` toggles tree view with expand/collapse per project
- **`agf list`** — plain text / JSON / CSV output with ANSI colors, `--agent` filter
- **`agf stats`** — session statistics with colored Unicode bar charts
- **`agf watch`** — live dashboard with auto-refresh and running agent detection via `pgrep`
- **Enhanced `agf resume`** — `--list N`, `--agent`, `--mode` flags

### Architecture
- **AgentPlugin trait** — adapter pattern for incremental migration, simplifies adding new agents
- **Scan caching** — `~/.cache/agf/sessions.json` with per-agent mtime-based invalidation
- **Settings refactor** — proper TOML serialization, `editor` and `pinned_sessions` fields

### UI Polish
- Action menu naming unified to Title Case
- Removed redundant `Back` menu item (Esc suffices)
- Improved grouped view with tree characters (`├─` / `└─`), agent badges, git branch display
- `agf list` and `agf stats` output with ANSI-aware column alignment

## Test plan
- [ ] `agf` — verify PWD boost, pin, count badge, Ctrl+G grouped view
- [ ] `agf list` / `agf list --format json` / `agf list --agent claude`
- [ ] `agf stats` / `agf stats --json`
- [ ] `agf watch` — verify auto-refresh
- [ ] `agf resume test --list 3` — interactive selection
- [ ] Pin via action menu → verify `*` indicator and config persistence

🤖 Generated with [Claude Code](https://claude.com/claude-code)