### PR TITLE
feat: add Hermes Agent session support

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -50,6 +50,7 @@ fn agent_from_str(s: &str) -> Option<Agent> {
         "Kiro" => Some(Agent::Kiro),
         "CursorAgent" => Some(Agent::CursorAgent),
         "Gemini" => Some(Agent::Gemini),
+        "Hermes" => Some(Agent::Hermes),
         _ => None,
     }
 }
@@ -63,6 +64,7 @@ fn agent_to_str(a: Agent) -> &'static str {
         Agent::Kiro => "Kiro",
         Agent::CursorAgent => "CursorAgent",
         Agent::Gemini => "Gemini",
+        Agent::Hermes => "Hermes",
     }
 }
 
@@ -309,6 +311,7 @@ pub fn start_stale_scan(stale: &[Agent]) -> std::sync::mpsc::Receiver<ScanResult
                 Agent::Kiro => crate::scanner::kiro::scan().unwrap_or_default(),
                 Agent::CursorAgent => crate::scanner::cursor_agent::scan().unwrap_or_default(),
                 Agent::Gemini => crate::scanner::gemini::scan().unwrap_or_default(),
+                Agent::Hermes => crate::scanner::hermes::scan().unwrap_or_default(),
             };
             if debug {
                 eprintln!(

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,6 +33,10 @@ pub fn cursor_dir() -> Result<PathBuf, AgfError> {
     Ok(home_dir()?.join(".cursor"))
 }
 
+pub fn hermes_dir() -> Result<PathBuf, AgfError> {
+    Ok(home_dir()?.join(".hermes"))
+}
+
 pub fn kiro_data_dir() -> Result<PathBuf, AgfError> {
     // Kiro CLI stores data via dirs::data_local_dir()
     // macOS: ~/Library/Application Support/kiro-cli/

--- a/src/delete.rs
+++ b/src/delete.rs
@@ -24,6 +24,7 @@ pub fn delete_session(session: &Session) -> Result<(), io::Error> {
         Agent::Kiro => delete_kiro_session(session),
         Agent::CursorAgent => delete_cursor_agent_session(session),
         Agent::Gemini => delete_gemini_session(session),
+        Agent::Hermes => delete_hermes_session(session),
     }
 }
 
@@ -388,6 +389,69 @@ fn delete_gemini_session(session: &Session) -> Result<(), io::Error> {
                 {
                     fs::remove_file(&path)?;
                     return Ok(());
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Hermes
+// ---------------------------------------------------------------------------
+
+/// Hermes Agent sessions are stored in a SQLite database at
+/// `~/.hermes/state.db`. Messages are in a separate `messages` table
+/// with a foreign key to `sessions.id`.
+fn delete_hermes_session(session: &Session) -> Result<(), io::Error> {
+    let hermes_dir = config::hermes_dir().map_err(io::Error::other)?;
+    let db_path = hermes_dir.join("state.db");
+    if !db_path.exists() {
+        return Ok(());
+    }
+
+    let conn = rusqlite::Connection::open(&db_path)
+        .map_err(|e| io::Error::other(format!("SQLite open error: {e}")))?;
+
+    // Delete messages first (foreign key constraint).
+    conn.execute(
+        "DELETE FROM messages WHERE session_id = ?1",
+        [&session.session_id],
+    )
+    .map_err(|e| io::Error::other(format!("SQLite delete messages error: {e}")))?;
+
+    // Delete child sessions' messages and then the child sessions themselves.
+    conn.execute(
+        "DELETE FROM messages WHERE session_id IN \
+         (SELECT id FROM sessions WHERE parent_session_id = ?1)",
+        [&session.session_id],
+    )
+    .map_err(|e| io::Error::other(format!("SQLite delete child messages error: {e}")))?;
+
+    conn.execute(
+        "DELETE FROM sessions WHERE parent_session_id = ?1",
+        [&session.session_id],
+    )
+    .map_err(|e| io::Error::other(format!("SQLite delete child sessions error: {e}")))?;
+
+    // Delete the parent session.
+    conn.execute(
+        "DELETE FROM sessions WHERE id = ?1",
+        [&session.session_id],
+    )
+    .map_err(|e| io::Error::other(format!("SQLite delete session error: {e}")))?;
+
+    // Also remove any on-disk session JSON dumps.
+    let sessions_dir = hermes_dir.join("sessions");
+    if sessions_dir.exists() {
+        let prefix = format!("session_{}", session.session_id);
+        if let Ok(entries) = fs::read_dir(&sessions_dir) {
+            for entry in entries.flatten() {
+                if let Some(name) = entry.file_name().to_str() {
+                    if name.starts_with(&prefix) && name.ends_with(".json") {
+                        let _ = fs::remove_file(entry.path());
+                    }
                 }
             }
         }

--- a/src/model.rs
+++ b/src/model.rs
@@ -10,6 +10,7 @@ pub enum Agent {
     Kiro,
     CursorAgent,
     Gemini,
+    Hermes,
 }
 
 impl fmt::Display for Agent {
@@ -22,6 +23,7 @@ impl fmt::Display for Agent {
             Agent::Kiro => write!(f, "Kiro"),
             Agent::CursorAgent => write!(f, "Cursor CLI"),
             Agent::Gemini => write!(f, "Gemini"),
+            Agent::Hermes => write!(f, "Hermes"),
         }
     }
 }
@@ -36,6 +38,7 @@ impl Agent {
             Agent::Kiro => (136, 69, 244),       // #8845F4 deep purple (AWS Kiro)
             Agent::CursorAgent => (245, 184, 65), // #F5B841 Cursor brand yellow
             Agent::Gemini => (66, 133, 244),     // #4285F4 Google blue
+            Agent::Hermes => (168, 85, 247),     // #A855F7 purple (Nous Research)
         }
     }
 
@@ -48,6 +51,7 @@ impl Agent {
             Agent::Kiro,
             Agent::CursorAgent,
             Agent::Gemini,
+            Agent::Hermes,
         ]
     }
 
@@ -61,6 +65,7 @@ impl Agent {
             Agent::Kiro => "kiro-cli",
             Agent::CursorAgent => "cursor-agent",
             Agent::Gemini => "gemini",
+            Agent::Hermes => "hermes",
         }
     }
 
@@ -74,6 +79,7 @@ impl Agent {
             Agent::Kiro => "kiro-cli chat --resume".to_string(),
             Agent::CursorAgent => format!("cursor-agent --resume '{session_id}'"),
             Agent::Gemini => format!("gemini --resume '{session_id}'"),
+            Agent::Hermes => format!("hermes --resume '{session_id}'"),
         }
     }
 
@@ -116,6 +122,7 @@ impl Agent {
             Agent::Kiro => "kiro-cli chat",
             Agent::CursorAgent => "cursor-agent",
             Agent::Gemini => "gemini",
+            Agent::Hermes => "hermes",
         }
     }
 }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -32,6 +32,7 @@ pub fn all_plugins() -> Vec<Box<dyn AgentPlugin>> {
         Box::new(PluginAdapter(Agent::Kiro)),
         Box::new(PluginAdapter(Agent::CursorAgent)),
         Box::new(PluginAdapter(Agent::Gemini)),
+        Box::new(PluginAdapter(Agent::Hermes)),
     ]
 }
 
