### PR TITLE
release: v0.10.2 — cache write race fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.10.2] - 2026-04-25
+
+### Fixed
+
+- **Cache write race on early TUI exit (regression in 0.10.1)** — v0.10.1 introduced streaming background scans; if the user exited the TUI before a worker finished, `cache::write_cache` persisted that agent as `(empty session list, fresh mtime)`, hiding its sessions on the next launch until file mtime changed again. `write_cache` now takes the still-scanning agent set and carries the prior cache entry verbatim for those agents — only completed scans replace cache state.
+
 ## [0.10.1] - 2026-04-25
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agf"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agf"
-version = "0.10.1"
+version = "0.10.2"
 edition = "2021"
 description = "AI Agent Session Finder TUI — find, resume, and manage Claude Code, Codex, OpenCode, Gemini, Kiro, pi, and Cursor CLI sessions"
 license = "MIT"

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -181,7 +181,13 @@ pub fn load_cache() -> (Vec<Session>, Vec<Agent>) {
 }
 
 /// Write all sessions to cache, grouped by agent.
-pub fn write_cache(sessions: &[Session]) {
+///
+/// `skip_agents` lists agents whose background scan did not complete this
+/// run (e.g. the user exited the TUI before the worker finished); for those
+/// we preserve the prior cache entry verbatim so we don't accidentally
+/// persist an empty session list with a fresh `mtime`, which would mark the
+/// agent "fresh" on the next launch and hide its sessions.
+pub fn write_cache(sessions: &[Session], skip_agents: &std::collections::HashSet<Agent>) {
     let path = cache_path();
     if let Some(parent) = path.parent() {
         let _ = fs::create_dir_all(parent);
@@ -192,8 +198,33 @@ pub fn write_cache(sessions: &[Session]) {
     let plugins = plugin::all_plugins();
     let mut agents: HashMap<String, AgentCache> = HashMap::new();
 
+    // Carry over prior cache entries for in-flight agents.
+    if !skip_agents.is_empty() {
+        if let Ok(content) = fs::read_to_string(&path) {
+            if let Ok(prior) = serde_json::from_str::<CacheFile>(&content) {
+                if prior.version == CACHE_VERSION {
+                    for skip in skip_agents {
+                        let key = agent_to_str(*skip).to_string();
+                        if let Some(entry) = prior.agents.get(&key) {
+                            agents.insert(
+                                key,
+                                AgentCache {
+                                    mtime: entry.mtime,
+                                    sessions: entry.sessions.iter().map(clone_cached).collect(),
+                                },
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     for p in &plugins {
         if !installed.contains(&p.agent()) {
+            continue;
+        }
+        if skip_agents.contains(&p.agent()) {
             continue;
         }
         let key = agent_to_str(p.agent()).to_string();
@@ -222,6 +253,20 @@ pub fn write_cache(sessions: &[Session]) {
         if fs::write(&tmp, json).is_ok() {
             let _ = fs::rename(&tmp, &path);
         }
+    }
+}
+
+fn clone_cached(c: &CachedSession) -> CachedSession {
+    CachedSession {
+        agent: c.agent.clone(),
+        session_id: c.session_id.clone(),
+        project_name: c.project_name.clone(),
+        project_path: c.project_path.clone(),
+        summaries: c.summaries.clone(),
+        timestamp: c.timestamp,
+        git_branch: c.git_branch.clone(),
+        worktree: c.worktree.clone(),
+        recap: c.recap.clone(),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -256,7 +256,9 @@ fn main() -> anyhow::Result<()> {
         let result = app.run()?;
         // Persist whatever sessions accumulated during the TUI lifetime so
         // the next launch reflects all scans that completed before exit.
-        cache::write_cache(&app.sessions);
+        // Agents still scanning at exit keep their prior cache entry so we
+        // don't accidentally persist "empty + fresh-mtime" for them.
+        cache::write_cache(&app.sessions, &app.scanning_agents);
         result
     };
 


### PR DESCRIPTION
## Summary
Ships v0.10.2 with the cache-write race fix introduced by v0.10.1's streaming TUI ingest.

## The race
v0.10.1 made stale-agent scans run in the background and the TUI ingest results progressively. `cache::write_cache` runs at TUI exit to persist the merged result. **But if the user exits before a worker has reported in**, `write_cache` would persist that agent as `(empty session list, fresh mtime)` — making it look "fresh + empty" on the next launch and hiding its sessions until file mtime changed again.

## What changed
- `cache::write_cache` takes a new `&HashSet<Agent>` of agents whose scan didn't finish in this run.
- For each in-flight agent, the function loads the existing on-disk cache and carries that entry verbatim (mtime + sessions) into the new file — so completed scans persist while interrupted ones are left untouched.
- `main.rs` passes `app.scanning_agents` (the live set the TUI updates as workers report in) to `write_cache`.
- Bump `Cargo.toml` to 0.10.2 + CHANGELOG entry.

## Why ship 0.10.2 instead of patching 0.10.1
The race only matters when the user exits during a scan. With v0.10.1's head/tail cap making scans complete in <1s on most setups, it's rare in practice — but the fix is small and worth shipping promptly since the race CAN cause a temporarily empty agent. Tag for v0.10.1 is already pushed and on crates.io; force-pushing it would break consumers who already have it.

## Test plan
- [x] `cargo test`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [ ] Manual: open `agf`, exit immediately during scan, reopen → previously-cached sessions still visible
- [ ] After merge: tag v0.10.2 + push → release.yml builds artifacts; auto-publish to crates.io (CARGO_REGISTRY_TOKEN secret added)
- [ ] Follow-up PR for `homebrew/agf.rb` v0.10.2 sha256 update

🤖 Generated with [Claude Code](https://claude.com/claude-code)