### PR TITLE
Add PowerShell / Windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,8 +152,25 @@ See [CHANGELOG.md](CHANGELOG.md) for full details.
 
 ## Requirements
 
-- macOS or Linux
+- macOS, Linux, or Windows (PowerShell 5.1+ / PowerShell 7+)
 - One or more of: `claude`, `codex`, `opencode`, `pi`, `kiro-cli`, `cursor-agent`, `gemini`
+
+### Shells
+
+`agf setup` auto-detects your shell and installs the wrapper. Supported shells:
+
+- **zsh / bash** — appends to `~/.zshrc` or `~/.bashrc`
+- **fish** — writes to `~/.config/fish/config.fish`
+- **PowerShell** (Windows or cross-platform `pwsh`) — writes to `$PROFILE.CurrentUserAllHosts` (`Documents\PowerShell\profile.ps1` on Windows, `~/.config/powershell/profile.ps1` elsewhere)
+
+If auto-detection misses your shell, run the matching `agf init` form manually:
+
+```bash
+eval "$(agf init zsh)"                               # zsh
+eval "$(agf init bash)"                              # bash
+agf init fish | source                               # fish
+agf init powershell | Out-String | Invoke-Expression # PowerShell
+```
 
 ## Contributing
 

--- a/src/action.rs
+++ b/src/action.rs
@@ -1,28 +1,30 @@
 use crate::model::{Action, Agent, Session};
+use crate::shell::CommandShell;
 
 pub fn generate_command(
     session: &Session,
     action: Action,
     new_agent: Option<Agent>,
 ) -> Option<String> {
-    let escaped_path = shell_escape(&session.project_path);
+    let shell = CommandShell::from_env();
+    let quoted_path = shell.quote(&session.project_path);
 
     match action {
         Action::Resume => {
             // NOTE: Pi/Kiro CLI only resume latest; session_id ignored.
             let cmd = session.agent.resume_cmd(&session.session_id);
-            Some(format!("cd {escaped_path} && {cmd}"))
+            Some(shell.cd_and(&quoted_path, &cmd))
         }
         Action::NewSession => {
             let agent = new_agent.unwrap_or(session.agent);
             let cmd = agent.new_session_cmd();
-            Some(format!("cd {escaped_path} && {cmd}"))
+            Some(shell.cd_and(&quoted_path, cmd))
         }
         Action::Open => {
             let editor = detect_editor();
-            Some(format!("cd {escaped_path} && {editor} ."))
+            Some(shell.cd_and(&quoted_path, &format!("{editor} .")))
         }
-        Action::Cd => Some(format!("cd {escaped_path}")),
+        Action::Cd => Some(shell.cd_only(&quoted_path)),
         Action::Delete | Action::Back | Action::Pin => None,
     }
 }
@@ -61,18 +63,16 @@ pub fn detect_editor() -> String {
 }
 
 pub fn resume_with_flags(session: &Session, flags: &str) -> String {
-    let escaped_path = shell_escape(&session.project_path);
+    let shell = CommandShell::from_env();
+    let quoted_path = shell.quote(&session.project_path);
     // NOTE: Pi/Kiro CLI only resume latest; session_id ignored.
     let base_cmd = session.agent.resume_cmd(&session.session_id);
-    format!("cd {escaped_path} && {base_cmd}{flags}")
+    shell.cd_and(&quoted_path, &format!("{base_cmd}{flags}"))
 }
 
 pub fn new_session_with_flags(session: &Session, agent: Agent, flags: &str) -> Option<String> {
-    let escaped_path = shell_escape(&session.project_path);
+    let shell = CommandShell::from_env();
+    let quoted_path = shell.quote(&session.project_path);
     let base = agent.new_session_cmd();
-    Some(format!("cd {escaped_path} && {base}{flags}"))
-}
-
-fn shell_escape(s: &str) -> String {
-    format!("'{}'", s.replace('\'', "'\\''"))
+    Some(shell.cd_and(&quoted_path, &format!("{base}{flags}")))
 }

