### PR TITLE
release: v0.11.2 — pi session resume + scoped follow-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [0.11.2] - 2026-05-23
+
+### Fixed
+
+- **pi: resume the selected session by id** (#43, by @shellus) — pi sessions were resumed with a bare `pi --resume`, which opens an interactive picker / the latest session for the cwd and ignored the session the user actually selected in agf. The command is now `pi --session '<id>'`. Verified against the pi-mono source (`resolveSessionPath` in `packages/coding-agent/src/main.ts`): an argument with no `/`, `\`, or `.jsonl` is treated as a session-id prefix and matched against the session store; because agf wraps resume as `cd '<project_path>' && pi --session '<id>'`, pi resolves it in the session's own project directory and resumes directly without a fork prompt. (Confirmed on pi 0.53.0.)
+- **pi: keep every session from a project selectable** (#43, by @shellus) — the scanner deduped to the most recent session per project directory, a workaround for the old "only resumes latest" assumption. Now that resume-by-id works, all sessions are listed and individually resumable.
+- **pi: show prompt summaries and full history** (#43, by @shellus) — the scanner now extracts user-message text from each session's JSONL (collapsing whitespace, capped at 120 chars per line) so the listing shows what a session was about, and the Preview `History:` pane lists every prompt — parity with the other agents instead of bare `project (model)` rows.
+
+### Changed
+
+- **cache: `CACHE_VERSION` bumped to 5** (#43, by @shellus) — the pi payload now carries prompt summaries, so 0.11.x cache entries written before this release would otherwise keep rendering only the project name until each session's source mtime happened to change. The bump forces a one-time rescan on upgrade.
+
+### Internal
+
+- **pi scanner: bound the per-file read with a 512 KiB budget** — collecting every prompt requires reading the whole JSONL, but pi transcripts can grow to several MB and the `CACHE_VERSION` bump forces a cold rescan for everyone on upgrade. The read loop now stops after 512 KiB (the header is the first line, so it is always captured), mirroring the `read_head_tail` cap added in v0.10.1 after large Claude logs stalled the TUI.
+- **model: document Kiro's resume-latest behavior** — restored the note (dropped in #43) that `kiro-cli chat --resume` has no per-session flag and ignores `session_id`, now placed on the `Agent::Kiro` arm of `resume_cmd` where the command is defined.
+
+### Reverted
+
+- **TUI default-to-cwd search query** (from #43) — the merged PR also pre-filled the search box with `$PWD` when `agf` was launched without a query. That changed the no-arg behavior for *every* agent (empty list in non-project directories) and re-introduced the cwd special-casing deliberately removed in v0.11.0 (the cwd-match sort boost made time-sort look broken). Reverted to keep this release scoped to pi; a cwd default can land later as its own opt-in setting.
+
 ## [0.11.1] - 2026-05-04
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agf"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agf"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2021"
 description = "Find and resume local AI coding-agent sessions across Claude Code, Codex, Gemini, Cursor CLI, OpenCode, Kiro, pi, and Hermes"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ Then you either dig through history files or start over.
 - **Fuzzy search** — find sessions by project name, path, branch, or summary
 - **One-key resume** — resume the selected session with the right agent command
 - **Quick resume** — `agf resume <query>` skips the TUI entirely
-- **Current directory default** — launching `agf` without a query pre-filters by the current working directory
 - **Bulk delete** — `Ctrl+D` to multi-select and clean up stale sessions
 - **Project awareness** — git branches and Claude Code `--worktree` sessions surface in the UI
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -231,11 +231,10 @@ fn main() -> anyhow::Result<()> {
         let cwd = std::env::current_dir()
             .ok()
             .and_then(|p| p.to_str().map(|s| s.to_string()));
-        let initial_query = default_tui_query(cli.query, cwd.clone());
         let include_summaries = config.search_scope == "all";
         let mut app = tui::App::new(
             sessions,
-            initial_query,
+            cli.query,
             config.summary_search_count,
             include_summaries,
             cwd,
@@ -271,10 +270,6 @@ fn main() -> anyhow::Result<()> {
     }
 
     Ok(())
-}
-
-fn default_tui_query(query: Option<String>, cwd: Option<String>) -> Option<String> {
-    query.or(cwd)
 }
 
 /// RAII guard that enters the alternate screen and hides the cursor on
@@ -363,26 +358,4 @@ fn exec_via_shell(cmd: &str, shell: shell::CommandShell) -> anyhow::Result<()> {
         std::process::exit(status.code().unwrap_or(1));
     }
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn default_tui_query_uses_cwd_when_no_query_is_given() {
-        assert_eq!(
-            super::default_tui_query(None, Some("/data/projects/llmcmd".to_string())),
-            Some("/data/projects/llmcmd".to_string())
-        );
-    }
-
-    #[test]
-    fn default_tui_query_keeps_explicit_query() {
-        assert_eq!(
-            super::default_tui_query(
-                Some("pi llmcmd".to_string()),
-                Some("/data/projects/llmcmd".to_string())
-            ),
-            Some("pi llmcmd".to_string())
-        );
-    }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -76,6 +76,8 @@ impl Agent {
             Agent::Codex => format!("codex resume '{session_id}'"),
             Agent::OpenCode => format!("opencode -s '{session_id}'"),
             Agent::Pi => format!("pi --session '{session_id}'"),
+            // Kiro CLI has no per-session resume flag — `--resume` always
+            // reopens the latest session for the cwd, so session_id is unused.
             Agent::Kiro => "kiro-cli chat --resume".to_string(),
             Agent::CursorAgent => format!("cursor-agent --resume '{session_id}'"),
             Agent::Gemini => format!("gemini --resume '{session_id}'"),

--- a/src/scanner/pi.rs
+++ b/src/scanner/pi.rs
@@ -10,6 +10,15 @@ use crate::scanner::first_line_truncated;
 
 const SUMMARY_MAX_CHARS: usize = 120;
 
+/// Cap on bytes parsed per pi session file. Pi transcripts are usually small,
+/// but a long-running session can grow to several MB. Reading every byte on a
+/// cold scan — which the v5 `CACHE_VERSION` bump forces once on upgrade —
+/// repeats the v0.10.1 heavy-log stall that `read_head_tail` was added to
+/// prevent for Claude. The header (id/cwd/timestamp) is the first line so it
+/// is always read; this only bounds how many prompt summaries are collected
+/// from pathologically large sessions.
+const MAX_PARSE_BYTES: usize = 512 * 1024;
+
 #[derive(Deserialize)]
 struct PiSessionHeader {
     #[serde(rename = "type")]
@@ -53,24 +62,29 @@ fn parse_session(path: &std::path::Path) -> Option<Session> {
     let reader = BufReader::new(file);
     let mut header = None;
     let mut summaries = Vec::new();
+    let mut bytes_read = 0usize;
 
     for line in reader.lines().map_while(Result::ok) {
+        // +1 approximates the newline stripped by `lines()`; we only need a
+        // rough byte budget, not an exact count.
+        bytes_read += line.len() + 1;
+
         let line = line.trim();
-        if line.is_empty() {
-            continue;
+        if !line.is_empty() {
+            if let Ok(value) = serde_json::from_str::<Value>(line) {
+                if header.is_none() && value.get("type").and_then(Value::as_str) == Some("session")
+                {
+                    header = serde_json::from_value::<PiSessionHeader>(value.clone()).ok();
+                }
+
+                if let Some(summary) = extract_user_summary(&value) {
+                    summaries.push(summary);
+                }
+            }
         }
 
-        let value: Value = match serde_json::from_str(line) {
-            Ok(value) => value,
-            Err(_) => continue,
-        };
-
-        if header.is_none() && value.get("type").and_then(Value::as_str) == Some("session") {
-            header = serde_json::from_value::<PiSessionHeader>(value.clone()).ok();
-        }
-
-        if let Some(summary) = extract_user_summary(&value) {
-            summaries.push(summary);
+        if bytes_read >= MAX_PARSE_BYTES {
+            break;
         }
     }
 
@@ -145,73 +159,107 @@ mod tests {
     use super::*;
     use std::fs;
     use std::io::Write;
-    use std::sync::{Mutex, OnceLock};
 
-    fn home_lock() -> &'static Mutex<()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
-    }
-
-    fn temp_home(name: &str) -> std::path::PathBuf {
+    /// Write a standalone pi session JSONL to a unique temp path and return it.
+    /// Tests that exercise `parse_session` directly don't need to redirect
+    /// `$HOME`, so they stay portable — `dirs::home_dir()` only honors a `HOME`
+    /// override on Unix (Windows resolves via the Known Folder API).
+    fn temp_session_file(name: &str, lines: &[&str]) -> std::path::PathBuf {
         let path = std::env::temp_dir().join(format!(
-            "agf-pi-scan-{name}-{}-{}",
+            "agf-pi-{name}-{}-{}.jsonl",
             std::process::id(),
             chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
         ));
-        fs::create_dir_all(&path).unwrap();
-        path
-    }
-
-    fn write_pi_session(
-        home: &std::path::Path,
-        dir: &str,
-        filename: &str,
-        id: &str,
-        timestamp: &str,
-        cwd: &str,
-    ) {
-        let session_dir = home.join(".pi/agent/sessions").join(dir);
-        fs::create_dir_all(&session_dir).unwrap();
-        let mut file = fs::File::create(session_dir.join(filename)).unwrap();
-        writeln!(
-            file,
-            r#"{{"type":"session","id":"{id}","timestamp":"{timestamp}","cwd":"{cwd}"}}"#
-        )
-        .unwrap();
-    }
-
-    fn write_pi_session_lines(home: &std::path::Path, dir: &str, filename: &str, lines: &[&str]) {
-        let session_dir = home.join(".pi/agent/sessions").join(dir);
-        fs::create_dir_all(&session_dir).unwrap();
-        let mut file = fs::File::create(session_dir.join(filename)).unwrap();
+        let mut file = fs::File::create(&path).unwrap();
         for line in lines {
             writeln!(file, "{line}").unwrap();
         }
+        path
     }
 
     #[test]
-    fn scan_keeps_multiple_sessions_from_same_project() {
-        let _guard = home_lock().lock().unwrap();
-        let old_home = std::env::var_os("HOME");
-        let home = temp_home("same-project");
-        std::env::set_var("HOME", &home);
+    fn parse_session_extracts_user_messages_as_summaries() {
+        let path = temp_session_file(
+            "user-summary",
+            &[
+                r#"{"type":"session","id":"session-with-summary","timestamp":"2026-05-01T00:00:00Z","cwd":"/tmp/project"}"#,
+                r#"{"type":"model_change","id":"model"}"#,
+                r#"{"type":"message","message":{"role":"bashExecution","content":[{"type":"text","text":"cargo test"}]}}"#,
+                r#"{"type":"message","message":{"role":"user","content":[{"type":"text","text":"发布pip版本\n后续细节不用进入列表标题"}]}}"#,
+                r#"{"type":"message","message":{"role":"assistant","content":[{"type":"text","text":"done"}]}}"#,
+                r#"{"type":"message","message":{"role":"user","content":[{"type":"text","text":"再发一个版本"}]}}"#,
+            ],
+        );
 
-        write_pi_session(
-            &home,
-            "--tmp-project--",
-            "old.jsonl",
-            "old-session",
-            "2026-05-01T00:00:00Z",
-            "/tmp/project",
+        let session = parse_session(&path);
+        let _ = fs::remove_file(&path);
+
+        let session = session.expect("session header should parse");
+        assert_eq!(session.session_id, "session-with-summary");
+        assert_eq!(session.summaries, vec!["发布pip版本", "再发一个版本"]);
+    }
+
+    #[test]
+    fn parse_session_stops_at_byte_budget() {
+        // Header on line 1, then user messages whose raw bytes far exceed
+        // MAX_PARSE_BYTES so the read loop has to break early.
+        let big_text = "x".repeat(2000); // ~2 KiB per line
+        let user_line = format!(
+            r#"{{"type":"message","message":{{"role":"user","content":[{{"type":"text","text":"{big_text}"}}]}}}}"#
         );
-        write_pi_session(
-            &home,
-            "--tmp-project--",
-            "new.jsonl",
-            "new-session",
-            "2026-05-02T00:00:00Z",
-            "/tmp/project",
+        let mut lines = vec![
+            r#"{"type":"session","id":"big","timestamp":"2026-05-01T00:00:00Z","cwd":"/tmp/project"}"#
+                .to_string(),
+        ];
+        for _ in 0..400 {
+            lines.push(user_line.clone()); // ~800 KiB total
+        }
+        let line_refs: Vec<&str> = lines.iter().map(String::as_str).collect();
+        let path = temp_session_file("byte-budget", &line_refs);
+
+        let session = parse_session(&path);
+        let _ = fs::remove_file(&path);
+
+        let session = session.expect("header on line 1 should parse within the budget");
+        assert_eq!(session.session_id, "big");
+        // The 512 KiB budget stops collection before all 400 prompts are read.
+        assert!(
+            session.summaries.len() < 400,
+            "expected the byte budget to cap summaries, got {}",
+            session.summaries.len()
         );
+    }
+
+    /// `scan()` walks `$HOME/.pi/agent/sessions`; redirecting the home dir via
+    /// the `HOME` env var only works on Unix, so the dir-walk + multi-session
+    /// (dedup-removal) coverage is gated to Unix.
+    #[cfg(unix)]
+    #[test]
+    fn scan_keeps_multiple_sessions_from_same_project() {
+        use std::sync::{Mutex, OnceLock};
+        static HOME_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        let _guard = HOME_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
+
+        let old_home = std::env::var_os("HOME");
+        let home = std::env::temp_dir().join(format!(
+            "agf-pi-scan-{}-{}",
+            std::process::id(),
+            chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        ));
+        let session_dir = home.join(".pi/agent/sessions/--tmp-project--");
+        fs::create_dir_all(&session_dir).unwrap();
+        for (file, id, ts) in [
+            ("old.jsonl", "old-session", "2026-05-01T00:00:00Z"),
+            ("new.jsonl", "new-session", "2026-05-02T00:00:00Z"),
+        ] {
+            let mut f = fs::File::create(session_dir.join(file)).unwrap();
+            writeln!(
+                f,
+                r#"{{"type":"session","id":"{id}","timestamp":"{ts}","cwd":"/tmp/project"}}"#
+            )
+            .unwrap();
+        }
+        std::env::set_var("HOME", &home);
 
         let sessions = scan().unwrap();
 
@@ -223,38 +271,5 @@ mod tests {
 
         let ids: Vec<_> = sessions.iter().map(|s| s.session_id.as_str()).collect();
         assert_eq!(ids, vec!["new-session", "old-session"]);
-    }
-
-    #[test]
-    fn scan_extracts_user_messages_as_summaries() {
-        let _guard = home_lock().lock().unwrap();
-        let old_home = std::env::var_os("HOME");
-        let home = temp_home("user-summary");
-        std::env::set_var("HOME", &home);
-
-        write_pi_session_lines(
-            &home,
-            "--tmp-project--",
-            "session.jsonl",
-            &[
-                r#"{"type":"session","id":"session-with-summary","timestamp":"2026-05-01T00:00:00Z","cwd":"/tmp/project"}"#,
-                r#"{"type":"model_change","id":"model"}"#,
-                r#"{"type":"message","message":{"role":"bashExecution","content":[{"type":"text","text":"cargo test"}]}}"#,
-                r#"{"type":"message","message":{"role":"user","content":[{"type":"text","text":"发布pip版本\n后续细节不用进入列表标题"}]}}"#,
-                r#"{"type":"message","message":{"role":"assistant","content":[{"type":"text","text":"done"}]}}"#,
-                r#"{"type":"message","message":{"role":"user","content":[{"type":"text","text":"再发一个版本"}]}}"#,
-            ],
-        );
-
-        let sessions = scan().unwrap();
-
-        if let Some(old_home) = old_home {
-            std::env::set_var("HOME", old_home);
-        } else {
-            std::env::remove_var("HOME");
-        }
-
-        assert_eq!(sessions.len(), 1);
-        assert_eq!(sessions[0].summaries, vec!["发布pip版本", "再发一个版本"]);
     }
 }


### PR DESCRIPTION
Builds on @shellus's pi work in #43 (already merged to main, commits f727ba4..afc2c09, authorship preserved) and scopes it into a clean pi-only release.

## Kept from #43 (verified)
- **pi resume by id** — `pi --session '<id>'`. Verified against the pi-mono source (`resolveSessionPath`, `packages/coding-agent/src/main.ts`): a bare id with no `/`/`\`/`.jsonl` is prefix-matched against the session store, and since agf wraps resume as `cd '<project_path>' && pi --session '<id>'`, pi resolves it locally and resumes directly (no fork prompt). Confirmed on pi 0.53.0.
- **Keep every session per project selectable** — dedup-to-latest removed now that resume-by-id works.
- **pi prompt summaries + full History** — parity with other agents.
- **`CACHE_VERSION` 5** — one-time rescan on upgrade.

## Follow-ups in this PR
- **Revert the default-to-cwd search query** — the merged PR pre-filled the search box with `$PWD` when `agf` ran with no query. That changed no-arg behavior for *every* agent (empty list in non-project dirs) and re-introduced the cwd special-casing deliberately removed in v0.11.0 (the cwd-match sort boost made time-sort look broken). Deferred to a future opt-in setting.
- **Bound `pi parse_session` with a 512 KiB read budget** — collecting every prompt requires reading the whole JSONL, but pi transcripts can reach several MB and the `CACHE_VERSION` bump forces a cold rescan for everyone on upgrade. The read loop now stops after 512 KiB (header is line 1, always captured), mirroring `read_head_tail` (added v0.10.1 after large Claude logs stalled the TUI).
- **Restore the Kiro resume-latest note** — `kiro-cli chat --resume` has no per-session flag; note moved onto `Agent::Kiro` in `resume_cmd`.
- **Regression test** for the byte-budget cap.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — 31 passed
- [x] `cargo build --release`; `agf list` works across agents; `agf --version` → 0.11.2
- [x] Diff scoped to 7 intended files; other agents' `resume_cmd` unchanged