### PR TITLE
release: v0.10.3 — Codex/Claude orphan cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.10.3] - 2026-05-01
+
+### Fixed
+
+- **scanner/claude: skip sessions whose per-session JSONL is missing** (#27, #29, by @Mert-coderoid) — `~/.claude/history.jsonl` accumulates session IDs forever; Claude Code never trims it when the per-session JSONL under `~/.claude/projects/*/<id>.jsonl` is deleted. Those orphan IDs surfaced in the listing and resume failed with `No conversation found`. `scanner::claude::scan` now filters its output through the set of session IDs that have a JSONL on disk; the directory walk is shared with `scan_session_metadata` so the tree is still read once per scan.
+- **delete/codex: also remove the SQLite `threads` row** (#28, #30, by @Mert-coderoid) — since the Codex scanner moved to `state_*.sqlite` as primary source, deletes that only removed the rollout JSONL and `history.jsonl` entry came back on the next scan. `delete_codex_session` now walks every `state_*.sqlite` in `~/.codex/` and runs `DELETE FROM threads WHERE id = ?1`; older-schema dbs without `threads` are skipped silently.
+- **scanner/codex: prune orphan `threads` rows on scan** (#31, #32, by @Mert-coderoid) — `state_*.sqlite` rows whose rollout JSONL no longer exists kept dominating `agf list` / `agf stats` (e.g. 324 ghost rows for an empty `~/.codex/sessions/`) and could not be resumed. `scan_sqlite` now builds the live session-id set from `~/.codex/sessions/`, excludes orphans from the listing, and `DELETE`s them from every `state_*.sqlite`. A walker error with no live IDs collected falls back to the legacy "surface every row" behavior so a transient I/O failure cannot wipe the table. Note: Codex scans are no longer strictly read-only — they will hard-delete unrecoverable orphan rows.
+
 ## [0.10.2] - 2026-04-25
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agf"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agf"
-version = "0.10.2"
+version = "0.10.3"
 edition = "2021"
 description = "Find and resume local AI coding-agent sessions across Claude Code, Codex, Gemini, Cursor CLI, OpenCode, Kiro, and pi"
 license = "MIT"


### PR DESCRIPTION
Patch release bundling three fixes contributed by @Mert-coderoid — thanks for the careful diagnoses, the per-PR repro/impact numbers, and the green test suites that came with each change.

## Included

| PR | Closes | Summary |
|:---|:---|:---|
| #29 | #27 | `scanner/claude`: skip sessions whose per-session JSONL no longer exists. |
| #30 | #28 | `delete/codex`: also remove the SQLite `threads` row so deletes survive a rescan. |
| #32 | #31 | `scanner/codex`: prune orphan `threads` rows whose rollout JSONL is gone. |

## Heads-up for users

Codex scans are no longer strictly read-only. After this release, every Codex scan walks `~/.codex/sessions/` to build a live-session-id set, and any `state_*.sqlite` `threads` row whose rollout JSONL is missing is hard-deleted from SQLite. A walker error with no live IDs collected falls back to the legacy "surface every row" behavior so a transient I/O failure cannot wipe the table.

Codex cannot resume those rows once the rollout JSONL is gone, so this is consistent cleanup, not data loss — but worth calling out in the changelog.

## Verification

- `cargo test` — 22 passing (was 12 + 10 new)
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean

## Post-merge checklist

- [ ] Tag `v0.10.3` and push
- [ ] Verify CI release.yml builds the four target binaries
- [ ] Verify `cargo publish` step on crates.io
- [ ] Mention @Mert-coderoid in the GitHub release notes