### PR TITLE
release: v0.11.1 — SLT 0.20 bump + UX polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [0.11.1] - 2026-05-04
+
+### Changed
+
+- **`superlighttui` bumped 0.17 → 0.20.1** — picks up 8 patch/minor releases of the underlying TUI library since v0.10.0 was tagged. Drop-in: every public API agf uses (`Context`, `Color::Rgb`, `KeyCode`, `KeyModifiers`, `RunConfig`, `TextareaState`, container/col/row builders, `help_colored`, `separator_colored`, `consume_key`, `mouse_down`, `quit`) is unchanged; agf does not touch any of the v0.20 breaking APIs (`gauge`/`line_gauge`/`breadcrumb` chainable builders, `scrollable_with_gutter` `GutterOpts`, `Constraints` `WidthSpec`/`HeightSpec` redesign, `f32 → f64` ratio unification on `SplitPane`). Notable improvements inherited for free:
+  - **3–5× flush-path speedup on redraw-heavy frames** (SLT 0.18.2 #62) — `flush_buffer_diff` now coalesces consecutive same-style cells in a row into a single `Print(run)` instead of per-cell, dropping `queue!` calls roughly 12000 → 2000 on a 200×60 redraw.
+  - **~1000× speedup on static frames** (SLT 0.20.0 #171) — per-row hash skip in `flush_buffer_diff` short-circuits cell iteration on rows whose contents and style didn't change. The agf list view, which is mostly static while the user reads it, gets the full benefit.
+  - **`rgb_to_ansi256` u8 overflow fix at `r=g=b=248`** (SLT 0.19.1 #104) — agf's color palette (`Rgb(229, 229, 229)`, `Rgb(245, 158, 11)`, etc.) sits below the threshold so the user-visible bug never fired in agf, but downstream installs on color-limited terminals now route grayscale tones to the correct ANSI 256 cell instead of silently mapping to `Indexed(0)` (Black).
+  - **`stdout` BufWriter** (SLT 0.19.1 #172) — every frame now batches dozens of `write_all` ANSI commands behind a 64 KiB `BufWriter`, ending with a single `flush()`. Reduces syscalls per frame on every TUI mode without any agf-side change.
+  - **Bordered title CJK truncation + overdraw fixes, image command count drop, treemap/textarea panic fixes** (SLT 0.19.x), **textarea undo/redo, modal `tab_trap` opt-in, `Anchor` enum + `modal_at`** (SLT 0.20.0) — not used by agf today; available for future TUI work.
+
+### Fixed
+
+- **DeleteConfirm: arrow Up/Down (and `j`/`k`, `Ctrl-j`/`Ctrl-k`) now toggle Yes/No** ([#38](https://github.com/subinium/agf/issues/38)) — previously only Left/Right worked, which was surprising on the v0.11.0 release because every other modal-style picker in agf accepts both axes. The toggle is the same direction-agnostic flip (`Yes ↔ No`) regardless of which arrow key fires.
+- **ActionSelect / AgentSelect / PermissionSelect / ResumeSelect: arrow keys cycle through the menu instead of stopping at edges** ([#39](https://github.com/subinium/agf/issues/39)) — `Up` on the first item now jumps to the last; `Down` on the last wraps to the first. Tab/BackTab already wrapped — Up/Down/`Ctrl-p`/`Ctrl-n`/`Ctrl-j`/`Ctrl-k` now match.
+- **Footer shows `agf v<version>` on the leftmost cell of every mode's status bar** ([#40](https://github.com/subinium/agf/issues/40)) — version is read from `CARGO_PKG_VERSION` at compile time so it stays in sync with the published crate. The 10 per-mode status bars are now routed through a single `render_footer` helper to keep layout uniform.
+
 ## [0.11.0] - 2026-05-04
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agf"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -854,12 +854,13 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "superlighttui"
-version = "0.17.1"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e214c6ff0939b6e0b161d072c8f27883ce3afd953d4b7e72c01628e86e08da69"
+checksum = "1663c34928b1f1e320e42d8cca6b8c32a62510cc42c1940b5c7594d8c31738c0"
 dependencies = [
  "compact_str",
  "crossterm",
+ "smallvec",
  "unicode-width",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agf"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 description = "Find and resume local AI coding-agent sessions across Claude Code, Codex, Gemini, Cursor CLI, OpenCode, Kiro, pi, and Hermes"
 license = "MIT"
@@ -10,7 +10,7 @@ categories = ["command-line-utilities"]
 readme = "README.md"
 
 [dependencies]
-superlighttui = "0.17"
+superlighttui = "0.20"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 rusqlite = { version = "0.32", features = ["bundled"] }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -772,26 +772,21 @@ fn ui_browse(ui: &mut slt::Context, app: &mut App) {
         // Separator between content and statusbar
         ui.separator_colored(SEPARATOR);
 
-        // Help bar (dim, right-aligned)
-        let _ = ui.container().pr(1).row(|ui| {
-            ui.spacer();
-            let _ = ui.help_colored(
-                &[
-                    ("↑↓", "nav"),
-                    ("Tab", "agent"),
-                    ("[/]", "summary"),
-                    ("→", "detail"),
-                    ("Enter", "select"),
-                    ("^S", "sort"),
-                    ("^G", "group"),
-                    ("^D", "delete"),
-                    ("?", "help"),
-                    ("Esc", "quit"),
-                ],
-                GRAY_500,
-                SEPARATOR,
-            );
-        });
+        render_footer(
+            ui,
+            &[
+                ("↑↓", "nav"),
+                ("Tab", "agent"),
+                ("[/]", "summary"),
+                ("→", "detail"),
+                ("Enter", "select"),
+                ("^S", "sort"),
+                ("^G", "group"),
+                ("^D", "delete"),
+                ("?", "help"),
+                ("Esc", "quit"),
+            ],
+        );
     });
 
     // Sync textarea → query (textarea stores lines, we use first line only)
@@ -1066,19 +1061,15 @@ fn ui_grouped_browse(ui: &mut slt::Context, app: &mut App) {
         });
 
         ui.separator_colored(SEPARATOR);
-        let _ = ui.container().pr(1).row(|ui| {
-            ui.spacer();
-            let _ = ui.help_colored(
-                &[
-                    ("↑↓", "nav"),
-                    ("Enter/Space", "expand"),
-                    ("^G", "flat view"),
-                    ("Esc", "back"),
-                ],
-                GRAY_500,
-                SEPARATOR,
-            );
-        });
+        render_footer(
+            ui,
+            &[
+                ("↑↓", "nav"),
+                ("Enter/Space", "expand"),
+                ("^G", "flat view"),
+                ("Esc", "back"),
+            ],
+        );
     });
 }
 
@@ -1090,25 +1081,18 @@ fn ui_action_select(ui: &mut slt::Context, app: &mut App, result: &mut Option<St
         app.mode = Mode::Browse;
     }
 
-    // Tab/BackTab: wrap-around navigation
-    if ui.consume_key_code(slt::KeyCode::BackTab) {
-        app.action_index = (app.action_index + action_count - 1) % action_count;
-    } else if (ui.key_code(slt::KeyCode::Up)
+    if ui.consume_key_code(slt::KeyCode::BackTab)
+        || ui.key_code(slt::KeyCode::Up)
         || ui.key_mod('p', slt::KeyModifiers::CONTROL)
-        || ui.key_mod('k', slt::KeyModifiers::CONTROL))
-        && app.action_index > 0
+        || ui.key_mod('k', slt::KeyModifiers::CONTROL)
     {
-        app.action_index -= 1;
-    }
-
-    if ui.consume_key_code(slt::KeyCode::Tab) {
-        app.action_index = (app.action_index + 1) % action_count;
-    } else if (ui.key_code(slt::KeyCode::Down)
+        app.action_index = (app.action_index + action_count - 1) % action_count;
+    } else if ui.consume_key_code(slt::KeyCode::Tab)
+        || ui.key_code(slt::KeyCode::Down)
         || ui.key_mod('n', slt::KeyModifiers::CONTROL)
-        || ui.key_mod('j', slt::KeyModifiers::CONTROL))
-        && app.action_index < action_count - 1
+        || ui.key_mod('j', slt::KeyModifiers::CONTROL)
     {
-        app.action_index += 1;
+        app.action_index = (app.action_index + 1) % action_count;
     }
 
     for i in 0..action_count.min(9) {
@@ -1260,13 +1244,7 @@ fn ui_action_select(ui: &mut slt::Context, app: &mut App, result: &mut Option<St
 
         ui.text("");
         ui.separator_colored(SEPARATOR);
-        let _ = ui.container().pl(1).row(|ui| {
-            let _ = ui.help_colored(
-                &[("Tab", "nav"), ("Enter", "select"), ("Esc", "back")],
-                GRAY_500,
-                SEPARATOR,
-            );
-        });
+        render_footer(ui, &[("Tab", "nav"), ("Enter", "select"), ("Esc", "back")]);
     });
 }
 
@@ -1319,26 +1297,20 @@ fn ui_agent_select(ui: &mut slt::Context, app: &mut App, result: &mut Option<Str
         app.mode = Mode::ActionSelect;
     }
 
-    // Tab/BackTab: wrap-around navigation
-    if ui.consume_key_code(slt::KeyCode::BackTab) && option_count > 0 {
+    if option_count > 0
+        && (ui.consume_key_code(slt::KeyCode::BackTab)
+            || ui.key_code(slt::KeyCode::Up)
+            || ui.key_mod('p', slt::KeyModifiers::CONTROL)
+            || ui.key_mod('k', slt::KeyModifiers::CONTROL))
+    {
         app.agent_index = (app.agent_index + option_count - 1) % option_count;
-    } else if (ui.key_code(slt::KeyCode::Up)
-        || ui.key_mod('p', slt::KeyModifiers::CONTROL)
-        || ui.key_mod('k', slt::KeyModifiers::CONTROL))
-        && app.agent_index > 0
+    } else if option_count > 0
+        && (ui.consume_key_code(slt::KeyCode::Tab)
+            || ui.key_code(slt::KeyCode::Down)
+            || ui.key_mod('n', slt::KeyModifiers::CONTROL)
+            || ui.key_mod('j', slt::KeyModifiers::CONTROL))
     {
-        app.agent_index -= 1;
-    }
-
-    if ui.consume_key_code(slt::KeyCode::Tab) && option_count > 0 {
         app.agent_index = (app.agent_index + 1) % option_count;
-    } else if (ui.key_code(slt::KeyCode::Down)
-        || ui.key_mod('n', slt::KeyModifiers::CONTROL)
-        || ui.key_mod('j', slt::KeyModifiers::CONTROL))
-        && option_count > 0
-        && app.agent_index < option_count - 1
-    {
-        app.agent_index += 1;
     }
 
     for i in 0..option_count.min(9) {
@@ -1412,18 +1384,15 @@ fn ui_agent_select(ui: &mut slt::Context, app: &mut App, result: &mut Option<Str
 
         ui.text("");
         ui.separator_colored(SEPARATOR);
-        let _ = ui.container().pl(1).row(|ui| {
-            let _ = ui.help_colored(
-                &[
-                    ("1-9", "select"),
-                    ("Tab", "nav"),
-                    ("Enter", "mode"),
-                    ("Esc", "back"),
-                ],
-                GRAY_500,
-                SEPARATOR,
-            );
-        });
+        render_footer(
+            ui,
+            &[
+                ("1-9", "select"),
+                ("Tab", "nav"),
+                ("Enter", "mode"),
+                ("Esc", "back"),
+            ],
+        );
     });
 }
 
@@ -1475,26 +1444,20 @@ fn ui_permission_select(ui: &mut slt::Context, app: &mut App, result: &mut Optio
         app.mode = Mode::AgentSelect;
     }
 
-    // Tab/BackTab: wrap-around navigation
-    if ui.key_code(slt::KeyCode::BackTab) && option_count > 0 {
+    if option_count > 0
+        && (ui.key_code(slt::KeyCode::BackTab)
+            || ui.key_code(slt::KeyCode::Up)
+            || ui.key_mod('p', slt::KeyModifiers::CONTROL)
+            || ui.key_mod('k', slt::KeyModifiers::CONTROL))
+    {
         app.mode_index = (app.mode_index + option_count - 1) % option_count;
-    } else if (ui.key_code(slt::KeyCode::Up)
-        || ui.key_mod('p', slt::KeyModifiers::CONTROL)
-        || ui.key_mod('k', slt::KeyModifiers::CONTROL))
-        && app.mode_index > 0
+    } else if option_count > 0
+        && (ui.key_code(slt::KeyCode::Tab)
+            || ui.key_code(slt::KeyCode::Down)
+            || ui.key_mod('n', slt::KeyModifiers::CONTROL)
+            || ui.key_mod('j', slt::KeyModifiers::CONTROL))
     {
-        app.mode_index -= 1;
-    }
-
-    if ui.key_code(slt::KeyCode::Tab) && option_count > 0 {
         app.mode_index = (app.mode_index + 1) % option_count;
-    } else if (ui.key_code(slt::KeyCode::Down)
-        || ui.key_mod('n', slt::KeyModifiers::CONTROL)
-        || ui.key_mod('j', slt::KeyModifiers::CONTROL))
-        && option_count > 0
-        && app.mode_index < option_count - 1
-    {
-        app.mode_index += 1;
     }
 
     for i in 0..option_count.min(9) {
@@ -1567,13 +1530,10 @@ fn ui_permission_select(ui: &mut slt::Context, app: &mut App, result: &mut Optio
 
         ui.text("");
         ui.separator_colored(SEPARATOR);
-        let _ = ui.container().pl(1).row(|ui| {
-            let _ = ui.help_colored(
-                &[("1-9", "select"), ("Enter", "confirm"), ("Esc", "back")],
-                GRAY_500,
-                SEPARATOR,
-            );
-        });
+        render_footer(
+            ui,
+            &[("1-9", "select"), ("Enter", "confirm"), ("Esc", "back")],
+        );
     });
 }
 
