### PR TITLE
fix: bump superlighttui to v0.17 to fix [/] and ? keybindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -854,9 +854,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "superlighttui"
-version = "0.15.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1c915e13165fb797aba1125439112622eadc30b0eec966d38463dd47cd308d4"
+checksum = "e214c6ff0939b6e0b161d072c8f27883ce3afd953d4b7e72c01628e86e08da69"
 dependencies = [
  "compact_str",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["command-line-utilities"]
 readme = "README.md"
 
 [dependencies]
-superlighttui = "0.15"
+superlighttui = "0.17"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 rusqlite = { version = "0.32", features = ["bundled"] }


### PR DESCRIPTION
## Summary

- Bumps `superlighttui` from v0.15 to v0.17 to fix `[`/`]` summary cycling and `?` help keybindings being swallowed by the search textarea

## Root cause

The textarea widget in superlighttui v0.15 iterates over raw events without checking the `consumed` flag. `consume_key()` marks the event but the textarea ignores it, inserting the character into the search box instead. This was fixed upstream in SuperLightTUI via `available_key_presses()` which filters consumed events.

Fixes #18

## Test plan

- [x] `cargo build` compiles cleanly
- [ ] Press `[`/`]` in browse mode — cycles summaries, does not type into search
- [ ] Press `?` in browse mode — opens help, does not type into search
- [ ] Normal search typing is unaffected