@@ -53,6 +54,7 @@ impl AgentPlugin for PluginAdapter {
             Agent::Kiro => "Kiro",
             Agent::CursorAgent => "Cursor CLI",
             Agent::Gemini => "Gemini",
+            Agent::Hermes => "Hermes",
         }
     }
 
@@ -74,6 +76,7 @@ impl AgentPlugin for PluginAdapter {
             Agent::Kiro => scanner::kiro::scan().unwrap_or_default(),
             Agent::CursorAgent => scanner::cursor_agent::scan().unwrap_or_default(),
             Agent::Gemini => scanner::gemini::scan().unwrap_or_default(),
+            Agent::Hermes => scanner::hermes::scan().unwrap_or_default(),
         }
     }
 
@@ -114,6 +117,9 @@ impl AgentPlugin for PluginAdapter {
                 .unwrap_or_default(),
             Agent::Gemini => config::gemini_dir()
                 .map(|d| vec![d.join("tmp")])
+                .unwrap_or_default(),
+            Agent::Hermes => config::hermes_dir()
+                .map(|d| vec![d.join("state.db")])
                 .unwrap_or_default(),
         }
     }

--- a/src/scanner/hermes.rs
+++ b/src/scanner/hermes.rs
@@ -1,0 +1,117 @@
+use rusqlite::Connection;
+
+use crate::error::AgfError;
+use crate::model::{Agent, Session};
+
+/// Scan Hermes Agent sessions from `~/.hermes/state.db`.
+///
+/// Hermes stores sessions in a SQLite database with a `sessions` table
+/// (metadata, title, token counts) and a `messages` table (conversation
+/// content). Timestamps are Unix-epoch floats (seconds), which we convert
+/// to milliseconds to match the agf `Session.timestamp` convention.
+///
+/// Sessions with a `parent_session_id` are delegation/compression children
+/// and are excluded from the top-level listing (their titles are aggregated
+/// as additional summaries on the parent, matching the OpenCode pattern).
+pub fn scan() -> Result<Vec<Session>, AgfError> {
+    let db_path = crate::config::hermes_dir()?.join("state.db");
+
+    if !db_path.exists() {
+        return Ok(Vec::new());
+    }
+
+    let conn = Connection::open_with_flags(
+        &db_path,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )?;
+
+    // Fetch top-level sessions (no parent), ordered by most recent activity.
+    // Use MAX(messages.timestamp) as last_active, falling back to started_at.
+    // Aggregate child session titles as extra summaries.
+    let mut stmt = conn.prepare(
+        "SELECT s.id, \
+                s.title, \
+                s.source, \
+                s.model, \
+                s.message_count, \
+                CAST(COALESCE(m.last_active, s.started_at) * 1000 AS INTEGER) AS ts_ms, \
+                GROUP_CONCAT(child.title, '|||') \
+         FROM sessions s \
+         LEFT JOIN ( \
+             SELECT session_id, MAX(timestamp) AS last_active \
+             FROM messages GROUP BY session_id \
+         ) m ON m.session_id = s.id \
+         LEFT JOIN sessions child ON child.parent_session_id = s.id \
+         WHERE s.parent_session_id IS NULL \
+         GROUP BY s.id \
+         ORDER BY ts_ms DESC",
+    )?;
+
+    let sessions = stmt
+        .query_map([], |row| {
+            let id: String = row.get(0)?;
+            let title: Option<String> = row.get(1)?;
+            let source: String = row.get(2)?;
+            let model: Option<String> = row.get(3)?;
+            let message_count: i64 = row.get(4)?;
+            let timestamp: i64 = row.get(5)?;
+            let child_titles: Option<String> = row.get(6)?;
+            Ok((id, title, source, model, message_count, timestamp, child_titles))
+        })?
+        .filter_map(|r| r.ok())
+        .map(|(id, title, source, model, message_count, timestamp, child_titles)| {
+            // Build summaries: title first, then child session titles.
+            let mut summaries: Vec<String> = Vec::new();
+            if let Some(ref t) = title {
+                if !t.is_empty() {
+                    summaries.push(t.clone());
+                }
+            }
+            if let Some(ref children) = child_titles {
+                let mut seen = std::collections::HashSet::new();
+                for t in children.split("|||") {
+                    let t = t.trim();
+                    if !t.is_empty() && seen.insert(t.to_string()) {
+                        summaries.push(t.to_string());
+                    }
+                }
+            }
+
+            // If no title, build a fallback from source + model info.
+            if summaries.is_empty() {
+                let mut fallback = format!("{source} session");
+                if let Some(ref m) = model {
+                    if !m.is_empty() {
+                        // Extract short model name (e.g. "claude-opus-4-6" from "anthropic/claude-opus-4-6")
+                        let short = m.rsplit('/').next().unwrap_or(m);
+                        fallback = format!("{fallback} ({short})");
+                    }
+                }
+                if message_count > 0 {
+                    fallback = format!("{fallback} — {message_count} msgs");
+                }
+                summaries.push(fallback);
+            }
+
+            // Hermes doesn't store working directory per session.
+            // Default to the hermes home directory.
+            let hermes_home = crate::config::hermes_dir()
+                .map(|d| d.to_string_lossy().into_owned())
+                .unwrap_or_else(|_| "~/.hermes".to_string());
+
+            Session {
+                agent: Agent::Hermes,
+                session_id: id,
+                project_name: "hermes".to_string(),
+                project_path: hermes_home,
+                summaries,
+                timestamp,
+                git_branch: None,
+                worktree: None,
+                recap: None,
+            }
+        })
+        .collect();
+
+    Ok(sessions)
+}

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -6,6 +6,7 @@ pub mod claude;
 pub mod codex;
 pub mod cursor_agent;
 pub mod gemini;
