### PR TITLE
chore(homebrew): update formula to v0.10.1

### DIFF
--- a/homebrew/agf.rb
+++ b/homebrew/agf.rb
@@ -1,22 +1,22 @@
 class Agf < Formula
   desc "AI Agent Session Finder TUI — find, resume, and manage AI coding agent sessions"
   homepage "https://github.com/subinium/agf"
-  version "0.10.0"
+  version "0.10.1"
   license "MIT"
 
   on_macos do
     if Hardware::CPU.arm?
       url "https://github.com/subinium/agf/releases/download/v#{version}/agf-aarch64-apple-darwin.tar.gz"
-      sha256 "9a18208a2b1afc209758a0f91aed185313f5030790efd49f0d0f07955d31a468"
+      sha256 "b66d83dc14fbddde51bae918d263f285e0fb1ae61bd222cbdab1c8baa8c3f412"
     else
       url "https://github.com/subinium/agf/releases/download/v#{version}/agf-x86_64-apple-darwin.tar.gz"
-      sha256 "db084e4202cf9ca0fe199ca9cb1f50c7cffa3abb8a1687e00a12819aec34fb04"
+      sha256 "289a4d870c0e735f9286514a3be985bd302013d83bc79452973382a03e99259e"
     end
   end
 
   on_linux do
     url "https://github.com/subinium/agf/releases/download/v#{version}/agf-x86_64-unknown-linux-gnu.tar.gz"
-    sha256 "da3a678be3e8496b55b66198726e97c702969aade0b1e8cbd6a8b7442d31a4c6"
+    sha256 "ed9c2a0130dd94e67c7512c896f1523d3ed19ee194fbac5be832fa893274e157"
   end
 
   def install


### PR DESCRIPTION
## Summary
- Bump Homebrew formula version + sha256 for the three platforms the local formula covers (mac arm64/x86_64, linux x86_64).
- Windows is published via the GitHub release `.zip` directly, not Homebrew.

## Sha256 source
[checksums.txt](https://github.com/subinium/agf/releases/download/v0.10.1/checksums.txt) generated by `release.yml` on tag push.

## Test plan
- [ ] `brew install --build-from-source ./homebrew/agf.rb`
- [ ] `agf --version` reports `0.10.1`
- [ ] PR linked to the [v0.10.1 release](https://github.com/subinium/agf/releases/tag/v0.10.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)