--- a/src/action.rs
+++ b/src/action.rs
@@ -34,7 +34,7 @@ pub fn action_preview(session: &Session, action: Action) -> String {
         Action::Resume => session.agent.resume_cmd(&session.session_id),
         Action::NewSession => "choose agent CLI...".to_string(),
         Action::Open => format!("{} .", detect_editor()),
-        Action::Cd => format!("cd {}", session.display_path()),
+        Action::Cd => CommandShell::from_env().cd_only(&session.display_path()),
         Action::Pin => "toggle pin".to_string(),
         Action::Delete => "remove session data".to_string(),
         Action::Back => "return to session list".to_string(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -42,15 +42,9 @@ pub fn kiro_data_dir() -> Result<PathBuf, AgfError> {
         .ok_or(AgfError::NoHomeDir)
 }
 
-/// Cached set of executable names found in `$PATH`. Built once per process so
-/// `is_agent_installed` does not fork a `which` subprocess per agent.
-///
-/// On Windows the set is populated case-insensitively and additionally
-/// contains the *stem* of any file whose extension is in `%PATHEXT%`
-/// (e.g. both `claude.exe` and `claude` land in the set). Agents are
-/// registered with bare names like `claude`, so without stemming the
-/// lookup misses on Windows where the real file is `claude.exe` /
-/// `claude.cmd` / `claude.ps1`.
+/// Cached set of executable names found in `$PATH`, built once per process.
+/// On Windows entries are lower-cased and `%PATHEXT%` stems are inserted
+/// alongside the full filename so bare-name lookups match `.exe`/`.cmd`/etc.
 fn path_executables() -> &'static HashSet<String> {
     static CACHE: OnceLock<HashSet<String>> = OnceLock::new();
     CACHE.get_or_init(|| {
@@ -106,9 +100,6 @@ pub fn is_agent_installed(agent: Agent) -> bool {
     let name = agent.cli_name();
     let execs = path_executables();
     if cfg!(windows) {
-        // Names in the set are lower-cased on Windows to match the
-        // case-insensitive filesystem; cli_name() is already lowercase for
-        // all built-in agents, but normalize defensively.
         execs.contains(&name.to_lowercase())
     } else {
         execs.contains(name)

--- a/src/config.rs
+++ b/src/config.rs
@@ -44,16 +44,24 @@ pub fn kiro_data_dir() -> Result<PathBuf, AgfError> {
 
 /// Cached set of executable names found in `$PATH`. Built once per process so
 /// `is_agent_installed` does not fork a `which` subprocess per agent.
+///
+/// On Windows the set is populated case-insensitively and additionally
+/// contains the *stem* of any file whose extension is in `%PATHEXT%`
+/// (e.g. both `claude.exe` and `claude` land in the set). Agents are
+/// registered with bare names like `claude`, so without stemming the
+/// lookup misses on Windows where the real file is `claude.exe` /
+/// `claude.cmd` / `claude.ps1`.
 fn path_executables() -> &'static HashSet<String> {
     static CACHE: OnceLock<HashSet<String>> = OnceLock::new();
     CACHE.get_or_init(|| {
+        let pathext = windows_pathext();
         let mut set = HashSet::new();
         if let Some(path) = std::env::var_os("PATH") {
             for dir in std::env::split_paths(&path) {
                 if let Ok(entries) = std::fs::read_dir(&dir) {
                     for entry in entries.flatten() {
                         if let Some(name) = entry.file_name().to_str() {
-                            set.insert(name.to_string());
+                            insert_executable_name(&mut set, name, &pathext);
                         }
                     }
                 }
@@ -63,8 +71,48 @@ fn path_executables() -> &'static HashSet<String> {
     })
 }
 
+/// Return the list of PATHEXT suffixes (lower-cased, each beginning with `.`)
+/// on Windows; empty on other platforms.
+fn windows_pathext() -> Vec<String> {
+    if !cfg!(windows) {
+        return Vec::new();
+    }
+    std::env::var("PATHEXT")
+        .unwrap_or_else(|_| String::from(".COM;.EXE;.BAT;.CMD"))
+        .split(';')
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_lowercase())
+        .collect()
+}
+
+/// Insert `filename` into `set`. On Windows, also insert its lower-cased
+/// stem (without a `PATHEXT` suffix). On other platforms, insert verbatim.
+fn insert_executable_name(set: &mut HashSet<String>, filename: &str, pathext: &[String]) {
+    if cfg!(windows) {
+        let lower = filename.to_lowercase();
+        for ext in pathext {
+            if let Some(stem) = lower.strip_suffix(ext.as_str()) {
+                set.insert(stem.to_string());
+                break;
+            }
+        }
+        set.insert(lower);
+    } else {
+        set.insert(filename.to_string());
+    }
+}
+
 pub fn is_agent_installed(agent: Agent) -> bool {
-    path_executables().contains(agent.cli_name())
+    let name = agent.cli_name();
+    let execs = path_executables();
+    if cfg!(windows) {
+        // Names in the set are lower-cased on Windows to match the
+        // case-insensitive filesystem; cli_name() is already lowercase for
+        // all built-in agents, but normalize defensively.
+        execs.contains(&name.to_lowercase())
+    } else {
+        execs.contains(name)
+    }
 }
 
 pub fn installed_agents() -> Vec<Agent> {
@@ -73,4 +121,43 @@ pub fn installed_agents() -> Vec<Agent> {
         .copied()
         .filter(|a| is_agent_installed(*a))
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[cfg(windows)]
+    fn insert_executable_name_adds_stem_on_windows() {
+        let pathext: Vec<String> = [".com", ".exe", ".bat", ".cmd"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let mut set = HashSet::new();
+        insert_executable_name(&mut set, "Claude.EXE", &pathext);
+        // Full lower-cased name and stem both present.
+        assert!(set.contains("claude.exe"));
+        assert!(set.contains("claude"));
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn insert_executable_name_no_stem_when_ext_missing() {
+        let pathext: Vec<String> = [".exe"].iter().map(|s| s.to_string()).collect();
+        let mut set = HashSet::new();
+        insert_executable_name(&mut set, "README.md", &pathext);
+        assert!(set.contains("readme.md"));
+        // No bare "readme" stem should be inserted — .md is not in PATHEXT.
+        assert!(!set.contains("readme"));
+    }
+
+    #[test]
+    #[cfg(not(windows))]
+    fn insert_executable_name_verbatim_on_unix() {
+        let mut set = HashSet::new();
+        insert_executable_name(&mut set, "claude", &[]);
+        assert!(set.contains("claude"));
+        assert_eq!(set.len(), 1);
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ struct Cli {
 enum Commands {
     /// Output shell wrapper function for the given shell
     Init {
-        /// Shell type: zsh, bash, or fish
+        /// Shell type: zsh, bash, fish, or powershell (alias: pwsh)
         shell: String,
     },
     /// Auto-detect shell and add agf to your shell config
@@ -303,9 +303,8 @@ fn deliver_command(cmd: &str) -> anyhow::Result<()> {
         return Ok(());
     }
 
-    let is_cd_only = !cmd.contains(" && ");
-
-    if is_cd_only {
+    let shell = shell::CommandShell::from_env();
+    if shell.is_cd_only(cmd) {
         eprintln!("⚠  Shell integration not active — `cd` won't persist in your shell.");
         eprintln!("   Run `agf setup` to install the wrapper, then restart your shell.");
         println!("{cmd}");
@@ -313,7 +312,7 @@ fn deliver_command(cmd: &str) -> anyhow::Result<()> {
     }
 
     if std::io::stdout().is_terminal() {
-        return exec_via_shell(cmd);
+        return exec_via_shell(cmd, shell);
     }
 
     // Piped / redirected: preserve the printable contract so callers can capture output.
@@ -322,19 +321,33 @@ fn deliver_command(cmd: &str) -> anyhow::Result<()> {
 }
 
 #[cfg(unix)]
-fn exec_via_shell(cmd: &str) -> anyhow::Result<()> {
+fn exec_via_shell(cmd: &str, shell: shell::CommandShell) -> anyhow::Result<()> {
     use std::os::unix::process::CommandExt;
-    let err = std::process::Command::new("sh").arg("-c").arg(cmd).exec();
+    let err = match shell {
+        shell::CommandShell::PowerShell => std::process::Command::new("pwsh")
+            .arg("-NoProfile")
+            .arg("-Command")
+            .arg(cmd)
+            .exec(),
+        shell::CommandShell::Posix => std::process::Command::new("sh").arg("-c").arg(cmd).exec(),
+    };
     // `exec` only returns on failure.
     Err(anyhow::anyhow!("failed to exec shell: {err}"))
 }
 
 #[cfg(not(unix))]
-fn exec_via_shell(cmd: &str) -> anyhow::Result<()> {
-    let status = std::process::Command::new("sh")
-        .arg("-c")
-        .arg(cmd)
-        .status()?;
+fn exec_via_shell(cmd: &str, shell: shell::CommandShell) -> anyhow::Result<()> {
+    let status = match shell {
+        shell::CommandShell::PowerShell => std::process::Command::new("powershell")
+            .arg("-NoProfile")
+            .arg("-Command")
+            .arg(cmd)
+            .status()?,
+        shell::CommandShell::Posix => std::process::Command::new("sh")
+            .arg("-c")
+            .arg(cmd)
+            .status()?,
+    };
     if !status.success() {
         std::process::exit(status.code().unwrap_or(1));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -323,31 +323,19 @@ fn deliver_command(cmd: &str) -> anyhow::Result<()> {
 #[cfg(unix)]
 fn exec_via_shell(cmd: &str, shell: shell::CommandShell) -> anyhow::Result<()> {
     use std::os::unix::process::CommandExt;
-    let err = match shell {
-        shell::CommandShell::PowerShell => std::process::Command::new("pwsh")
-            .arg("-NoProfile")
-            .arg("-Command")
-            .arg(cmd)
-            .exec(),
-        shell::CommandShell::Posix => std::process::Command::new("sh").arg("-c").arg(cmd).exec(),
-    };
+    let (exe, args) = shell.exec_parts();
+    let err = std::process::Command::new(exe).args(args).arg(cmd).exec();
     // `exec` only returns on failure.
     Err(anyhow::anyhow!("failed to exec shell: {err}"))
 }
 
 #[cfg(not(unix))]
 fn exec_via_shell(cmd: &str, shell: shell::CommandShell) -> anyhow::Result<()> {
-    let status = match shell {
-        shell::CommandShell::PowerShell => std::process::Command::new("powershell")
-            .arg("-NoProfile")
-            .arg("-Command")
-            .arg(cmd)
-            .status()?,
-        shell::CommandShell::Posix => std::process::Command::new("sh")
-            .arg("-c")
-            .arg(cmd)
-            .status()?,
-    };
+    let (exe, args) = shell.exec_parts();
+    let status = std::process::Command::new(exe)
+        .args(args)
+        .arg(cmd)
+        .status()?;
     if !status.success() {
         std::process::exit(status.code().unwrap_or(1));
     }

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -250,6 +250,13 @@ end"#;
 // commands (Set-Location + `; if ($?) { ... }` rather than `cd ... && ...`).
 // Invoke-Expression runs in the caller's scope, so `Set-Location` persists
 // after the wrapper returns — matching the POSIX `eval` semantics.
+//
+// `Get-Content -Encoding UTF8` is required: the agf binary writes the command
+// file as raw UTF-8, and Windows PowerShell 5.1's default read encoding is
+// the system ANSI code page (e.g. CP949 on Korean Windows, CP1252 on
+// Western). Without the explicit encoding, non-ASCII project paths round-trip
+// as mojibake and `Set-Location` fails. PS 7+ already defaults to UTF-8;
+// specifying it is a no-op there.
 const POWERSHELL_WRAPPER: &str = r#"function agf {
     $__agfExe = Get-Command -Name agf -CommandType Application -ErrorAction SilentlyContinue |
                 Select-Object -First 1
@@ -264,7 +271,7 @@ const POWERSHELL_WRAPPER: &str = r#"function agf {
         & $__agfExe.Source @args
         $__agfExit = $LASTEXITCODE
         if ($__agfExit -eq 0 -and (Test-Path -LiteralPath $__agfTmp)) {
-            $__agfResult = Get-Content -Raw -LiteralPath $__agfTmp
+            $__agfResult = Get-Content -Raw -LiteralPath $__agfTmp -Encoding UTF8
             if ($__agfResult) {
                 Invoke-Expression $__agfResult
             }

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -1,4 +1,68 @@
 use std::fs;
+use std::path::PathBuf;
+
+/// Which shell's command syntax is in effect for the current invocation.
+///
+/// Selected by the `AGF_SHELL` environment variable, which the installed
+/// shell wrapper sets before invoking the real `agf` binary. Falls back to
+/// POSIX when the variable is absent, matching the pre-existing behavior
+/// for bash/zsh/fish users.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CommandShell {
+    Posix,
+    PowerShell,
+}
+
+impl CommandShell {
+    pub fn from_env() -> Self {
+        match std::env::var("AGF_SHELL").as_deref() {
+            Ok("powershell") | Ok("pwsh") => Self::PowerShell,
+            _ => Self::Posix,
+        }
+    }
+
+    /// Escape a string so it can be interpolated into a single-quoted
+    /// literal for this shell.
+    ///
+    /// POSIX: `'...'` with embedded `'` written as `'\''`.
+    /// PowerShell: `'...'` with embedded `'` written as `''`.
+    pub fn quote(&self, s: &str) -> String {
+        match self {
+            Self::Posix => format!("'{}'", s.replace('\'', "'\\''")),
+            Self::PowerShell => format!("'{}'", s.replace('\'', "''")),
+        }
+    }
+
+    /// Build "change directory to `path`, then run `cmd` only if the cd
+    /// succeeded." The separator differs between shells.
+    ///
+    /// POSIX uses `&&`. PowerShell 5.1 has no `&&` (that lands in 7+), so
+    /// we use `; if ($?) { ... }` which works in both 5.1 and 7+.
+    pub fn cd_and(&self, quoted_path: &str, cmd: &str) -> String {
+        match self {
+            Self::Posix => format!("cd {quoted_path} && {cmd}"),
+            Self::PowerShell => format!("Set-Location {quoted_path}; if ($?) {{ {cmd} }}"),
+        }
+    }
+
+    /// Build a "cd only, no follow-up" command.
+    pub fn cd_only(&self, quoted_path: &str) -> String {
+        match self {
+            Self::Posix => format!("cd {quoted_path}"),
+            Self::PowerShell => format!("Set-Location {quoted_path}"),
+        }
+    }
+
+    /// True if `cmd` only changes directory (no chained follow-up).
+    /// Used by the delivery path to warn when shell integration is missing
+    /// (a bare `cd` printed to stdout doesn't persist in the parent shell).
+    pub fn is_cd_only(&self, cmd: &str) -> bool {
+        match self {
+            Self::Posix => !cmd.contains(" && "),
+            Self::PowerShell => !cmd.contains("; if ($?) {"),
+        }
+    }
+}
 
 /// Detect user's shell and append the init line to the appropriate rc file.
 pub fn setup() -> anyhow::Result<()> {
@@ -8,7 +72,7 @@ pub fn setup() -> anyhow::Result<()> {
     let (rc_file, init_line) = match shell_name {
         "zsh" => (
             dirs::home_dir().unwrap_or_default().join(".zshrc"),
-            r#"eval "$(agf init zsh)""#,
+            r#"eval "$(agf init zsh)""#.to_string(),
         ),
         "bash" => {
             let home = dirs::home_dir().unwrap_or_default();
@@ -18,21 +82,27 @@ pub fn setup() -> anyhow::Result<()> {
             } else {
                 home.join(".bash_profile")
             };
-            (rc, r#"eval "$(agf init bash)""#)
+            (rc, r#"eval "$(agf init bash)""#.to_string())
         }
         "fish" => (
             dirs::config_dir()
                 .unwrap_or_else(|| dirs::home_dir().unwrap_or_default().join(".config"))
                 .join("fish")
                 .join("config.fish"),
-            "agf init fish | source",
+            "agf init fish | source".to_string(),
+        ),
+        // No POSIX SHELL and we're on Windows — default to PowerShell.
+        _ if shell_name.is_empty() && cfg!(windows) => (
+            powershell_profile_path(),
+            "agf init powershell | Out-String | Invoke-Expression".to_string(),
         ),
         _ => {
             eprintln!("Unsupported shell: {shell_name}");
             eprintln!("Manually add to your shell config:");
-            eprintln!("  eval \"$(agf init zsh)\"   # for zsh");
-            eprintln!("  eval \"$(agf init bash)\"  # for bash");
-            eprintln!("  agf init fish | source    # for fish");
+            eprintln!("  eval \"$(agf init zsh)\"                            # for zsh");
+            eprintln!("  eval \"$(agf init bash)\"                           # for bash");
+            eprintln!("  agf init fish | source                             # for fish");
+            eprintln!("  agf init powershell | Out-String | Invoke-Expression  # for PowerShell");
             return Err(anyhow::anyhow!("unsupported shell: {shell_name}"));
         }
     };
@@ -47,7 +117,7 @@ pub fn setup() -> anyhow::Result<()> {
         }
     }
 
-    // Ensure parent directory exists (for fish)
+    // Ensure parent directory exists (for fish / PowerShell)
     if let Some(parent) = rc_file.parent() {
         fs::create_dir_all(parent)?;
     }
@@ -70,12 +140,45 @@ pub fn setup() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Resolve the PowerShell `$PROFILE` (CurrentUserAllHosts) path.
+///
+/// On Windows, PowerShell 7 (`pwsh`) and Windows PowerShell 5.1 use distinct
+/// profile directories. Prefer an existing `PowerShell` dir (PS 7); fall back
+/// to `WindowsPowerShell` (PS 5.1) if only that one exists; otherwise default
+/// to the PS 7 path (modern default, created on demand).
+///
+/// On non-Windows, PowerShell 7 uses `~/.config/powershell/profile.ps1`.
+fn powershell_profile_path() -> PathBuf {
+    if cfg!(windows) {
+        let docs = dirs::document_dir()
+            .unwrap_or_else(|| dirs::home_dir().unwrap_or_default().join("Documents"));
+        let ps7 = docs.join("PowerShell");
+        let ps5 = docs.join("WindowsPowerShell");
+        let dir = if ps7.exists() {
+            ps7
+        } else if ps5.exists() {
+            ps5
+        } else {
+            ps7
+        };
+        dir.join("profile.ps1")
+    } else {
+        dirs::config_dir()
+            .unwrap_or_else(|| dirs::home_dir().unwrap_or_default().join(".config"))
+            .join("powershell")
+            .join("profile.ps1")
+    }
+}
+
 pub fn shell_init(shell: &str) -> String {
     match shell {
         "zsh" => ZSH_WRAPPER.to_string(),
         "bash" => BASH_WRAPPER.to_string(),
         "fish" => FISH_WRAPPER.to_string(),
-        other => format!("echo \"Unsupported shell: {other}. Use zsh, bash, or fish.\""),
+        "powershell" | "pwsh" => POWERSHELL_WRAPPER.to_string(),
+        other => {
+            format!("echo \"Unsupported shell: {other}. Use zsh, bash, fish, or powershell.\"")
+        }
     }
 }
 
@@ -121,3 +224,97 @@ const FISH_WRAPPER: &str = r#"function agf
     end
     rm -f $tmpfile
 end"#;
+
+// PowerShell wrapper. Compatible with Windows PowerShell 5.1 and PowerShell 7+.
+//
+// `AGF_SHELL=powershell` tells the agf binary to emit PowerShell-flavored
+// commands (Set-Location + `; if ($?) { ... }` rather than `cd ... && ...`).
+// Invoke-Expression runs in the caller's scope, so `Set-Location` persists
+// after the wrapper returns — matching the POSIX `eval` semantics.
+const POWERSHELL_WRAPPER: &str = r#"function agf {
+    $__agfExe = Get-Command -Name agf -CommandType Application -ErrorAction SilentlyContinue |
+                Select-Object -First 1
+    if (-not $__agfExe) {
+        Write-Error 'agf: executable not found on PATH.'
+        return
+    }
+    $__agfTmp = [System.IO.Path]::GetTempFileName()
+    try {
+        $env:AGF_CMD_FILE = $__agfTmp
+        $env:AGF_SHELL = 'powershell'
+        & $__agfExe.Source @args
+        $__agfExit = $LASTEXITCODE
+        if ($__agfExit -eq 0 -and (Test-Path -LiteralPath $__agfTmp)) {
+            $__agfResult = Get-Content -Raw -LiteralPath $__agfTmp
+            if ($__agfResult) {
+                Invoke-Expression $__agfResult
+            }
+        }
+    }
+    finally {
+        if (Test-Path -LiteralPath $__agfTmp) {
+            Remove-Item -Force -LiteralPath $__agfTmp -ErrorAction SilentlyContinue
+        }
+        Remove-Item -Path Env:AGF_CMD_FILE -ErrorAction SilentlyContinue
+        Remove-Item -Path Env:AGF_SHELL -ErrorAction SilentlyContinue
+    }
+}"#;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn posix_quote_escapes_single_quote() {
+        let s = CommandShell::Posix.quote("Jon's files");
+        assert_eq!(s, r#"'Jon'\''s files'"#);
+    }
+
+    #[test]
+    fn powershell_quote_doubles_single_quote() {
+        let s = CommandShell::PowerShell.quote("Jon's files");
+        assert_eq!(s, "'Jon''s files'");
+    }
+
+    #[test]
+    fn cd_and_posix_uses_amp_amp() {
+        let cmd = CommandShell::Posix.cd_and("'/tmp'", "claude");
+        assert_eq!(cmd, "cd '/tmp' && claude");
+    }
+
+    #[test]
+    fn cd_and_powershell_uses_if_dollar_question() {
+        let cmd = CommandShell::PowerShell.cd_and("'C:\\tmp'", "claude");
+        assert_eq!(cmd, "Set-Location 'C:\\tmp'; if ($?) { claude }");
+    }
+
+    #[test]
+    fn is_cd_only_detects_chained_commands() {
+        let posix = CommandShell::Posix;
+        assert!(posix.is_cd_only("cd '/tmp'"));
+        assert!(!posix.is_cd_only("cd '/tmp' && claude"));
+
+        let pwsh = CommandShell::PowerShell;
+        assert!(pwsh.is_cd_only("Set-Location '/tmp'"));
+        assert!(!pwsh.is_cd_only("Set-Location '/tmp'; if ($?) { claude }"));
+    }
+
+    #[test]
+    fn from_env_reads_agf_shell() {
+        let prev = std::env::var("AGF_SHELL").ok();
+
+        std::env::set_var("AGF_SHELL", "powershell");
+        assert_eq!(CommandShell::from_env(), CommandShell::PowerShell);
+
+        std::env::set_var("AGF_SHELL", "pwsh");
+        assert_eq!(CommandShell::from_env(), CommandShell::PowerShell);
+
+        std::env::remove_var("AGF_SHELL");
+        assert_eq!(CommandShell::from_env(), CommandShell::Posix);
+
+        match prev {
+            Some(v) => std::env::set_var("AGF_SHELL", v),
+            None => std::env::remove_var("AGF_SHELL"),
+        }
+    }
+}

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -15,8 +15,14 @@ pub enum CommandShell {
 
 impl CommandShell {
     pub fn from_env() -> Self {
-        match std::env::var("AGF_SHELL").as_deref() {
-            Ok("powershell") | Ok("pwsh") => Self::PowerShell,
+        Self::from_name(std::env::var("AGF_SHELL").ok().as_deref())
+    }
+
+    /// Pure helper behind `from_env` — classifies a shell name string.
+    /// Exposed so tests can drive it without mutating process env.
+    fn from_name(name: Option<&str>) -> Self {
+        match name {
+            Some("powershell") | Some("pwsh") => Self::PowerShell,
             _ => Self::Posix,
         }
     }
@@ -60,6 +66,20 @@ impl CommandShell {
         match self {
             Self::Posix => !cmd.contains(" && "),
             Self::PowerShell => !cmd.contains("; if ($?) {"),
+        }
+    }
+
+    /// Executable name and leading args used to evaluate a generated command
+    /// string in this shell's syntax (e.g. `("sh", &["-c"])`).
+    pub fn exec_parts(&self) -> (&'static str, &'static [&'static str]) {
+        match self {
+            Self::Posix => ("sh", &["-c"]),
+            // On Unix, `pwsh` is the cross-platform binary; on Windows either
+            // `pwsh` or the 5.1 `powershell.exe` work with the same flags.
+            #[cfg(unix)]
+            Self::PowerShell => ("pwsh", &["-NoProfile", "-Command"]),
+            #[cfg(not(unix))]
+            Self::PowerShell => ("powershell", &["-NoProfile", "-Command"]),
         }
     }
 }
@@ -152,14 +172,13 @@ fn powershell_profile_path() -> PathBuf {
     if cfg!(windows) {
         let docs = dirs::document_dir()
             .unwrap_or_else(|| dirs::home_dir().unwrap_or_default().join("Documents"));
-        let ps7 = docs.join("PowerShell");
         let ps5 = docs.join("WindowsPowerShell");
-        let dir = if ps7.exists() {
-            ps7
-        } else if ps5.exists() {
+        // Prefer PS 7 (`PowerShell`); fall back to PS 5.1 only when its dir
+        // exists and PS 7's does not. Created on demand by setup().
+        let dir = if ps5.exists() && !docs.join("PowerShell").exists() {
             ps5
         } else {
-            ps7
+            docs.join("PowerShell")
         };
         dir.join("profile.ps1")
     } else {
@@ -252,9 +271,7 @@ const POWERSHELL_WRAPPER: &str = r#"function agf {
         }
     }
     finally {
-        if (Test-Path -LiteralPath $__agfTmp) {
-            Remove-Item -Force -LiteralPath $__agfTmp -ErrorAction SilentlyContinue
-        }
+        Remove-Item -Force -LiteralPath $__agfTmp -ErrorAction SilentlyContinue
         Remove-Item -Path Env:AGF_CMD_FILE -ErrorAction SilentlyContinue
         Remove-Item -Path Env:AGF_SHELL -ErrorAction SilentlyContinue
     }
@@ -300,21 +317,17 @@ mod tests {
     }
 
     #[test]
-    fn from_env_reads_agf_shell() {
-        let prev = std::env::var("AGF_SHELL").ok();
-
-        std::env::set_var("AGF_SHELL", "powershell");
-        assert_eq!(CommandShell::from_env(), CommandShell::PowerShell);
-
-        std::env::set_var("AGF_SHELL", "pwsh");
-        assert_eq!(CommandShell::from_env(), CommandShell::PowerShell);
-
-        std::env::remove_var("AGF_SHELL");
-        assert_eq!(CommandShell::from_env(), CommandShell::Posix);
-
-        match prev {
-            Some(v) => std::env::set_var("AGF_SHELL", v),
-            None => std::env::remove_var("AGF_SHELL"),
-        }
+    fn from_name_classifies_shells() {
+        assert_eq!(
+            CommandShell::from_name(Some("powershell")),
+            CommandShell::PowerShell
+        );
+        assert_eq!(
+            CommandShell::from_name(Some("pwsh")),
+            CommandShell::PowerShell
+        );
+        assert_eq!(CommandShell::from_name(Some("bash")), CommandShell::Posix);
+        assert_eq!(CommandShell::from_name(Some("")), CommandShell::Posix);
+        assert_eq!(CommandShell::from_name(None), CommandShell::Posix);
     }
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1290,7 +1290,7 @@ fn ui_agent_select(ui: &mut slt::Context, app: &mut App, result: &mut Option<Str
                 let indicator = format!(" {}) ", i + 1);
                 let preview = if let Some(s) = app.selected_session() {
                     let base = opt.agent.new_session_cmd();
-                    format!("cd {} && {base}", s.display_path())
+                    crate::shell::CommandShell::from_env().cd_and(&s.display_path(), base)
                 } else {
                     String::new()
                 };


### PR DESCRIPTION
## Summary

Adds Windows / PowerShell support so Windows PowerShell 5.1 and cross-platform `pwsh` 7+ users can install and use `agf`. POSIX behavior is unchanged.

## What's in it

**Shell syntax layer.** New `CommandShell` enum (Posix / PowerShell) selected at runtime from an `AGF_SHELL` env var that the installed wrapper exports before calling the real binary. Every place that built a shell command string — `action::{generate_command, resume_with_flags, new_session_with_flags, action_preview}`, `main::exec_via_shell`, and the TUI's new-session preview — routes through `CommandShell`, so `Set-Location '…'; if ($?) { … }` (compatible with PS 5.1 and 7+) is emitted under PowerShell and `cd '…' && …` stays identical under POSIX. Single-quote escaping follows shell-specific rules (`''` for PS, `'\''` for POSIX), so paths with apostrophes round-trip correctly in both.

**Shell installation.** `agf init powershell` (alias `pwsh`) emits a wrapper function that works in both PS 5.1 and 7+. `agf setup` auto-detects PowerShell on Windows (when `$SHELL` is unset) and writes to `$PROFILE.CurrentUserAllHosts` — preferring `Documents\PowerShell\profile.ps1` (PS 7), falling back to `WindowsPowerShell\profile.ps1` (5.1) only when the PS 7 dir is absent. On non-Windows, pwsh users get `~/.config/powershell/profile.ps1`.

**Agent detection on Windows.** `is_agent_installed` used to compare bare names (`claude`) verbatim against `$PATH` directory listings. On Windows the real files are `claude.exe` / `.cmd` / `.ps1`, so every agent read as "not installed" — the cache wrote an empty map, and the TUI reported "No agent sessions found" even when `agf list` (direct scan) had data. Fixed by `%PATHEXT%`-aware stemming in `path_executables()`: both the full lower-cased filename and the PATHEXT-stripped stem go into the set, and lookups on Windows lower-case the query. Unix path is literally unchanged.

**UTF-8 round-trip.** The agf binary writes the captured command to `AGF_CMD_FILE` as raw UTF-8. Windows PowerShell 5.1's `Get-Content -Raw` defaults to the system ANSI code page (CP949 on Korean Windows, CP1252 on Western), so non-ASCII project paths came back as mojibake and `Set-Location` failed. The PowerShell wrapper now reads with `-Encoding UTF8` (no-op on PS 7+, which defaults to UTF-8).

## Verified locally

- [x] `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (8 unit tests: shell quoting, `cd_and` / `cd_only` formatting, `is_cd_only` detection, shell name classification, PATHEXT stemming with negative case)
- [x] Windows 11 / PS 5.1, Korean locale: wrapper loads via `agf init powershell | Out-String | Invoke-Expression`, `agf list` and TUI detect sessions, round-trip works end-to-end for a path containing apostrophe + Korean + space (`John's 프로젝트 공백`) — `Set-Location` lands in the correct directory with the literal apostrophe preserved
- [x] Unix regression — reasoned analytically hunk-by-hunk: when `AGF_SHELL` is unset (default for bash/zsh/fish; none of those wrappers set it), every branch produces byte-identical output to `main`. `cfg!(windows)` is a compile-time literal so non-Windows branches are DCE'd

## Not yet verified (relying on upstream CI)

- [ ] Build + tests on `ubuntu-latest` — I couldn't trigger CI on my fork (Actions unregistered on fresh forks), so I didn't get a green check locally. Upstream CI should confirm on this PR
- [ ] macOS — no macOS box to hand; same byte-equivalence argument as Linux applies

## Disclaimer

This PR was authored with Claude Code as a pair-programming assistant (I directed, ran the Windows tests, made design calls). Flagging up front so reviewers know what's been on the diff. Treat normally — push back on anything off.

One design question I'd value input on: whether to drop PS 5.1 support and use `&&` instead of `; if ($?) { ... }` — current form works in both, but 7+-only would be cleaner if you're OK dropping 5.1.