@@ -1598,26 +1558,20 @@ fn ui_resume_select(ui: &mut slt::Context, app: &mut App, result: &mut Option<St
         app.mode = Mode::ActionSelect;
     }
 
-    // Tab/BackTab: wrap-around navigation
-    if ui.key_code(slt::KeyCode::BackTab) && option_count > 0 {
+    if option_count > 0
+        && (ui.key_code(slt::KeyCode::BackTab)
+            || ui.key_code(slt::KeyCode::Up)
+            || ui.key_mod('p', slt::KeyModifiers::CONTROL)
+            || ui.key_mod('k', slt::KeyModifiers::CONTROL))
+    {
         app.resume_mode_index = (app.resume_mode_index + option_count - 1) % option_count;
-    } else if (ui.key_code(slt::KeyCode::Up)
-        || ui.key_mod('p', slt::KeyModifiers::CONTROL)
-        || ui.key_mod('k', slt::KeyModifiers::CONTROL))
-        && app.resume_mode_index > 0
+    } else if option_count > 0
+        && (ui.key_code(slt::KeyCode::Tab)
+            || ui.key_code(slt::KeyCode::Down)
+            || ui.key_mod('n', slt::KeyModifiers::CONTROL)
+            || ui.key_mod('j', slt::KeyModifiers::CONTROL))
     {
-        app.resume_mode_index -= 1;
-    }
-
-    if ui.key_code(slt::KeyCode::Tab) && option_count > 0 {
         app.resume_mode_index = (app.resume_mode_index + 1) % option_count;
-    } else if (ui.key_code(slt::KeyCode::Down)
-        || ui.key_mod('n', slt::KeyModifiers::CONTROL)
-        || ui.key_mod('j', slt::KeyModifiers::CONTROL))
-        && option_count > 0
-        && app.resume_mode_index < option_count - 1
-    {
-        app.resume_mode_index += 1;
     }
 
     for i in 0..option_count.min(9) {
@@ -1686,13 +1640,10 @@ fn ui_resume_select(ui: &mut slt::Context, app: &mut App, result: &mut Option<St
 
         ui.text("");
         ui.separator_colored(SEPARATOR);
-        let _ = ui.container().pl(1).row(|ui| {
-            let _ = ui.help_colored(
-                &[("1-9", "select"), ("Enter", "confirm"), ("Esc", "back")],
-                GRAY_500,
-                SEPARATOR,
-            );
-        });
+        render_footer(
+            ui,
+            &[("1-9", "select"), ("Enter", "confirm"), ("Esc", "back")],
+        );
     });
 }
 
