### PR TITLE
feat: add show_recap option to display Claude Code session recaps

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use crate::model::{Agent, Session};
 use crate::plugin;
 
-const CACHE_VERSION: u32 = 1;
+const CACHE_VERSION: u32 = 2;
 
 #[derive(Serialize, Deserialize)]
 struct CacheFile {
@@ -32,6 +32,7 @@ struct CachedSession {
     timestamp: i64,
     git_branch: Option<String>,
     worktree: Option<String>,
+    recap: Option<String>,
 }
 
 fn cache_path() -> PathBuf {
@@ -76,6 +77,7 @@ fn to_cached(s: &Session) -> CachedSession {
         timestamp: s.timestamp,
         git_branch: s.git_branch.clone(),
         worktree: s.worktree.clone(),
+        recap: s.recap.clone(),
     }
 }
 
@@ -90,6 +92,7 @@ fn from_cached(c: &CachedSession) -> Option<Session> {
         timestamp: c.timestamp,
         git_branch: c.git_branch.clone(),
         worktree: c.worktree.clone(),
+        recap: c.recap.clone(),
     })
 }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -155,6 +155,7 @@ pub struct Session {
     pub timestamp: i64, // Unix ms
     pub git_branch: Option<String>,
     pub worktree: Option<String>,
+    pub recap: Option<String>, // Claude Code away_summary, optionally prefixed with aiTitle
 }
 
 impl Session {

--- a/src/scanner/claude.rs
+++ b/src/scanner/claude.rs
@@ -25,12 +25,18 @@ struct SessionData {
     summaries: Vec<(f64, String)>, // (timestamp, display) pairs
 }
 
-/// Scan ~/.claude/projects/*/<sessionId>.jsonl to detect worktree sessions.
-/// Returns session_id → worktree_name for sessions started inside a worktree.
+/// Metadata extracted from per-session JSONL files.
+struct SessionMeta {
+    worktree: Option<String>,
+    recap: Option<String>, // most recent away_summary, optionally prefixed with aiTitle
+}
+
+/// Scan ~/.claude/projects/*/<sessionId>.jsonl to detect worktree sessions
+/// and extract recap (away_summary / aiTitle) metadata.
 ///
 /// `cwd` in the per-session JSONL is the actual working directory, which for
 /// worktree sessions looks like `<project>/.claude/worktrees/<name>`.
-fn scan_session_worktrees(claude_dir: &std::path::Path) -> HashMap<String, String> {
+fn scan_session_metadata(claude_dir: &std::path::Path) -> HashMap<String, SessionMeta> {
     let projects_dir = claude_dir.join("projects");
 
     let Ok(proj_entries) = fs::read_dir(&projects_dir) else {
@@ -62,24 +68,76 @@ fn scan_session_worktrees(claude_dir: &std::path::Path) -> HashMap<String, Strin
         }
     }
 
-    // Read the first 3 lines of each file in parallel to find worktree sessions.
     file_paths
         .into_par_iter()
         .filter_map(|(session_id, file_path)| {
             let file = fs::File::open(&file_path).ok()?;
-            for line in BufReader::new(file).lines().take(3) {
+            let reader = BufReader::new(file);
+            let mut worktree: Option<String> = None;
+            let mut latest_recap: Option<String> = None;
+            let mut latest_recap_ts: Option<String> = None;
+            let mut ai_title: Option<String> = None;
+
+            for line in reader.lines() {
                 let Ok(line) = line else { continue };
-                if let Ok(val) = serde_json::from_str::<Value>(&line) {
+                let Ok(val) = serde_json::from_str::<Value>(&line) else {
+                    continue;
+                };
+
+                // Detect worktree from cwd (only first few lines matter, but we
+                // scan the whole file anyway for away_summary)
+                if worktree.is_none() {
                     if let Some(cwd) = val.get("cwd").and_then(|c| c.as_str()) {
                         if let Some((_, wt)) = cwd.split_once("/.claude/worktrees/") {
                             if !wt.is_empty() {
-                                return Some((session_id, wt.to_string()));
+                                worktree = Some(wt.to_string());
                             }
                         }
                     }
                 }
+
+                // Extract aiTitle
+                if val.get("type").and_then(|t| t.as_str()) == Some("ai-title") {
+                    if let Some(title) = val.get("aiTitle").and_then(|t| t.as_str()) {
+                        ai_title = Some(title.to_string());
+                    }
+                }
+
+                // Extract the most recent away_summary (recap)
+                if val.get("type").and_then(|t| t.as_str()) == Some("system")
+                    && val.get("subtype").and_then(|t| t.as_str()) == Some("away_summary")
+                {
+                    let ts = val
+                        .get("timestamp")
+                        .and_then(|t| t.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    if latest_recap_ts.as_deref().is_none_or(|prev| ts.as_str() > prev) {
+                        if let Some(content) = val.get("content").and_then(|c| c.as_str()) {
+                            // Strip the "(disable recaps in /config)" suffix
+                            let clean = content
+                                .trim_end_matches("(disable recaps in /config)")
+                                .trim();
+                            latest_recap = Some(clean.to_string());
+                            latest_recap_ts = Some(ts);
+                        }
+                    }
+                }
             }
-            None
+
+            // Build recap: prepend "recap: " and optionally aiTitle
+            let recap = match (ai_title, latest_recap) {
+                (Some(title), Some(summary)) => Some(format!("recap: {title} — {summary}")),
+                (None, Some(summary)) => Some(format!("recap: {summary}")),
+                (Some(title), None) => Some(title),
+                (None, None) => None,
+            };
+
+            if worktree.is_some() || recap.is_some() {
+                Some((session_id, SessionMeta { worktree, recap }))
+            } else {
+                None
+            }
         })
         .collect()
 }
@@ -111,7 +169,7 @@ pub fn scan() -> Result<Vec<Session>, AgfError> {
         return Ok(Vec::new());
     }
 
-    let worktrees = scan_session_worktrees(&claude_dir);
+    let session_meta = scan_session_metadata(&claude_dir);
     let mut branch_cache: HashMap<String, Option<String>> = HashMap::new();
     let mut sessions_map: HashMap<String, SessionData> = HashMap::new();
 
@@ -180,7 +238,8 @@ pub fn scan() -> Result<Vec<Session>, AgfError> {
             //   - For worktree sessions this shows the root project's branch (e.g. "main"),
             //     which is displayed in the detail view alongside the worktree name.
             //   - For regular sessions this shows the project's current branch.
-            let worktree = worktrees.get(&session_id).cloned();
+            let meta = session_meta.get(&session_id);
+            let worktree = meta.and_then(|m| m.worktree.clone());
             let git_branch = branch_cache
                 .entry(project_path.clone())
                 .or_insert_with(|| read_git_branch(&project_path))
@@ -191,6 +250,8 @@ pub fn scan() -> Result<Vec<Session>, AgfError> {
                 .sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
             let summaries: Vec<String> = data.summaries.into_iter().map(|(_, s)| s).collect();
 
+            let recap = meta.and_then(|m| m.recap.clone());
+
             Some(Session {
                 agent: Agent::ClaudeCode,
                 session_id,
@@ -200,6 +261,7 @@ pub fn scan() -> Result<Vec<Session>, AgfError> {
                 timestamp,
                 git_branch,
                 worktree,
+                recap,
             })
         })
         .collect();

--- a/src/scanner/claude.rs
+++ b/src/scanner/claude.rs
@@ -112,7 +112,10 @@ fn scan_session_metadata(claude_dir: &std::path::Path) -> HashMap<String, Sessio
                         .and_then(|t| t.as_str())
                         .unwrap_or("")
                         .to_string();
-                    if latest_recap_ts.as_deref().is_none_or(|prev| ts.as_str() > prev) {
+                    if latest_recap_ts
+                        .as_deref()
+                        .is_none_or(|prev| ts.as_str() > prev)
+                    {
                         if let Some(content) = val.get("content").and_then(|c| c.as_str()) {
                             // Strip the "(disable recaps in /config)" suffix
                             let clean = content

--- a/src/scanner/codex.rs
+++ b/src/scanner/codex.rs
@@ -106,6 +106,7 @@ fn scan_sqlite(
             timestamp,
             git_branch,
             worktree: None,
+            recap: None,
         });
     }
 
@@ -242,6 +243,7 @@ fn scan_jsonl(
             timestamp,
             git_branch,
             worktree: None,
+            recap: None,
         });
     }
 

--- a/src/scanner/cursor_agent.rs
+++ b/src/scanner/cursor_agent.rs
@@ -100,6 +100,7 @@ pub fn scan() -> Result<Vec<Session>, AgfError> {
             timestamp,
             git_branch: None,
             worktree: None,
+            recap: None,
         });
     }
 

--- a/src/scanner/gemini.rs
+++ b/src/scanner/gemini.rs
@@ -143,6 +143,7 @@ fn parse_session(path: &Path, project_path: &str, project_name: &str) -> Option<
             timestamp,
             git_branch: None,
             worktree: None,
+            recap: None,
         });
     }
 
