### PR TITLE
Fix pi session resume, history, and cwd default

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Then you either dig through history files or start over.
 | [Cursor CLI](https://docs.cursor.com/agent) | `cursor-agent --resume <id>` | `~/.cursor/projects/*/agent-transcripts/*.txt` |
 | [OpenCode](https://github.com/opencode-ai/opencode) | `opencode -s <id>` | `~/.local/share/opencode/opencode.db` |
 | [Kiro](https://kiro.dev) | `kiro-cli chat --resume` | `~/Library/Application Support/kiro-cli/data.sqlite3` |
-| [pi](https://github.com/badlogic/pi-mono) | `pi --resume` | `~/.pi/agent/sessions/<cwd>/*.jsonl` |
+| [pi](https://github.com/badlogic/pi-mono) | `pi --session <id>` | `~/.pi/agent/sessions/<cwd>/*.jsonl` |
 | [Hermes](https://github.com/NousResearch/hermes-agent) | `hermes --resume <id>` | `~/.hermes/state.db` |
 
 <details>

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Then you either dig through history files or start over.
 - **Fuzzy search** — find sessions by project name, path, branch, or summary
 - **One-key resume** — resume the selected session with the right agent command
 - **Quick resume** — `agf resume <query>` skips the TUI entirely
+- **Current directory default** — launching `agf` without a query pre-filters by the current working directory
 - **Bulk delete** — `Ctrl+D` to multi-select and clean up stale sessions
 - **Project awareness** — git branches and Claude Code `--worktree` sessions surface in the UI
 

--- a/src/action.rs
+++ b/src/action.rs
@@ -11,7 +11,6 @@ pub fn generate_command(
 
     match action {
         Action::Resume => {
-            // NOTE: Pi/Kiro CLI only resume latest; session_id ignored.
             let cmd = session.agent.resume_cmd(&session.session_id);
             Some(shell.cd_and(&quoted_path, &cmd))
         }
@@ -65,7 +64,6 @@ pub fn detect_editor() -> String {
 pub fn resume_with_flags(session: &Session, flags: &str) -> String {
     let shell = CommandShell::from_env();
     let quoted_path = shell.quote(&session.project_path);
-    // NOTE: Pi/Kiro CLI only resume latest; session_id ignored.
     let base_cmd = session.agent.resume_cmd(&session.session_id);
     shell.cd_and(&quoted_path, &format!("{base_cmd}{flags}"))
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -7,6 +7,10 @@ use serde::{Deserialize, Serialize};
 use crate::model::{Agent, Session};
 use crate::plugin;
 
+// Bumped to 5 after v0.11.1:
+// - Pi scanner now keeps all user-message summaries instead of only the first
+//   one, matching the History preview behavior of other agents.
+//
 // Bumped to 4 after v0.11.1:
 // - Pi scanner now extracts first-user-message summaries from JSONL session
 //   logs. Older cache entries stored empty Pi summaries with fresh mtimes, so
@@ -20,7 +24,7 @@ use crate::plugin;
 //   entries written by 0.10.x would surface as stale "cli session (...)"
 //   summaries until the source DB mtime happens to change.
 //   Bumping the version forces a one-time rescan on first 0.11.0 launch.
-const CACHE_VERSION: u32 = 4;
+const CACHE_VERSION: u32 = 5;
 
 #[derive(Serialize, Deserialize)]
 struct CacheFile {

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -7,6 +7,12 @@ use serde::{Deserialize, Serialize};
 use crate::model::{Agent, Session};
 use crate::plugin;
 
+// Bumped to 4 after v0.11.1:
+// - Pi scanner now extracts first-user-message summaries from JSONL session
+//   logs. Older cache entries stored empty Pi summaries with fresh mtimes, so
+//   they would otherwise keep rendering only the project name until a source
+//   file changed.
+//
 // Bumped to 3 in v0.11.0:
 // - Hermes Agent registered (#34) so the per-agent cache map gains a new key.
 // - Hermes session payloads now carry first-user-message previews (only on
@@ -14,7 +20,7 @@ use crate::plugin;
 //   entries written by 0.10.x would surface as stale "cli session (...)"
 //   summaries until the source DB mtime happens to change.
 //   Bumping the version forces a one-time rescan on first 0.11.0 launch.
-const CACHE_VERSION: u32 = 3;
+const CACHE_VERSION: u32 = 4;
 
 #[derive(Serialize, Deserialize)]
 struct CacheFile {

--- a/src/main.rs
+++ b/src/main.rs
@@ -231,10 +231,11 @@ fn main() -> anyhow::Result<()> {
         let cwd = std::env::current_dir()
             .ok()
             .and_then(|p| p.to_str().map(|s| s.to_string()));
+        let initial_query = default_tui_query(cli.query, cwd.clone());
         let include_summaries = config.search_scope == "all";
         let mut app = tui::App::new(
             sessions,
-            cli.query,
+            initial_query,
             config.summary_search_count,
             include_summaries,
             cwd,
@@ -270,6 +271,10 @@ fn main() -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+fn default_tui_query(query: Option<String>, cwd: Option<String>) -> Option<String> {
+    query.or(cwd)
 }
 
 /// RAII guard that enters the alternate screen and hides the cursor on
@@ -358,4 +363,26 @@ fn exec_via_shell(cmd: &str, shell: shell::CommandShell) -> anyhow::Result<()> {
         std::process::exit(status.code().unwrap_or(1));
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn default_tui_query_uses_cwd_when_no_query_is_given() {
+        assert_eq!(
+            super::default_tui_query(None, Some("/data/projects/llmcmd".to_string())),
+            Some("/data/projects/llmcmd".to_string())
+        );
+    }
+
+    #[test]
+    fn default_tui_query_keeps_explicit_query() {
+        assert_eq!(
+            super::default_tui_query(
+                Some("pi llmcmd".to_string()),
+                Some("/data/projects/llmcmd".to_string())
+            ),
+            Some("pi llmcmd".to_string())
+        );
+    }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -75,7 +75,7 @@ impl Agent {
             Agent::ClaudeCode => format!("claude --resume '{session_id}'"),
             Agent::Codex => format!("codex resume '{session_id}'"),
             Agent::OpenCode => format!("opencode -s '{session_id}'"),
-            Agent::Pi => "pi --resume".to_string(),
+            Agent::Pi => format!("pi --session '{session_id}'"),
             Agent::Kiro => "kiro-cli chat --resume".to_string(),
             Agent::CursorAgent => format!("cursor-agent --resume '{session_id}'"),
             Agent::Gemini => format!("gemini --resume '{session_id}'"),
@@ -268,5 +268,18 @@ impl fmt::Display for Action {
             Action::Delete => write!(f, "Delete Session"),
             Action::Back => write!(f, "← Back"),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pi_resume_command_uses_selected_session_id() {
+        assert_eq!(
+            Agent::Pi.resume_cmd("019e14f4-c9a5-76dc-b7b6-0613e602a620"),
+            "pi --session '019e14f4-c9a5-76dc-b7b6-0613e602a620'"
+        );
     }
 }

--- a/src/scanner/pi.rs
+++ b/src/scanner/pi.rs
@@ -52,7 +52,7 @@ fn parse_session(path: &std::path::Path) -> Option<Session> {
     let file = File::open(path).ok()?;
     let reader = BufReader::new(file);
     let mut header = None;
-    let mut summary = None;
+    let mut summaries = Vec::new();
 
     for line in reader.lines().map_while(Result::ok) {
         let line = line.trim();
@@ -69,12 +69,8 @@ fn parse_session(path: &std::path::Path) -> Option<Session> {
             header = serde_json::from_value::<PiSessionHeader>(value.clone()).ok();
         }
 
-        if summary.is_none() {
-            summary = extract_user_summary(&value);
-        }
-
-        if header.is_some() && summary.is_some() {
-            break;
+        if let Some(summary) = extract_user_summary(&value) {
+            summaries.push(summary);
         }
     }
 
@@ -105,8 +101,6 @@ fn parse_session(path: &std::path::Path) -> Option<Session> {
         .and_then(|n| n.to_str())
         .unwrap_or("unknown")
         .to_string();
-
-    let summaries = summary.into_iter().collect();
 
     Some(Session {
         agent: Agent::Pi,
@@ -232,7 +226,7 @@ mod tests {
     }
 
     #[test]
-    fn scan_extracts_first_user_message_as_summary() {
+    fn scan_extracts_user_messages_as_summaries() {
         let _guard = home_lock().lock().unwrap();
         let old_home = std::env::var_os("HOME");
         let home = temp_home("user-summary");
@@ -247,6 +241,8 @@ mod tests {
                 r#"{"type":"model_change","id":"model"}"#,
                 r#"{"type":"message","message":{"role":"bashExecution","content":[{"type":"text","text":"cargo test"}]}}"#,
                 r#"{"type":"message","message":{"role":"user","content":[{"type":"text","text":"发布pip版本\n后续细节不用进入列表标题"}]}}"#,
+                r#"{"type":"message","message":{"role":"assistant","content":[{"type":"text","text":"done"}]}}"#,
+                r#"{"type":"message","message":{"role":"user","content":[{"type":"text","text":"再发一个版本"}]}}"#,
             ],
         );
 
@@ -259,6 +255,6 @@ mod tests {
         }
 
         assert_eq!(sessions.len(), 1);
-        assert_eq!(sessions[0].summaries, vec!["发布pip版本"]);
+        assert_eq!(sessions[0].summaries, vec!["发布pip版本", "再发一个版本"]);
     }
 }

--- a/src/scanner/pi.rs
+++ b/src/scanner/pi.rs
@@ -1,9 +1,14 @@
 use serde::Deserialize;
+use serde_json::Value;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
 use walkdir::WalkDir;
 
 use crate::error::AgfError;
 use crate::model::{Agent, Session};
-use crate::scanner::read_first_line;
+use crate::scanner::first_line_truncated;
+
+const SUMMARY_MAX_CHARS: usize = 120;
 
 #[derive(Deserialize)]
 struct PiSessionHeader {
@@ -31,63 +36,9 @@ pub fn scan() -> Result<Vec<Session>, AgfError> {
             continue;
         }
 
-        // Read just the first line rather than loading the whole JSONL.
-        let first_line = match read_first_line(path) {
-            Some(line) => line,
-            None => continue,
-        };
-
-        let header: PiSessionHeader = match serde_json::from_str(first_line.trim()) {
-            Ok(h) => h,
-            Err(_) => continue,
-        };
-
-        if header.entry_type.as_deref() != Some("session") {
-            continue;
+        if let Some(session) = parse_session(path) {
+            sessions.push(session);
         }
-
-        let session_id = match header.id {
-            Some(id) => id,
-            None => continue,
-        };
-
-        let cwd = match header.cwd {
-            Some(cwd) => cwd,
-            None => continue,
-        };
-
-        let timestamp = header
-            .timestamp
-            .and_then(|t| chrono::DateTime::parse_from_rfc3339(&t).ok())
-            .map(|dt| dt.timestamp_millis())
-            .unwrap_or_else(|| {
-                path.metadata()
-                    .and_then(|m| m.modified())
-                    .map(|t| {
-                        t.duration_since(std::time::UNIX_EPOCH)
-                            .unwrap_or_default()
-                            .as_millis() as i64
-                    })
-                    .unwrap_or(0)
-            });
-
-        let project_name = std::path::Path::new(&cwd)
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or("unknown")
-            .to_string();
-
-        sessions.push(Session {
-            agent: Agent::Pi,
-            session_id,
-            project_name,
-            project_path: cwd,
-            summaries: Vec::new(),
-            timestamp,
-            git_branch: None,
-            worktree: None,
-            recap: None,
-        });
     }
 
     // Sort by timestamp desc. Pi supports resuming a specific session by id,
@@ -95,6 +46,104 @@ pub fn scan() -> Result<Vec<Session>, AgfError> {
     sessions.sort_by_key(|s| std::cmp::Reverse(s.timestamp));
 
     Ok(sessions)
+}
+
+fn parse_session(path: &std::path::Path) -> Option<Session> {
+    let file = File::open(path).ok()?;
+    let reader = BufReader::new(file);
+    let mut header = None;
+    let mut summary = None;
+
+    for line in reader.lines().map_while(Result::ok) {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        let value: Value = match serde_json::from_str(line) {
+            Ok(value) => value,
+            Err(_) => continue,
+        };
+
+        if header.is_none() && value.get("type").and_then(Value::as_str) == Some("session") {
+            header = serde_json::from_value::<PiSessionHeader>(value.clone()).ok();
+        }
+
+        if summary.is_none() {
+            summary = extract_user_summary(&value);
+        }
+
+        if header.is_some() && summary.is_some() {
+            break;
+        }
+    }
+
+    let header = header?;
+    if header.entry_type.as_deref() != Some("session") {
+        return None;
+    }
+
+    let session_id = header.id?;
+    let cwd = header.cwd?;
+    let timestamp = header
+        .timestamp
+        .and_then(|t| chrono::DateTime::parse_from_rfc3339(&t).ok())
+        .map(|dt| dt.timestamp_millis())
+        .unwrap_or_else(|| {
+            path.metadata()
+                .and_then(|m| m.modified())
+                .map(|t| {
+                    t.duration_since(std::time::UNIX_EPOCH)
+                        .unwrap_or_default()
+                        .as_millis() as i64
+                })
+                .unwrap_or(0)
+        });
+
+    let project_name = std::path::Path::new(&cwd)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("unknown")
+        .to_string();
+
+    let summaries = summary.into_iter().collect();
+
+    Some(Session {
+        agent: Agent::Pi,
+        session_id,
+        project_name,
+        project_path: cwd,
+        summaries,
+        timestamp,
+        git_branch: None,
+        worktree: None,
+        recap: None,
+    })
+}
+
+fn extract_user_summary(value: &Value) -> Option<String> {
+    if value.get("type").and_then(Value::as_str) != Some("message") {
+        return None;
+    }
+
+    let message = value.get("message")?;
+    if message.get("role").and_then(Value::as_str) != Some("user") {
+        return None;
+    }
+
+    extract_text_content(message.get("content")?)
+}
+
+fn extract_text_content(content: &Value) -> Option<String> {
+    match content {
+        Value::String(text) => first_line_truncated(text, SUMMARY_MAX_CHARS),
+        Value::Array(items) => items.iter().find_map(extract_text_content),
+        Value::Object(map) => match map.get("text") {
+            Some(Value::String(text)) => first_line_truncated(text, SUMMARY_MAX_CHARS),
+            _ => None,
+        },
+        _ => None,
+    }
 }
 
 #[cfg(test)]
@@ -137,6 +186,15 @@ mod tests {
         .unwrap();
     }
 
+    fn write_pi_session_lines(home: &std::path::Path, dir: &str, filename: &str, lines: &[&str]) {
+        let session_dir = home.join(".pi/agent/sessions").join(dir);
+        fs::create_dir_all(&session_dir).unwrap();
+        let mut file = fs::File::create(session_dir.join(filename)).unwrap();
+        for line in lines {
+            writeln!(file, "{line}").unwrap();
+        }
+    }
+
     #[test]
     fn scan_keeps_multiple_sessions_from_same_project() {
         let _guard = home_lock().lock().unwrap();
@@ -171,5 +229,36 @@ mod tests {
 
         let ids: Vec<_> = sessions.iter().map(|s| s.session_id.as_str()).collect();
         assert_eq!(ids, vec!["new-session", "old-session"]);
+    }
+
+    #[test]
+    fn scan_extracts_first_user_message_as_summary() {
+        let _guard = home_lock().lock().unwrap();
+        let old_home = std::env::var_os("HOME");
+        let home = temp_home("user-summary");
+        std::env::set_var("HOME", &home);
+
+        write_pi_session_lines(
+            &home,
+            "--tmp-project--",
+            "session.jsonl",
+            &[
+                r#"{"type":"session","id":"session-with-summary","timestamp":"2026-05-01T00:00:00Z","cwd":"/tmp/project"}"#,
+                r#"{"type":"model_change","id":"model"}"#,
+                r#"{"type":"message","message":{"role":"bashExecution","content":[{"type":"text","text":"cargo test"}]}}"#,
+                r#"{"type":"message","message":{"role":"user","content":[{"type":"text","text":"发布pip版本\n后续细节不用进入列表标题"}]}}"#,
+            ],
+        );
+
+        let sessions = scan().unwrap();
+
+        if let Some(old_home) = old_home {
+            std::env::set_var("HOME", old_home);
+        } else {
+            std::env::remove_var("HOME");
+        }
+
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].summaries, vec!["发布pip版本"]);
     }
 }

--- a/src/scanner/pi.rs
+++ b/src/scanner/pi.rs
@@ -1,5 +1,3 @@
-use std::collections::HashSet;
-
 use serde::Deserialize;
 use walkdir::WalkDir;
 
@@ -92,11 +90,86 @@ pub fn scan() -> Result<Vec<Session>, AgfError> {
         });
     }
 
-    // Sort by timestamp desc, keep only the most recent session per project
-    // (pi --resume only resumes the latest session for a directory)
+    // Sort by timestamp desc. Pi supports resuming a specific session by id,
+    // so keep older sessions from the same project selectable.
     sessions.sort_by_key(|s| std::cmp::Reverse(s.timestamp));
-    let mut seen = HashSet::new();
-    sessions.retain(|s| seen.insert(s.project_path.clone()));
 
     Ok(sessions)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::io::Write;
+    use std::sync::{Mutex, OnceLock};
+
+    fn home_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    fn temp_home(name: &str) -> std::path::PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "agf-pi-scan-{name}-{}-{}",
+            std::process::id(),
+            chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        ));
+        fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    fn write_pi_session(
+        home: &std::path::Path,
+        dir: &str,
+        filename: &str,
+        id: &str,
+        timestamp: &str,
+        cwd: &str,
+    ) {
+        let session_dir = home.join(".pi/agent/sessions").join(dir);
+        fs::create_dir_all(&session_dir).unwrap();
+        let mut file = fs::File::create(session_dir.join(filename)).unwrap();
+        writeln!(
+            file,
+            r#"{{"type":"session","id":"{id}","timestamp":"{timestamp}","cwd":"{cwd}"}}"#
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn scan_keeps_multiple_sessions_from_same_project() {
+        let _guard = home_lock().lock().unwrap();
+        let old_home = std::env::var_os("HOME");
+        let home = temp_home("same-project");
+        std::env::set_var("HOME", &home);
+
+        write_pi_session(
+            &home,
+            "--tmp-project--",
+            "old.jsonl",
+            "old-session",
+            "2026-05-01T00:00:00Z",
+            "/tmp/project",
+        );
+        write_pi_session(
+            &home,
+            "--tmp-project--",
+            "new.jsonl",
+            "new-session",
+            "2026-05-02T00:00:00Z",
+            "/tmp/project",
+        );
+
+        let sessions = scan().unwrap();
+
+        if let Some(old_home) = old_home {
+            std::env::set_var("HOME", old_home);
+        } else {
+            std::env::remove_var("HOME");
+        }
+
+        let ids: Vec<_> = sessions.iter().map(|s| s.session_id.as_str()).collect();
+        assert_eq!(ids, vec!["new-session", "old-session"]);
+    }
 }


### PR DESCRIPTION
## Summary
- change pi resume commands from `pi --resume` to `pi --session <id>` so agf opens the selected pi session directly
- keep multiple pi sessions from the same project visible instead of retaining only the latest per path
- extract Pi user messages into `summaries`, so the TUI can show prompt titles instead of only project names
- keep all Pi user-message summaries so Preview session `History:` matches other agents instead of showing only the first prompt
- launch the TUI with the current working directory as the default fuzzy query when no explicit query is provided
- bump the cache version so existing empty/single-entry Pi summaries are rescanned after upgrade
- update README notes for Pi resume and the current-directory default

## Verification
- `cargo test default_tui_query`
- `cargo test scan_extracts_user_messages_as_summaries`
- `cargo test scanner::pi`
- `cargo test pi_`
- `cargo test`
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo build --release`
- installed release build to `/usr/local/bin/agf` and `/usr/local/bin/agf-bin`; both are now native binaries
- verified `/usr/local/bin/agf list --agent pi --limit 3 --format json` still works
- verified `/usr/local/bin/agf-bin list --agent pi --limit 600 --format json` shows `/data/projects/llmcmd` sessions with multiple summaries, including counts like 17 and 26 user prompts