@@ -1773,13 +1724,10 @@ fn ui_bulk_delete(ui: &mut slt::Context, app: &mut App) {
                 .fg(RED)
                 .bold();
         });
-        let _ = ui.container().pl(1).row(|ui| {
-            let _ = ui.help_colored(
-                &[("Space", "toggle"), ("Enter", "delete"), ("Esc", "cancel")],
-                GRAY_500,
-                SEPARATOR,
-            );
-        });
+        render_footer(
+            ui,
+            &[("Space", "toggle"), ("Enter", "delete"), ("Esc", "cancel")],
+        );
     });
 }
 
@@ -1794,15 +1742,18 @@ fn ui_delete_confirm(ui: &mut slt::Context, app: &mut App) {
         }
     }
 
-    // Horizontal toggle only: Yes/No is a horizontal choice. Up/Down would
-    // be confusing (and easy to hit accidentally), so only Left/Right and
-    // Ctrl-h/l toggle.
     if ui.key_code(slt::KeyCode::Left)
         || ui.key_code(slt::KeyCode::Right)
+        || ui.key_code(slt::KeyCode::Up)
+        || ui.key_code(slt::KeyCode::Down)
         || ui.key('h')
         || ui.key('l')
+        || ui.key('j')
+        || ui.key('k')
         || ui.key_mod('h', slt::KeyModifiers::CONTROL)
         || ui.key_mod('l', slt::KeyModifiers::CONTROL)
