### PR TITLE
docs(readme): drop Homebrew from Quick Start, point to cargo install

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,10 @@ Built with [SuperLightTUI (SLT)](https://github.com/subinium/SuperLightTUI) — 
 ## Quick Start
 
 ```bash
-# Homebrew (macOS/Linux)
-brew install subinium/tap/agf
-
-# Cargo (any platform)
 cargo install agf
 ```
+
+Requires a Rust toolchain (`rustup` recommended). Prebuilt binaries for macOS, Linux, and Windows are also available on the [Releases page](https://github.com/subinium/agf/releases).
 
 Then run `agf setup` and restart your shell. Type `agf` to launch.
 


### PR DESCRIPTION
## Summary
Pausing Homebrew as the recommended install path. Quick Start now shows only \`cargo install agf\` plus a Releases-page pointer for users who want a prebuilt binary.

## Changes
- README \`Quick Start\` section: remove Homebrew block, keep \`cargo install agf\`.
- Add a one-line note: requires a Rust toolchain; prebuilt binaries available on the Releases page (mac/linux/windows).

## Not in this PR
- \`homebrew/agf.rb\` formula stays in the repo for future use.
- \`subinium/homebrew-tap\` repo unchanged (not touched here).
- No code changes.

## Test plan
- [ ] Render README on GitHub looks clean
- [ ] All existing links still resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)