### PR TITLE
release: v0.11.0 — Hermes Agent (thanks @SHL0MS)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 .vscode/
 *.iml
 CLAUDE.md
+.release-notes-*.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [0.11.0] - 2026-05-04
+
+### Added
+
+- **Hermes Agent support** (#34, by @SHL0MS) — adds [Hermes Agent](https://github.com/NousResearch/hermes-agent) (Nous Research's self-improving agent) as a first-class scanner. Reads top-level sessions from `~/.hermes/state.db` (SQLite); aggregates child-session titles as additional summaries (same pattern as OpenCode subagents); cascade-deletes messages → child sessions → parent → on-disk JSON dumps under `~/.hermes/sessions/session_<id>.json`. Resume via `hermes --resume <session_id>`.
+
+### Fixed
+
+- **scanner/hermes: pull first user message as preview when title is NULL** — Hermes lazily auto-generates titles after the first exchange, so short sessions stay un-titled and the listing fell back to bare `api_server session (model) — N msgs`. The scan query now selects the earliest `messages.content WHERE role='user'`, collapses whitespace, strips `<user_query>` wrapper tags, and caps to 160 chars so the detail pane shows what the conversation was actually about.
+- **scanner/hermes: empty project_path so resume stays in the user's cwd** — Hermes is cwd-independent; the original PR set `project_path = ~/.hermes`, which made `agf` emit `cd ~/.hermes && hermes --resume <id>` and yanked the shell out of whatever project the user was working in. `shell::cd_and` now skips the `cd` when the quoted path is empty (`""` / `''` / `\"\"`), and the Hermes scanner leaves `project_path` empty. `display_path()` renders empty paths as `—` so the TUI doesn't show a blank cell.
+- **delete/hermes: wrap cascade in a single SQLite transaction** — the original four DELETEs ran independently; a mid-cascade failure (disk full, DB locked, etc.) could leave orphan messages whose `sessions` row was already gone, surfacing as ghost rows on the next scan. The four DELETEs are now `BEGIN`/`COMMIT`-wrapped via `Connection::transaction`.
+- **TUI: time sort not applied on first frame when `config.sort_by` is unset** (regression visible since the cache was grouped per-agent) — `main.rs` only called `app.apply_sort()` inside an `if let Some(sort_by) = config.sort_by`, so the default-sort path silently rendered the cache's per-agent grouping order. A session from 11 minutes ago could land below sessions from a month ago on the first paint. `apply_sort()` is now always called; `sort_mode` falls through to `SortMode::Time` when `config.sort_by` is `None`.
+- **TUI: cwd-match boost removed** — the secondary sort that pushed sessions whose `project_path == $PWD` above everything else made the time-sorted listing look broken when `agf` was launched from inside a project: 11 sessions from "this project" surfaced first, then suddenly a 2-minute-old session from another project, then a 31-minute-old Hermes session, and so on. The boost was implicit (no on-screen indicator), so users read it as "time sort is wrong." Pinning is still honored — it's an explicit user action — but cwd is no longer special-cased.
+- **cache: bump `CACHE_VERSION` to 3** — Hermes Agent gained a new entry in the per-agent cache map, and the Hermes session payload now carries first-user-message previews instead of bare source/model fallbacks. Without bumping, 0.10.x cache files would surface as stale "cli session (...)" summaries on first 0.11.0 launch until the underlying DB mtime happened to change. The bump forces a one-time rescan on upgrade.
+
+### Notes
+
+- Cursor CLI scanner regression tracked separately in [#35](https://github.com/subinium/agf/issues/35) — recent cursor-agent installs write transcripts as `<id>/<id>.jsonl` (depth 4) instead of the legacy `<id>.txt` (depth 3) the scanner expects, so `agf list --agent cursor-agent` returns 0 sessions on those installs. Out of scope for this release.
+
 ## [0.10.3] - 2026-05-01
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agf"
-version = "0.10.3"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "agf"
-version = "0.10.3"
+version = "0.11.0"
 edition = "2021"
-description = "Find and resume local AI coding-agent sessions across Claude Code, Codex, Gemini, Cursor CLI, OpenCode, Kiro, and pi"
+description = "Find and resume local AI coding-agent sessions across Claude Code, Codex, Gemini, Cursor CLI, OpenCode, Kiro, pi, and Hermes"
 license = "MIT"
 repository = "https://github.com/subinium/agf"
 keywords = ["tui", "cli", "agent", "session", "claude"]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 > Find the AI coding session you meant to resume.
 
 `agf` is a local-first fuzzy finder for AI coding-agent sessions.
-Search local sessions across **Claude Code**, **Codex**, **Gemini CLI**, **Cursor CLI**, **OpenCode**, **Kiro**, and **pi** — then resume the right one in a keystroke.
+Search local sessions across **Claude Code**, **Codex**, **Gemini CLI**, **Cursor CLI**, **OpenCode**, **Kiro**, **pi**, and **Hermes** — then resume the right one in a keystroke.
 
 ![agf demo](./assets/demo.gif)
 
@@ -50,6 +50,7 @@ Then you either dig through history files or start over.
 | [OpenCode](https://github.com/opencode-ai/opencode) | `opencode -s <id>` | `~/.local/share/opencode/opencode.db` |
 | [Kiro](https://kiro.dev) | `kiro-cli chat --resume` | `~/Library/Application Support/kiro-cli/data.sqlite3` |
 | [pi](https://github.com/badlogic/pi-mono) | `pi --resume` | `~/.pi/agent/sessions/<cwd>/*.jsonl` |
+| [Hermes](https://github.com/NousResearch/hermes-agent) | `hermes --resume <id>` | `~/.hermes/state.db` |
 
 <details>
 <summary>Full session storage paths</summary>
@@ -63,6 +64,7 @@ Then you either dig through history files or start over.
 | Kiro | SQLite | macOS: `~/Library/Application Support/kiro-cli/data.sqlite3`<br>Linux: `~/.local/share/kiro-cli/data.sqlite3` |
 | Cursor CLI | SQLite + TXT | `~/.cursor/chats/*/<id>/store.db`<br>`~/.cursor/projects/*/agent-transcripts/<id>.txt` |
 | Gemini | JSON | `~/.gemini/tmp/<project>/chats/session-<date>-<id>.json`<br>`<project>` is a named dir or SHA-256 hash of the project path<br>Project paths resolved via `~/.gemini/projects.json` |
+| Hermes | SQLite | `~/.hermes/state.db` (sessions + messages)<br>JSON dumps in `~/.hermes/sessions/session_<id>.json`<br>Hermes is cwd-independent — resume runs in your current shell directory |
 
 </details>
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -7,7 +7,14 @@ use serde::{Deserialize, Serialize};
 use crate::model::{Agent, Session};
 use crate::plugin;
 
-const CACHE_VERSION: u32 = 2;
+// Bumped to 3 in v0.11.0:
+// - Hermes Agent registered (#34) so the per-agent cache map gains a new key.
+// - Hermes session payloads now carry first-user-message previews (only on
+//   CLI/TUI session ids) instead of bare source/model fallbacks; older cache
+//   entries written by 0.10.x would surface as stale "cli session (...)"
+//   summaries until the source DB mtime happens to change.
+//   Bumping the version forces a one-time rescan on first 0.11.0 launch.
+const CACHE_VERSION: u32 = 3;
 
 #[derive(Serialize, Deserialize)]
 struct CacheFile {

--- a/src/delete.rs
+++ b/src/delete.rs
@@ -403,7 +403,10 @@ fn delete_gemini_session(session: &Session) -> Result<(), io::Error> {
 
 /// Hermes Agent sessions are stored in a SQLite database at
 /// `~/.hermes/state.db`. Messages are in a separate `messages` table
-/// with a foreign key to `sessions.id`.
+/// with a foreign key to `sessions.id`. The four DELETEs are wrapped in
+/// a single transaction so a mid-cascade failure can't leave the DB in
+/// an inconsistent state (e.g. orphan messages whose sessions row is
+/// gone, which would surface as ghost rows on the next scan).
 fn delete_hermes_session(session: &Session) -> Result<(), io::Error> {
     let hermes_dir = config::hermes_dir().map_err(io::Error::other)?;
     let db_path = hermes_dir.join("state.db");
@@ -411,38 +414,44 @@ fn delete_hermes_session(session: &Session) -> Result<(), io::Error> {
         return Ok(());
     }
 
-    let conn = rusqlite::Connection::open(&db_path)
+    let mut conn = rusqlite::Connection::open(&db_path)
         .map_err(|e| io::Error::other(format!("SQLite open error: {e}")))?;
 
+    let tx = conn
+        .transaction()
+        .map_err(|e| io::Error::other(format!("SQLite begin tx error: {e}")))?;
+
     // Delete messages first (foreign key constraint).
-    conn.execute(
+    tx.execute(
         "DELETE FROM messages WHERE session_id = ?1",
         [&session.session_id],
     )
     .map_err(|e| io::Error::other(format!("SQLite delete messages error: {e}")))?;
 
     // Delete child sessions' messages and then the child sessions themselves.
-    conn.execute(
+    tx.execute(
         "DELETE FROM messages WHERE session_id IN \
          (SELECT id FROM sessions WHERE parent_session_id = ?1)",
         [&session.session_id],
     )
     .map_err(|e| io::Error::other(format!("SQLite delete child messages error: {e}")))?;
 
-    conn.execute(
+    tx.execute(
         "DELETE FROM sessions WHERE parent_session_id = ?1",
         [&session.session_id],
     )
     .map_err(|e| io::Error::other(format!("SQLite delete child sessions error: {e}")))?;
 
     // Delete the parent session.
-    conn.execute(
-        "DELETE FROM sessions WHERE id = ?1",
-        [&session.session_id],
-    )
-    .map_err(|e| io::Error::other(format!("SQLite delete session error: {e}")))?;
+    tx.execute("DELETE FROM sessions WHERE id = ?1", [&session.session_id])
+        .map_err(|e| io::Error::other(format!("SQLite delete session error: {e}")))?;
 
-    // Also remove any on-disk session JSON dumps.
+    tx.commit()
+        .map_err(|e| io::Error::other(format!("SQLite commit error: {e}")))?;
+
+    // Also remove any on-disk session JSON dumps. These are best-effort:
+    // a failure here doesn't undo the DB delete (which is the source of
+    // truth for the listing), so we swallow the error.
     let sessions_dir = hermes_dir.join("sessions");
     if sessions_dir.exists() {
         let prefix = format!("session_{}", session.session_id);

--- a/src/main.rs
+++ b/src/main.rs
@@ -244,15 +244,18 @@ fn main() -> anyhow::Result<()> {
             scanning_agents,
         );
 
-        // Apply sort_by from config
-        if let Some(ref sort_by) = config.sort_by {
-            app.sort_mode = match sort_by.as_str() {
-                "name" => model::SortMode::Name,
-                "agent" => model::SortMode::Agent,
-                _ => model::SortMode::Time,
-            };
-            app.apply_sort();
-        }
+        // Apply sort from config (default: time). Always call apply_sort()
+        // so the initial render is ordered — without this, agents loaded
+        // from the cache appear in the order they were grouped on disk
+        // (per-agent buckets) rather than by timestamp, so a session from
+        // 11 minutes ago can land below sessions from a month ago on the
+        // first frame.
+        app.sort_mode = match config.sort_by.as_deref() {
+            Some("name") => model::SortMode::Name,
+            Some("agent") => model::SortMode::Agent,
+            _ => model::SortMode::Time,
+        };
+        app.apply_sort();
         let result = app.run()?;
         // Persist whatever sessions accumulated during the TUI lifetime so
         // the next launch reflects all scans that completed before exit.

--- a/src/model.rs
+++ b/src/model.rs
@@ -205,6 +205,12 @@ impl Session {
     }
 
     pub fn display_path(&self) -> String {
+        // cwd-independent agents (Hermes) leave project_path empty so resume
+        // doesn't drag the user out of their current directory; surface that
+        // visually instead of rendering an empty cell.
+        if self.project_path.is_empty() {
+            return "—".to_string();
+        }
         if let Some(home) = dirs::home_dir() {
             if let Some(rest) = self.project_path.strip_prefix(home.to_str().unwrap_or("")) {
                 return format!("~{rest}");

--- a/src/scanner/hermes.rs
+++ b/src/scanner/hermes.rs
@@ -3,6 +3,49 @@ use rusqlite::Connection;
 use crate::error::AgfError;
 use crate::model::{Agent, Session};
 
+/// Trim a chunk of message text down to a single-line preview that fits in
+/// a TUI summary row. Collapses whitespace, drops common wrapper tags, and
+/// caps to ~160 chars.
+fn message_preview(raw: &str) -> Option<String> {
+    let stripped = raw
+        .replace("<user_query>", " ")
+        .replace("</user_query>", " ");
+    let collapsed: String = stripped.split_whitespace().collect::<Vec<_>>().join(" ");
+    if collapsed.is_empty() {
+        return None;
+    }
+    let max_chars = 160;
+    let truncated: String = if collapsed.chars().count() > max_chars {
+        let head: String = collapsed.chars().take(max_chars).collect();
+        format!("{head}…")
+    } else {
+        collapsed
+    };
+    Some(truncated)
+}
+
+/// True iff the id looks like a session a user actually started from the
+/// Hermes CLI/TUI (id format `YYYYMMDD_HHMMSS_<6hex>`). Hermes also stores
+/// long-lived API integration sessions under ids like `dashboard:admin:...`
+/// or `api-<16hex>` — those receive messages from external callers (Notion
+/// integrations, scheduled cron jobs, dashboard webhooks), so their first
+/// `messages.role='user'` row is not the user's own first prompt and would
+/// be misleading as a TUI summary preview.
+fn is_user_cli_session(id: &str) -> bool {
+    // YYYYMMDD = 8 ASCII digits, then `_`, then HHMMSS = 6 ASCII digits,
+    // then `_`, then 6 hex chars. The exact suffix length isn't load-bearing
+    // here — we just need to distinguish CLI ids from `dashboard:*`,
+    // `api-*`, UUID, and named (`research`, `test`) ids.
+    let bytes = id.as_bytes();
+    if bytes.len() < 16 {
+        return false;
+    }
+    bytes[..8].iter().all(|b| b.is_ascii_digit())
+        && bytes[8] == b'_'
+        && bytes[9..15].iter().all(|b| b.is_ascii_digit())
+        && bytes[15] == b'_'
+}
+
 /// Scan Hermes Agent sessions from `~/.hermes/state.db`.
 ///
 /// Hermes stores sessions in a SQLite database with a `sessions` table
@@ -13,6 +56,12 @@ use crate::model::{Agent, Session};
 /// Sessions with a `parent_session_id` are delegation/compression children
 /// and are excluded from the top-level listing (their titles are aggregated
 /// as additional summaries on the parent, matching the OpenCode pattern).
+///
+/// Project path is intentionally empty: Hermes is cwd-independent (the
+/// agent runs from `~/.hermes` regardless of where the user invoked it),
+/// so resume should not drag the user's shell into `~/.hermes`. The empty
+/// project_path is honored by `shell::cd_and`, which skips the `cd` step
+/// when the path is empty.
 pub fn scan() -> Result<Vec<Session>, AgfError> {
     let db_path = crate::config::hermes_dir()?.join("state.db");
 
@@ -27,7 +76,12 @@ pub fn scan() -> Result<Vec<Session>, AgfError> {
 
     // Fetch top-level sessions (no parent), ordered by most recent activity.
     // Use MAX(messages.timestamp) as last_active, falling back to started_at.
-    // Aggregate child session titles as extra summaries.
+    // Aggregate child session titles as extra summaries; pull the first few
+    // user messages as a conversation preview so sessions with NULL title
+    // (short / un-titled sessions) still surface readable history in the
+    // TUI detail pane. We `||| `-join up to 4 user messages chronologically
+    // and split them back out in Rust — that's enough to show how the
+    // conversation started without flooding the row.
     let mut stmt = conn.prepare(
         "SELECT s.id, \
                 s.title, \
@@ -35,7 +89,14 @@ pub fn scan() -> Result<Vec<Session>, AgfError> {
                 s.model, \
                 s.message_count, \
                 CAST(COALESCE(m.last_active, s.started_at) * 1000 AS INTEGER) AS ts_ms, \
-                GROUP_CONCAT(child.title, '|||') \
+                GROUP_CONCAT(child.title, '|||'), \
+                ( \
+                    SELECT GROUP_CONCAT(content, '|||') FROM ( \
+                        SELECT content FROM messages \
+                        WHERE session_id = s.id AND role = 'user' AND content IS NOT NULL \
+                        ORDER BY timestamp ASC LIMIT 4 \
+                    ) \
+                ) AS user_msgs \
          FROM sessions s \
          LEFT JOIN ( \
              SELECT session_id, MAX(timestamp) AS last_active \
@@ -56,62 +117,132 @@ pub fn scan() -> Result<Vec<Session>, AgfError> {
             let message_count: i64 = row.get(4)?;
             let timestamp: i64 = row.get(5)?;
             let child_titles: Option<String> = row.get(6)?;
-            Ok((id, title, source, model, message_count, timestamp, child_titles))
+            let user_msgs: Option<String> = row.get(7)?;
+            Ok((
+                id,
+                title,
+                source,
+                model,
+                message_count,
+                timestamp,
+                child_titles,
+                user_msgs,
+            ))
         })?
         .filter_map(|r| r.ok())
-        .map(|(id, title, source, model, message_count, timestamp, child_titles)| {
-            // Build summaries: title first, then child session titles.
-            let mut summaries: Vec<String> = Vec::new();
-            if let Some(ref t) = title {
-                if !t.is_empty() {
-                    summaries.push(t.clone());
-                }
-            }
-            if let Some(ref children) = child_titles {
-                let mut seen = std::collections::HashSet::new();
-                for t in children.split("|||") {
-                    let t = t.trim();
-                    if !t.is_empty() && seen.insert(t.to_string()) {
-                        summaries.push(t.to_string());
+        .map(
+            |(id, title, source, model, message_count, timestamp, child_titles, user_msgs)| {
+                // Build summaries: title first, then child session titles,
+                // then up to 4 user-message previews so the TUI detail pane
+                // shows how the conversation actually went, not just one
+                // line.
+                let mut summaries: Vec<String> = Vec::new();
+                if let Some(ref t) = title {
+                    if !t.is_empty() {
+                        summaries.push(t.clone());
                     }
                 }
-            }
-
-            // If no title, build a fallback from source + model info.
-            if summaries.is_empty() {
-                let mut fallback = format!("{source} session");
-                if let Some(ref m) = model {
-                    if !m.is_empty() {
-                        // Extract short model name (e.g. "claude-opus-4-6" from "anthropic/claude-opus-4-6")
-                        let short = m.rsplit('/').next().unwrap_or(m);
-                        fallback = format!("{fallback} ({short})");
+                if let Some(ref children) = child_titles {
+                    let mut seen = std::collections::HashSet::new();
+                    for t in children.split("|||") {
+                        let t = t.trim();
+                        if !t.is_empty() && seen.insert(t.to_string()) {
+                            summaries.push(t.to_string());
+                        }
                     }
                 }
-                if message_count > 0 {
-                    fallback = format!("{fallback} — {message_count} msgs");
+                // Only surface user-message previews for ids that look like
+                // CLI/TUI sessions. dashboard:*/api-*/named ids get messages
+                // from external integrations (Notion webhooks, scheduled
+                // crons, dashboard callers), so their `role='user'` rows
+                // are not the user's own prompts and would mislead the
+                // TUI summary.
+                if is_user_cli_session(&id) {
+                    if let Some(ref blob) = user_msgs {
+                        let mut seen: std::collections::HashSet<String> =
+                            summaries.iter().cloned().collect();
+                        for raw in blob.split("|||") {
+                            if let Some(preview) = message_preview(raw) {
+                                if seen.insert(preview.clone()) {
+                                    summaries.push(preview);
+                                }
+                            }
+                        }
+                    }
                 }
-                summaries.push(fallback);
-            }
 
-            // Hermes doesn't store working directory per session.
-            // Default to the hermes home directory.
-            let hermes_home = crate::config::hermes_dir()
-                .map(|d| d.to_string_lossy().into_owned())
-                .unwrap_or_else(|_| "~/.hermes".to_string());
+                // If we still have nothing, fall back to source + model info
+                // so the row is never blank.
+                if summaries.is_empty() {
+                    let mut fallback = format!("{source} session");
+                    if let Some(ref m) = model {
+                        if !m.is_empty() {
+                            // Extract short model name (e.g. "claude-opus-4-6" from "anthropic/claude-opus-4-6")
+                            let short = m.rsplit('/').next().unwrap_or(m);
+                            fallback = format!("{fallback} ({short})");
+                        }
+                    }
+                    if message_count > 0 {
+                        fallback = format!("{fallback} — {message_count} msgs");
+                    }
+                    summaries.push(fallback);
+                }
 
-            Session {
-                agent: Agent::Hermes,
-                session_id: id,
-                project_name: "hermes".to_string(),
-                project_path: hermes_home,
-                summaries,
-                timestamp,
-                git_branch: None,
-                worktree: None,
-                recap: None,
-            }
-        })
+                Session {
+                    agent: Agent::Hermes,
+                    session_id: id,
+                    project_name: "hermes".to_string(),
+                    // Empty path → resume runs in the user's current cwd
+                    // (Hermes is cwd-independent). See shell::cd_and.
+                    project_path: String::new(),
+                    summaries,
+                    timestamp,
+                    git_branch: None,
+                    worktree: None,
+                    recap: None,
+                }
+            },
+        )
         .collect();
 
     Ok(sessions)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn message_preview_collapses_whitespace_and_strips_user_query_tags() {
+        let raw = "<user_query>\n  hello\n  there  \n</user_query>";
+        assert_eq!(message_preview(raw).as_deref(), Some("hello there"));
+    }
+
+    #[test]
+    fn message_preview_truncates_with_ellipsis() {
+        let raw = "a ".repeat(200);
+        let preview = message_preview(&raw).unwrap();
+        assert!(preview.chars().count() <= 161);
+        assert!(preview.ends_with('…'));
+    }
+
+    #[test]
+    fn message_preview_returns_none_for_blank_input() {
+        assert_eq!(message_preview("   \n\t  "), None);
+    }
+
+    #[test]
+    fn is_user_cli_session_recognizes_cli_id_format() {
+        assert!(is_user_cli_session("20260504_093414_1e69e0"));
+        assert!(is_user_cli_session("20260411_001454_e77613"));
+    }
+
+    #[test]
+    fn is_user_cli_session_rejects_api_and_named_ids() {
+        assert!(!is_user_cli_session("dashboard:admin:notion-checker"));
+        assert!(!is_user_cli_session("api-1234567890abcdef"));
+        assert!(!is_user_cli_session("research"));
+        assert!(!is_user_cli_session("test"));
+        assert!(!is_user_cli_session("4619234e-10b6-4db2-8745-cc56a2682503"));
+    }
 }

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -50,7 +50,15 @@ impl CommandShell {
     ///
     /// POSIX uses `&&`. PowerShell 5.1 has no `&&` (that lands in 7+), so
     /// we use `; if ($?) { ... }` which works in both 5.1 and 7+.
+    ///
+    /// When `quoted_path` is empty (or the empty quoted form `''` / `""`)
+    /// the cd is skipped entirely — used by cwd-independent agents like
+    /// Hermes that don't have a project root and shouldn't drag the user
+    /// out of their current working directory on resume.
     pub fn cd_and(&self, quoted_path: &str, cmd: &str) -> String {
+        if quoted_path.is_empty() || quoted_path == "''" || quoted_path == "\"\"" {
+            return cmd.to_string();
+        }
         match self {
             Self::Posix => format!("cd {quoted_path} && {cmd}"),
             Self::PowerShell => format!("Set-Location {quoted_path}; if ($?) {{ {cmd} }}"),

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -75,6 +75,11 @@ pub struct App {
     pub show_recap: bool,
     pub help_selected: usize,
     pub search_textarea: slt::TextareaState,
+    /// Current working directory at TUI launch. Previously drove a cwd-match
+    /// boost in `apply_sort` (removed in v0.11.0); kept on the struct so the
+    /// surrounding wiring (CLI plumbing in `main.rs`, `App::new` signature)
+    /// stays stable for a future settings-gated reintroduction.
+    #[allow(dead_code)]
     pub cwd: Option<String>,
     pub agent_counts: HashMap<Agent, usize>,
     pub pinned_sessions: Vec<String>,
@@ -210,17 +215,20 @@ impl App {
             }),
         }
 
-        // Boost: pinned first, then $PWD matches (stable sort preserves primary order within groups)
+        // Boost: pinned first; everything else keeps the primary sort order
+        // (stable sort preserves it within rank). The previous cwd-match
+        // boost was removed in v0.11.0 because it implicitly grouped the
+        // current project's sessions above older sessions from elsewhere,
+        // which made the listing look "out of time order" without any
+        // visible cause — `agf` has no UI hint that cwd boost is active.
+        // Pinning is still honored because it's an explicit user action.
         let pinned = self.pinned_sessions.clone();
-        let cwd = self.cwd.clone();
         self.sessions.sort_by(|a, b| {
             let rank = |s: &Session| -> u8 {
                 if pinned.contains(&s.session_id) {
                     0
-                } else if cwd.as_ref().is_some_and(|c| s.project_path == *c) {
-                    1
                 } else {
-                    2
+                    1
                 }
             };
             rank(a).cmp(&rank(b))


### PR DESCRIPTION
Follows up [#34](https://github.com/subinium/agf/pull/34) by @SHL0MS — really clean Hermes integration, shipping it as v0.11.0 with a small batch of usability fixes that surfaced during dogfooding on the same day.

## Includes

- **scanner/hermes**: surface up to 4 user-message previews on CLI/TUI sessions only (`YYYYMMDD_HHMMSS_*` ids); `dashboard:*` / `api-*` / named ids keep the source/model fallback because their `role='user'` rows come from external integrations.
- **scanner/hermes**: empty `project_path` so resume stays in the user's cwd. `shell::cd_and` now skips the `cd` when path is empty (Hermes is cwd-independent — original PR set it to `~/.hermes`, which yanked the shell out of whatever project the user was in).
- **delete/hermes**: cascade in a single SQLite transaction.
- **TUI**: `apply_sort()` always called on first frame (was gated behind `Some(config.sort_by)`, default-sort path silently rendered cache's per-agent grouping).
- **TUI**: cwd-match boost removed from secondary sort (made time-sorted listing look broken when launched from inside a project — pinning still honored).
- **cache**: `CACHE_VERSION` 2 → 3 to invalidate stale "cli session..." summaries from 0.10.x cache files on first 0.11.0 launch.
- **README** / **CHANGELOG** / **Cargo.toml** updated with Hermes; version 0.11.0.
- New unit tests (`message_preview`, `is_user_cli_session`).

## Verification

- `cargo fmt --all -- --check` — pass
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test --all` — 27 passed (5 new)
- Manual: \`./target/release/agf list --agent hermes\` shows 12 sessions with multi-line conversation history; resume command no longer cd's into ~/.hermes; main TUI sort is purely time-ordered regardless of cwd.

Cursor scanner regression on the new \`agent-transcripts/<id>/<id>.jsonl\` layout is tracked separately in [#35](https://github.com/subinium/agf/issues/35) — out of scope for this release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)