+        || ui.key_mod('j', slt::KeyModifiers::CONTROL)
+        || ui.key_mod('k', slt::KeyModifiers::CONTROL)
     {
         app.delete_index = if app.delete_index == 0 { 1 } else { 0 };
     }
@@ -2076,13 +2027,10 @@ fn ui_preview(ui: &mut slt::Context, app: &mut App) {
 
         ui.text("");
         ui.separator_colored(SEPARATOR);
-        let _ = ui.container().pl(1).row(|ui| {
-            let _ = ui.help_colored(
-                &[("↑↓", "cycle"), ("Enter", "actions"), ("Esc/←", "back")],
-                GRAY_500,
-                SEPARATOR,
-            );
-        });
+        render_footer(
+            ui,
+            &[("↑↓", "cycle"), ("Enter", "actions"), ("Esc/←", "back")],
+        );
     });
 }
 
@@ -2263,19 +2211,15 @@ fn ui_help(ui: &mut slt::Context, app: &mut App) {
         });
 
         ui.separator_colored(SEPARATOR);
-        let _ = ui.container().pr(1).row(|ui| {
-            ui.spacer();
-            let _ = ui.help_colored(
-                &[
-                    ("↑↓", "navigate"),
-                    ("Enter", "toggle"),
-                    ("+/-", "adjust"),
-                    ("Esc", "close"),
-                ],
-                GRAY_500,
-                SEPARATOR,
-            );
-        });
+        render_footer(
+            ui,
+            &[
+                ("↑↓", "navigate"),
+                ("Enter", "toggle"),
+                ("+/-", "adjust"),
+                ("Esc", "close"),
+            ],
+        );
     });
 }
 
