### PR TITLE
fix(scanner/claude): skip sessions whose per-session JSONL no longer exists

### DIFF
--- a/src/scanner/claude.rs
+++ b/src/scanner/claude.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::BufRead;
 
@@ -44,19 +44,18 @@ struct SessionMeta {
     recap: Option<String>, // most recent away_summary, optionally prefixed with aiTitle
 }
 
-/// Scan ~/.claude/projects/*/<sessionId>.jsonl to detect worktree sessions
-/// and extract recap (away_summary / aiTitle) metadata.
+/// Walk `~/.claude/projects/*/<sessionId>.jsonl` once and return the list of
+/// `(session_id, path)` pairs for every per-session JSONL on disk.
 ///
-/// `cwd` in the per-session JSONL is the actual working directory, which for
-/// worktree sessions looks like `<project>/.claude/worktrees/<name>`.
-fn scan_session_metadata(claude_dir: &std::path::Path) -> HashMap<String, SessionMeta> {
+/// Callers (orphan filtering + `scan_session_metadata`) share this so the
+/// directory tree is only read once per scan.
+fn list_session_files(claude_dir: &std::path::Path) -> Vec<(String, std::path::PathBuf)> {
     let projects_dir = claude_dir.join("projects");
 
     let Ok(proj_entries) = fs::read_dir(&projects_dir) else {
-        return HashMap::new();
+        return Vec::new();
     };
 
-    // Collect all JSONL file paths first, then process in parallel.
     let mut file_paths: Vec<(String, std::path::PathBuf)> = Vec::new();
     for proj_entry in proj_entries.flatten() {
         let proj_path = proj_entry.path();
@@ -81,6 +80,17 @@ fn scan_session_metadata(claude_dir: &std::path::Path) -> HashMap<String, Sessio
         }
     }
 
+    file_paths
+}
+
+/// Scan ~/.claude/projects/*/<sessionId>.jsonl to detect worktree sessions
+/// and extract recap (away_summary / aiTitle) metadata.
+///
+/// `cwd` in the per-session JSONL is the actual working directory, which for
+/// worktree sessions looks like `<project>/.claude/worktrees/<name>`.
+fn scan_session_metadata(
+    file_paths: Vec<(String, std::path::PathBuf)>,
+) -> HashMap<String, SessionMeta> {
     file_paths
         .into_par_iter()
         .filter_map(|(session_id, file_path)| {
@@ -212,7 +222,9 @@ pub fn scan() -> Result<Vec<Session>, AgfError> {
         return Ok(Vec::new());
     }
 
-    let session_meta = scan_session_metadata(&claude_dir);
+    let session_files = list_session_files(&claude_dir);
+    let existing_ids: HashSet<String> = session_files.iter().map(|(id, _)| id.clone()).collect();
+    let session_meta = scan_session_metadata(session_files);
     let mut branch_cache: HashMap<String, Option<String>> = HashMap::new();
     let mut sessions_map: HashMap<String, SessionData> = HashMap::new();
 
@@ -267,6 +279,14 @@ pub fn scan() -> Result<Vec<Session>, AgfError> {
             if data.project.is_empty() {
                 return None;
             }
+            // history.jsonl logs `sessionId` on session start, but the actual
+            // transcript file is created lazily by `claude --resume` and may
+            // be deleted by the user later. `claude --resume <id>` errors out
+            // with "No conversation found" for these orphans, so drop them
+            // from the listing rather than offering a dead resume target.
+            if !existing_ids.contains(&session_id) {
+                return None;
+            }
 
             // project in history.jsonl is always the real project root.
             let project_path = data.project.clone();
@@ -311,4 +331,56 @@ pub fn scan() -> Result<Vec<Session>, AgfError> {
 
     sessions.sort_by_key(|s| std::cmp::Reverse(s.timestamp));
     Ok(sessions)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn make_claude_dir(name: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(name);
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(dir.join("projects")).unwrap();
+        dir
+    }
+
+    fn touch_session(claude_dir: &std::path::Path, project: &str, session_id: &str) {
+        let proj = claude_dir.join("projects").join(project);
+        fs::create_dir_all(&proj).unwrap();
+        let path = proj.join(format!("{session_id}.jsonl"));
+        let mut f = fs::File::create(&path).unwrap();
+        f.write_all(b"{}\n").unwrap();
+    }
+
+    #[test]
+    fn list_session_files_collects_jsonl_session_ids() {
+        let claude_dir = make_claude_dir("agf-test-list-sessions");
+        touch_session(&claude_dir, "-home-foo", "aaa-111");
+        touch_session(&claude_dir, "-home-foo", "bbb-222");
+        touch_session(&claude_dir, "-home-bar", "ccc-333");
+        // Non-jsonl sibling must be ignored.
+        fs::write(claude_dir.join("projects/-home-foo/notes.txt"), "x").unwrap();
+
+        let ids: HashSet<String> = list_session_files(&claude_dir)
+            .into_iter()
+            .map(|(id, _)| id)
+            .collect();
+
+        assert_eq!(
+            ids,
+            ["aaa-111", "bbb-222", "ccc-333"]
+                .into_iter()
+                .map(String::from)
+                .collect()
+        );
+    }
+
+    #[test]
+    fn list_session_files_returns_empty_when_projects_missing() {
+        let dir = std::env::temp_dir().join("agf-test-no-projects");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        assert!(list_session_files(&dir).is_empty());
+    }
 }


### PR DESCRIPTION
Closes #27

## What

`scanner::claude::scan` builds the session list from `~/.claude/history.jsonl`. Claude Code never trims this file when a per-session JSONL is deleted, so dead session IDs accumulate and the listing offers them as resume targets — `claude --resume <id>` then errors out with `No conversation found`.

This filters `scan()` output through the set of session IDs that have a per-session JSONL on disk.

## Repro / impact

On my one-year-old `~/.claude`, before:

```
$ agf list --limit 1000 --agent claude --format json | jq length
99
```

After (10 of those had a JSONL still on disk; the other 89 were dead resume targets):

```
$ agf list --limit 1000 --agent claude --format json | jq length
10
```

## Approach

  * Split the per-session JSONL directory walk out of `scan_session_metadata` into a new `list_session_files` helper, so the directory tree is still only read once per scan.
  * Build a `HashSet<String>` of every session_id that has a JSONL file on disk and drop sessions from `scan()` whose id is not in that set.

`session_meta` looks like a tempting reuse, but it only contains entries with a `worktree` or `recap` (it filters out files with no recap yet via `worktree.is_some() || recap.is_some()`), so a fresh session with no recap would be filtered out by mistake. The fix needs to track every JSONL stem, not just the ones that produced metadata.

## Tests

Two new tests in `scanner::claude::tests`:

  * `list_session_files_collects_jsonl_session_ids` — confirms the walk picks up every `<id>.jsonl` across multiple project subdirs and ignores non-jsonl siblings.
  * `list_session_files_returns_empty_when_projects_missing` — confirms a missing `projects/` subdir returns an empty list rather than panicking.

Full suite: `cargo test` 14 passing (was 12 + 2 new), `cargo clippy -- -D warnings` clean, `cargo fmt --check` clean.

## Out of scope

This PR does not delete the orphan lines from `history.jsonl` itself. That would be a separate decision (the file belongs to Claude Code, not `agf`, and a user might want to keep history even if the transcript is gone). Filtering at scan time is enough to fix the user-visible bug.