@@ -164,6 +165,7 @@ fn parse_session(path: &Path, project_path: &str, project_name: &str) -> Option<
         timestamp,
         git_branch: None,
         worktree: None,
+        recap: None,
     })
 }
 

--- a/src/scanner/kiro.rs
+++ b/src/scanner/kiro.rs
@@ -57,6 +57,7 @@ pub fn scan() -> Result<Vec<Session>, AgfError> {
                 timestamp: updated_at,
                 git_branch: None,
                 worktree: None,
+                recap: None,
             }
         })
         .collect();

--- a/src/scanner/opencode.rs
+++ b/src/scanner/opencode.rs
@@ -69,6 +69,7 @@ pub fn scan() -> Result<Vec<Session>, AgfError> {
                 timestamp: time_updated,
                 git_branch: None,
                 worktree: None,
+                recap: None,
             }
         })
         .collect();

--- a/src/scanner/pi.rs
+++ b/src/scanner/pi.rs
@@ -93,6 +93,7 @@ pub fn scan() -> Result<Vec<Session>, AgfError> {
             timestamp,
             git_branch: None,
             worktree: None,
+            recap: None,
         });
     }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -92,10 +92,7 @@ impl Settings {
             existing.remove("pinned_sessions");
         }
         if self.show_recap {
-            existing.insert(
-                "show_recap".to_string(),
-                toml::Value::Boolean(true),
-            );
+            existing.insert("show_recap".to_string(), toml::Value::Boolean(true));
         } else {
             existing.remove("show_recap");
         }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -16,6 +16,8 @@ pub struct Settings {
     pub editor: Option<String>, // editor command (e.g. "code", "cursor"). Falls back to $EDITOR/$VISUAL
     #[serde(default)]
     pub pinned_sessions: Vec<String>, // session IDs pinned to top of list
+    #[serde(default)]
+    pub show_recap: bool, // show Claude Code recap (away_summary) instead of last prompt
 }
 
 fn default_summary_search_count() -> usize {
@@ -35,6 +37,7 @@ impl Default for Settings {
             search_scope: default_search_scope(),
             editor: None,
             pinned_sessions: Vec::new(),
+            show_recap: false,
         }
     }
 }