@@ -2283,6 +2227,15 @@ fn help_line(ui: &mut slt::Context, key: &str, desc: &str) {
     let _ = ui.row(|ui| {
         ui.styled(format!("  {:<16}", key), slt::Style::new().fg(GRAY_500));
         ui.text(desc).fg(GRAY_400);
+    });
+}
+
+fn render_footer(ui: &mut slt::Context, hints: &[(&str, &str)]) {
+    let _ = ui.container().px(1).row(|ui| {
+        ui.text(concat!("agf v", env!("CARGO_PKG_VERSION")))
+            .fg(GRAY_500);
+        ui.spacer();
+        let _ = ui.help_colored(hints, GRAY_500, SEPARATOR);
     });
 }
 


### PR DESCRIPTION
## Summary

- **`superlighttui` 0.17 → 0.20.1** — drop-in. agf does not touch any of the v0.20 breaking surface (`gauge`/`line_gauge`/`breadcrumb` chainable builders, `GutterOpts`, `Constraints` `WidthSpec`/`HeightSpec`, `f32→f64` ratio unification on `SplitPane`). Free gains:
  - **3–5× flush-path speedup** on redraw-heavy frames (SLT 0.18.2 #62 run-length coalescing)
  - **~1000× speedup on static frames** via per-row hash skip in `flush_buffer_diff` (SLT 0.20.0 #171) — directly relevant since agf list view is static while the user reads it
  - `rgb_to_ansi256` u8 overflow fix at `r=g=b=248` (SLT 0.19.1 #104)
  - `stdout` `BufWriter::with_capacity(65536)` so every frame batches dozens of `write_all` ANSI commands behind a single `flush()` (SLT 0.19.1 #172)
- **`#38`** — DeleteConfirm: Up/Down (and `j`/`k`, `Ctrl-j`/`Ctrl-k`) now toggle Yes/No (was Left/Right only)
- **`#39`** — ActionSelect / AgentSelect / PermissionSelect / ResumeSelect arrow keys cycle-wrap instead of stopping at edges; matches the existing Tab/BackTab wrap behavior
- **`#40`** — Footer shows `agf v<version>` on the leftmost cell of every mode's status bar via a single `render_footer` helper that replaces 9 ad-hoc layouts

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — 27 passed
- [x] Manual: SLT bump no rendering regressions across Browse / Grouped / ActionSelect / AgentSelect / PermissionSelect / ResumeSelect / DeleteConfirm / BulkDelete / Preview / Help
- [x] Manual: #38 Up/Down toggles Yes/No in DeleteConfirm
- [x] Manual: #39 cycle wrap on all four selectors (first → last on Up, last → first on Down)
- [x] Manual: #40 `agf v0.11.1` shown on the leftmost cell of every mode's footer

Closes #38, #39, #40.