### PR TITLE
chore(homebrew): update formula to v0.10.2

### DIFF
--- a/homebrew/agf.rb
+++ b/homebrew/agf.rb
@@ -1,22 +1,22 @@
 class Agf < Formula
   desc "AI Agent Session Finder TUI — find, resume, and manage AI coding agent sessions"
   homepage "https://github.com/subinium/agf"
-  version "0.10.0"
+  version "0.10.2"
   license "MIT"
 
   on_macos do
     if Hardware::CPU.arm?
       url "https://github.com/subinium/agf/releases/download/v#{version}/agf-aarch64-apple-darwin.tar.gz"
-      sha256 "9a18208a2b1afc209758a0f91aed185313f5030790efd49f0d0f07955d31a468"
+      sha256 "fccb1b0cdb53151242aed99059d5ce2e7e39bd7a0a73f03bb7b45c732dc8110d"
     else
       url "https://github.com/subinium/agf/releases/download/v#{version}/agf-x86_64-apple-darwin.tar.gz"
-      sha256 "db084e4202cf9ca0fe199ca9cb1f50c7cffa3abb8a1687e00a12819aec34fb04"
+      sha256 "dba143df771ab2571a4008766b9e9033791757b23b1d3f6147c9374b3c5c9bd8"
     end
   end
 
   on_linux do
     url "https://github.com/subinium/agf/releases/download/v#{version}/agf-x86_64-unknown-linux-gnu.tar.gz"
-    sha256 "da3a678be3e8496b55b66198726e97c702969aade0b1e8cbd6a8b7442d31a4c6"
+    sha256 "e0bdd9ab0011cc90dd5c27b0a70a9ad4bac703fff1ee1339ac2d0ce7ec9fca1d"
   end
 
   def install


### PR DESCRIPTION
## Summary
Bump Homebrew formula to v0.10.2. Skips v0.10.1 entirely (superseded by v0.10.2; see #24 for the cache write race fix).

## Changes
- `version "0.10.0"` → `"0.10.2"` (the previous formula bump landed in cbb5b3b for v0.10.0)
- Three sha256 entries refreshed from the v0.10.2 release artifacts.

## Source
[checksums.txt](https://github.com/subinium/agf/releases/download/v0.10.2/checksums.txt) generated by the release workflow on tag push.

## Test plan
- [ ] `brew install --build-from-source ./homebrew/agf.rb`
- [ ] `agf --version` reports `0.10.2`

Note: Windows users install from the [GitHub release .zip](https://github.com/subinium/agf/releases/tag/v0.10.2) directly — Homebrew is macOS/Linux only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)