@@ -87,6 +90,14 @@ impl Settings {
             );
         } else {
             existing.remove("pinned_sessions");
+        }
+        if self.show_recap {
+            existing.insert(
+                "show_recap".to_string(),
+                toml::Value::Boolean(true),
+            );
+        } else {
+            existing.remove("show_recap");
         }
 
         let _ = fs::write(&path, existing.to_string());

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -875,7 +875,9 @@ fn ui_grouped_browse(ui: &mut slt::Context, app: &mut App) {
                                 total_width.saturating_sub(fixed_width + git_width + 2);
 
                             let summary_src = if app.show_recap {
-                                s.recap.as_deref().or(s.summaries.first().map(String::as_str))
+                                s.recap
+                                    .as_deref()
+                                    .or(s.summaries.first().map(String::as_str))
                             } else {
                                 s.summaries.first().map(String::as_str)
                             };
@@ -2154,7 +2156,10 @@ fn render_session_list(ui: &mut slt::Context, app: &App, bulk_mode: bool) {
                 slt::Style::new().fg(slt::Color::White).bg(bg)
             };
             let summary_text = if app.show_recap {
-                session.recap.as_deref().or(session.summaries.first().map(String::as_str))
+                session
+                    .recap
+                    .as_deref()
+                    .or(session.summaries.first().map(String::as_str))
             } else {
                 session.summaries.first().map(String::as_str)
             };
@@ -2188,7 +2193,10 @@ fn render_session_list(ui: &mut slt::Context, app: &App, bulk_mode: bool) {
                 .copied()
                 .unwrap_or(0);
             let summary_text = if app.show_recap && summary_offset == 0 {
-                session.recap.as_deref().or(session.summaries.first().map(String::as_str))
+                session
+                    .recap
+                    .as_deref()
+                    .or(session.summaries.first().map(String::as_str))
             } else {
                 session.summaries.get(summary_offset).map(String::as_str)
             };

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -70,6 +70,7 @@ pub struct App {
     pub summary_offsets: HashMap<String, usize>,
     pub summary_search_count: usize,
     pub include_summaries: bool,
+    pub show_recap: bool,
     pub help_selected: usize,
     pub search_textarea: slt::TextareaState,
     pub cwd: Option<String>,
@@ -149,6 +150,7 @@ impl App {
             summary_offsets: HashMap::new(),
             summary_search_count,
             include_summaries,
+            show_recap: settings.show_recap,
             help_selected: 0,
             search_textarea,
             cwd,
@@ -281,6 +283,7 @@ impl App {
             "name_path".to_string()
         };
         settings.pinned_sessions = self.pinned_sessions.clone();
+        settings.show_recap = self.show_recap;
         settings.save_editable();
     }
 
@@ -871,9 +874,12 @@ fn ui_grouped_browse(ui: &mut slt::Context, app: &mut App) {
                             let summary_max =
                                 total_width.saturating_sub(fixed_width + git_width + 2);
 
-                            let summary = s
-                                .summaries
-                                .first()
+                            let summary_src = if app.show_recap {
+                                s.recap.as_deref().or(s.summaries.first().map(String::as_str))
+                            } else {
+                                s.summaries.first().map(String::as_str)
+                            };
+                            let summary = summary_src
                                 .map(|t| truncate_str(t, summary_max.max(10)))
                                 .unwrap_or_default();
 
@@ -895,10 +901,21 @@ fn ui_grouped_browse(ui: &mut slt::Context, app: &mut App) {
                                     slt::Style::new().fg(agent_color(s.agent)).bold().bg(bg),
                                 );
                                 if !summary.is_empty() {
-                                    ui.styled(
-                                        format!("  {summary}"),
-                                        slt::Style::new().fg(GRAY_400).bg(bg),
-                                    );
+                                    if let Some(rest) = summary.strip_prefix("recap: ") {
+                                        ui.styled(
+                                            "  recap: ".to_string(),
+                                            slt::Style::new().fg(VIOLET).bg(bg),
+                                        );
+                                        ui.styled(
+                                            rest.to_string(),
+                                            slt::Style::new().fg(GRAY_400).bg(bg),
+                                        );
+                                    } else {
+                                        ui.styled(
+                                            format!("  {summary}"),
+                                            slt::Style::new().fg(GRAY_400).bg(bg),
+                                        );
+                                    }
                                 }
                                 ui.spacer();
                                 if let Some(branch) = &s.git_branch {
@@ -1860,6 +1877,18 @@ fn ui_preview(ui: &mut slt::Context, app: &mut App) {
             });
         }
 
+        if let Some(recap) = &session.recap {
+            ui.line(|ui| {
+                ui.text("  Recap:    ").fg(GRAY_500);
+            });
+            let max_width = (ui.width() as usize).saturating_sub(14);
+            let truncated = truncate_str(recap, max_width);
+            ui.line(|ui| {
+                ui.text("    ").fg(GRAY_500);
+                ui.text(truncated.clone()).fg(GRAY_400);
+            });
+        }
+
         if !session.summaries.is_empty() {
             ui.line(|ui| {
                 ui.text("  History:  ").fg(GRAY_500);
@@ -1898,7 +1927,7 @@ fn ui_help(ui: &mut slt::Context, app: &mut App) {
     }
 
     if (ui.key_code(slt::KeyCode::Down) || ui.key_mod('j', slt::KeyModifiers::CONTROL))
-        && app.help_selected < 1
+        && app.help_selected < 2
     {
         app.help_selected += 1;
     }
@@ -1921,6 +1950,16 @@ fn ui_help(ui: &mut slt::Context, app: &mut App) {
 
     if app.help_selected == 1 && ui.key('-') {
         app.summary_search_count = app.summary_search_count.saturating_sub(1).max(1);
+        app.save_settings();
+    }
+
+    if app.help_selected == 2
+        && (ui.key_code(slt::KeyCode::Enter)
+            || ui.key(' ')
+            || ui.key_code(slt::KeyCode::Left)
+            || ui.key_code(slt::KeyCode::Right))
+    {
+        app.show_recap = !app.show_recap;
         app.save_settings();
     }
 
@@ -2013,6 +2052,39 @@ fn ui_help(ui: &mut slt::Context, app: &mut App) {
                 );
             });
 
+            // show_recap setting
+            let selected_recap = app.help_selected == 2;
+            let recap_bg = if selected_recap {
+                HIGHLIGHT_BG
+            } else {
+                slt::Color::Reset
+            };
+            let recap_label = if app.show_recap {
+                "on (show recap instead of last prompt)"
+            } else {
+                "off (default)"
+            };
+            let _ = ui.row(|ui| {
+                ui.styled(
+                    if selected_recap { "> " } else { "  " },
+                    slt::Style::new().fg(YELLOW).bg(recap_bg),
+                );
+                ui.styled(
+                    format!("{:<22}", "show_recap"),
+                    slt::Style::new().fg(BRIGHT_WHITE).bg(recap_bg),
+                );
+                ui.styled(
+                    recap_label,
+                    slt::Style::new()
+                        .fg(if selected_recap {
+                            BRIGHT_WHITE
+                        } else {
+                            GRAY_400
+                        })
+                        .bg(recap_bg),
+                );
+            });
+
             ui.text("");
             ui.text("Config").fg(GRAY_400).bold();
             ui.text("").dim();
@@ -2081,7 +2153,11 @@ fn render_session_list(ui: &mut slt::Context, app: &App, bulk_mode: bool) {
             } else {
                 slt::Style::new().fg(slt::Color::White).bg(bg)
             };
-            let summary_text = session.summaries.first().map(String::as_str);
+            let summary_text = if app.show_recap {
+                session.recap.as_deref().or(session.summaries.first().map(String::as_str))
+            } else {
+                session.summaries.first().map(String::as_str)
+            };
             let chunks = build_session_row(
                 session,
                 bg,
@@ -2111,7 +2187,11 @@ fn render_session_list(ui: &mut slt::Context, app: &App, bulk_mode: bool) {
                 .get(&session.session_id)
                 .copied()
                 .unwrap_or(0);
-            let summary_text = session.summaries.get(summary_offset).map(String::as_str);
+            let summary_text = if app.show_recap && summary_offset == 0 {
+                session.recap.as_deref().or(session.summaries.first().map(String::as_str))
+            } else {
+                session.summaries.get(summary_offset).map(String::as_str)
+            };
             let chunks = build_session_row(
                 session,
                 bg,
@@ -2258,7 +2338,12 @@ fn build_session_row(
             if max_summary > 5 {
                 let truncated = truncate_str(summary, max_summary);
                 chunks.push((sep.to_string(), slt::Style::new().bg(bg)));
-                chunks.push((truncated, slt::Style::new().fg(GRAY_400).bg(bg)));
+                if let Some(rest) = truncated.strip_prefix("recap: ") {
+                    chunks.push(("recap: ".to_string(), slt::Style::new().fg(VIOLET).bg(bg)));
+                    chunks.push((rest.to_string(), slt::Style::new().fg(GRAY_400).bg(bg)));
+                } else {
+                    chunks.push((truncated, slt::Style::new().fg(GRAY_400).bg(bg)));
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

- Adds a `show_recap` setting (off by default) that displays Claude Code's recap (away_summary) instead of the last user prompt in the session list
- Recaps are prefixed with `recap:` in a distinct color (violet) for visual differentiation
- If an `aiTitle` is present in the session, it is prepended to the recap text
- Sessions without a recap gracefully fall back to the normal last-prompt summary
- Toggle via the Help & Settings screen (`?` key) or `show_recap = true` in `~/.config/agf/config.toml`

## Details

Claude Code generates an `away_summary` (stored as `type: "system"`, `subtype: "away_summary"` in per-session JSONL files) when a user returns to a session after being away. This provides a much more useful summary than the last prompt (which is often just "exit" or "push").

The Claude scanner now reads the full per-session JSONL files (parallelized with rayon) to extract this data, piggybacking on the existing worktree detection scan.

## Test plan

- [ ] `cargo build` compiles cleanly
- [ ] Toggle `show_recap` on via `?` settings screen — sessions with recaps show `recap: <summary>`
- [ ] Sessions without recaps fall back to normal last-prompt display
- [ ] `[`/`]` cycling still works — offset 0 shows recap, further offsets show normal summaries
- [ ] Detail view (`→`) shows Recap section when available
- [ ] Setting persists across restarts in `~/.config/agf/config.toml`