+pub mod hermes;
 pub mod kiro;
 pub mod opencode;
 pub mod pi;
@@ -139,6 +140,7 @@ pub fn scan_all() -> Vec<Session> {
         thread::spawn(|| kiro::scan().unwrap_or_default()),
         thread::spawn(|| cursor_agent::scan().unwrap_or_default()),
         thread::spawn(|| gemini::scan().unwrap_or_default()),
+        thread::spawn(|| hermes::scan().unwrap_or_default()),
     ];
     let mut sessions: Vec<Session> = handles
         .into_iter()


### PR DESCRIPTION
## Summary

- Adds [Hermes Agent](https://github.com/nousresearch/hermes-agent) as a new supported agent
- Hermes stores sessions in `~/.hermes/state.db` (SQLite) with `sessions` and `messages` tables
- Resume command: `hermes --resume <session_id>`

## What's included

| File | Change |
|------|--------|
| `src/scanner/hermes.rs` | New scanner — reads top-level sessions, aggregates child session titles as summaries, falls back to `source + model` description when no title exists |
| `src/model.rs` | `Agent::Hermes` variant with color `#A855F7` (purple), CLI name `hermes`, resume/new-session commands |
| `src/config.rs` | `hermes_dir()` → `~/.hermes` |
| `src/delete.rs` | Cascade delete: messages → child sessions → parent session, plus on-disk JSON dumps in `~/.hermes/sessions/` |
| `src/plugin.rs` | Plugin registration and data source (`state.db`) |
| `src/scanner/mod.rs` | Wired into `scan_all()` parallel scan |
| `src/cache.rs` | Cache serialization/deserialization support |

## Details

Hermes Agent's SQLite schema is similar to OpenCode and Kiro — sessions table with parent-child relationships for delegation/compression chains. The scanner:

- Filters out child sessions (`parent_session_id IS NULL`)
- Uses `MAX(messages.timestamp)` as last-active time, falling back to `started_at`
- Aggregates child session titles as additional summaries (same pattern as OpenCode subagents)
- Hermes doesn't store working directory per session, so `project_path` defaults to `~/.hermes`

## Testing

- `cargo test` — all 22 existing tests pass
- Manually verified with a real `~/.hermes/state.db` containing 32 sessions (30 top-level):
  - `agf stats` correctly shows Hermes sessions
  - `agf list --agent hermes` lists sessions with titles/fallback descriptions
  - `agf list --format json` includes full session metadata

## Session storage reference

| Field | Location |
|-------|----------|
| Database | `~/.hermes/state.db` |
| Session ID format | `YYYYMMDD_HHMMSS_<6hex>` (CLI/TUI) or `api-<16hex>` (API) |
| Timestamps | Unix epoch floats (seconds), converted to ms for agf |
| Titles | Auto-generated by LLM after first exchange (often NULL for short sessions) |
| FTS | Built-in `messages_fts` (unicode61) and `messages_fts_trigram` tables |