### PR TITLE
fix(scanner/cursor): correct agent-transcript layout for current Cursor CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Then you either dig through history files or start over.
 | [Claude Code](https://github.com/anthropics/claude-code) | `claude --resume <id>` | `~/.claude/history.jsonl` + `~/.claude/projects/` |
 | [Codex](https://github.com/openai/codex) | `codex resume <id>` | `~/.codex/sessions/**/*.jsonl` |
 | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `gemini --resume <id>` | `~/.gemini/tmp/<project>/chats/session-*.json` |
-| [Cursor CLI](https://docs.cursor.com/agent) | `cursor-agent --resume <id>` | `~/.cursor/projects/*/agent-transcripts/*.txt` |
+| [Cursor CLI](https://cursor.com/docs/cli/overview) | `cursor-agent --resume <id>` | `~/.cursor/projects/*/agent-transcripts/<id>/<id>.jsonl` (Composer 2+)<br>`~/.cursor/projects/*/agent-transcripts/<id>.txt` (legacy) |
 | [OpenCode](https://github.com/opencode-ai/opencode) | `opencode -s <id>` | `~/.local/share/opencode/opencode.db` |
 | [Kiro](https://kiro.dev) | `kiro-cli chat --resume` | `~/Library/Application Support/kiro-cli/data.sqlite3` |
 | [pi](https://github.com/badlogic/pi-mono) | `pi --session <id>` | `~/.pi/agent/sessions/<cwd>/*.jsonl` |
@@ -62,7 +62,7 @@ Then you either dig through history files or start over.
 | OpenCode | SQLite | `~/.local/share/opencode/opencode.db` |
 | pi | JSONL | `~/.pi/agent/sessions/--<encoded-cwd>--/<ts>_<id>.jsonl` |
 | Kiro | SQLite | macOS: `~/Library/Application Support/kiro-cli/data.sqlite3`<br>Linux: `~/.local/share/kiro-cli/data.sqlite3` |
-| Cursor CLI | SQLite + TXT | `~/.cursor/chats/*/<id>/store.db`<br>`~/.cursor/projects/*/agent-transcripts/<id>.txt` |
+| Cursor CLI | SQLite + JSONL/TXT | `~/.cursor/chats/<workspace>/<id>/store.db` (metadata; required for `.jsonl` to be resumable)<br>`~/.cursor/projects/*/agent-transcripts/<id>/<id>.jsonl` (Composer 2+ transcript)<br>`~/.cursor/projects/*/agent-transcripts/<id>.txt` (legacy transcript) |
 | Gemini | JSON | `~/.gemini/tmp/<project>/chats/session-<date>-<id>.json`<br>`<project>` is a named dir or SHA-256 hash of the project path<br>Project paths resolved via `~/.gemini/projects.json` |
 | Hermes | SQLite | `~/.hermes/state.db` (sessions + messages)<br>JSON dumps in `~/.hermes/sessions/session_<id>.json`<br>Hermes is cwd-independent — resume runs in your current shell directory |
 

--- a/src/delete.rs
+++ b/src/delete.rs
@@ -322,7 +322,7 @@ fn delete_kiro_session(session: &Session) -> Result<(), io::Error> {
 
 /// Cursor Agent sessions are stored in two locations:
 /// 1. `~/.cursor/chats/<workspace-hash>/<session_id>/store.db` (SQLite)
-/// 2. `~/.cursor/projects/*/agent-transcripts/<session_id>.txt` (transcript files)
+/// 2. `~/.cursor/projects/*/agent-transcripts/<session_id>/` (transcript directory)
 fn delete_cursor_agent_session(session: &Session) -> Result<(), io::Error> {
     let cursor_dir = config::cursor_dir().map_err(io::Error::other)?;
 
@@ -332,20 +332,10 @@ fn delete_cursor_agent_session(session: &Session) -> Result<(), io::Error> {
         remove_dirs_matching_name(&chats_dir, &session.session_id)?;
     }
 
-    // 2. Remove transcript files: ~/.cursor/projects/*/agent-transcripts/<session_id>.txt
+    // 2. Remove transcript directory: ~/.cursor/projects/*/agent-transcripts/<session_id>/
     let projects_dir = cursor_dir.join("projects");
     if projects_dir.exists() {
-        let transcript_name = format!("{}.txt", session.session_id);
-        for entry in WalkDir::new(&projects_dir)
-            .into_iter()
-            .filter_map(|e| e.ok())
-        {
-            let path = entry.path();
-            if path.is_file() && path.file_name().and_then(|n| n.to_str()) == Some(&transcript_name)
-            {
-                let _ = fs::remove_file(path);
-            }
-        }
+        remove_dirs_matching_name(&projects_dir, &session.session_id)?;
     }
 
     Ok(())
@@ -558,5 +548,27 @@ mod tests {
 
         // Should swallow the "no such table: threads" error.
         delete_codex_sqlite_rows(&dir, "anything").unwrap();
+    }
+
+    #[test]
+    fn delete_cursor_agent_removes_transcript_dir_not_sibling() {
+        let base = make_codex_dir("agf-test-cursor-delete");
+        let transcripts = base.join("projects/encproj/agent-transcripts");
+
+        let target_uuid = "ddddddddddddddddddddddddddddddd1";
+        let sibling_uuid = "ddddddddddddddddddddddddddddddd2";
+
+        let target_dir = transcripts.join(target_uuid);
+        let sibling_dir = transcripts.join(sibling_uuid);
+        fs::create_dir_all(&target_dir).unwrap();
+        fs::create_dir_all(&sibling_dir).unwrap();
+        fs::write(target_dir.join(format!("{target_uuid}.jsonl")), b"{}").unwrap();
+        fs::write(sibling_dir.join(format!("{sibling_uuid}.jsonl")), b"{}").unwrap();
+
+        let projects_dir = base.join("projects");
+        remove_dirs_matching_name(&projects_dir, target_uuid).unwrap();
+
+        assert!(!target_dir.exists(), "target session dir should be deleted");
+        assert!(sibling_dir.exists(), "sibling session dir must survive");
     }
 }

--- a/src/scanner/cursor_agent.rs
+++ b/src/scanner/cursor_agent.rs
@@ -9,7 +9,10 @@ use crate::model::{Agent, Session};
 use super::truncate;
 
 pub fn scan() -> Result<Vec<Session>, AgfError> {
-    let cursor_dir = crate::config::cursor_dir()?;
+    scan_from(&crate::config::cursor_dir()?)
+}
+
+fn scan_from(cursor_dir: &Path) -> Result<Vec<Session>, AgfError> {
     let projects_dir = cursor_dir.join("projects");
 
     if !projects_dir.exists() {
@@ -19,23 +22,27 @@ pub fn scan() -> Result<Vec<Session>, AgfError> {
     let chats_dir = cursor_dir.join("chats");
     let mut sessions = Vec::new();
 
-    // Walk ~/.cursor/projects/*/agent-transcripts/*.txt
+    // Walk ~/.cursor/projects/*/agent-transcripts/*/<session>.jsonl
     for entry in WalkDir::new(&projects_dir)
-        .min_depth(3)
-        .max_depth(3)
+        .min_depth(4)
+        .max_depth(4)
         .into_iter()
         .filter_map(|e| e.ok())
     {
         let path = entry.path();
 
-        if !path.is_file() || path.extension().and_then(|e| e.to_str()) != Some("txt") {
+        if !path.is_file() || path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
             continue;
         }
 
-        // Parent must be "agent-transcripts"
-        let parent = match path.parent() {
-            Some(p) if p.file_name().and_then(|n| n.to_str()) == Some("agent-transcripts") => p,
-            _ => continue,
+        // Grandparent must be "agent-transcripts"
+        let agent_transcripts_dir = match path
+            .parent()
+            .and_then(|p| p.parent())
+            .filter(|p| p.file_name().and_then(|n| n.to_str()) == Some("agent-transcripts"))
+        {
+            Some(p) => p,
+            None => continue,
         };
 
         let session_id = match path.file_stem().and_then(|n| n.to_str()) {
@@ -43,8 +50,8 @@ pub fn scan() -> Result<Vec<Session>, AgfError> {
             None => continue,
         };
 
-        // Grandparent is the dash-encoded project path
-        let encoded_dir = match parent
+        // Parent of agent-transcripts is the dash-encoded project path
+        let encoded_dir = match agent_transcripts_dir
             .parent()
             .and_then(|p| p.file_name())
             .and_then(|n| n.to_str())
@@ -200,4 +207,147 @@ fn solve(parts: &[&str], idx: usize, current: &Path) -> Option<PathBuf> {
         }
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::io::Write;
+
+    /// Build a (cursor_dir, real_project_dir, dash_encoded_slug) fixture.
+    ///
+    /// Both directories are created under `temp_dir()`. The project dir is
+    /// canonicalized so macOS `/tmp` → `/private/tmp` is handled correctly,
+    /// and its path components are joined with `-` to produce the slug that
+    /// Cursor writes as the project folder name under `projects/`.
+    ///
+    /// Labels must be alphanumeric only (no dashes) to avoid ambiguity in
+    /// the backtracking decoder.
+    fn make_fixture(label: &str) -> (PathBuf, PathBuf, String) {
+        let pid = std::process::id();
+        let cursor_dir = std::env::temp_dir().join(format!("agfcursor{pid}{label}"));
+        let proj_dir = std::env::temp_dir().join(format!("agfproj{pid}{label}"));
+
+        let _ = fs::remove_dir_all(&cursor_dir);
+        let _ = fs::remove_dir_all(&proj_dir);
+        fs::create_dir_all(cursor_dir.join("projects")).unwrap();
+        fs::create_dir_all(&proj_dir).unwrap();
+
+        let real_proj = proj_dir.canonicalize().unwrap();
+        let encoded = real_proj
+            .to_str()
+            .unwrap()
+            .trim_start_matches('/')
+            .replace('/', "-");
+
+        (cursor_dir, real_proj, encoded)
+    }
+
+    /// Write an empty `.jsonl` at the correct depth:
+    /// `<cursor_dir>/projects/<slug>/agent-transcripts/<uuid>/<uuid>.jsonl`
+    fn place_session(cursor_dir: &Path, slug: &str, uuid: &str) {
+        let session_dir = cursor_dir
+            .join("projects")
+            .join(slug)
+            .join("agent-transcripts")
+            .join(uuid);
+        fs::create_dir_all(&session_dir).unwrap();
+        let mut f = fs::File::create(session_dir.join(format!("{uuid}.jsonl"))).unwrap();
+        f.write_all(b"{}\n").unwrap();
+    }
+
+    #[test]
+    fn scan_from_finds_jsonl_session() {
+        let (cursor_dir, real_proj, encoded) = make_fixture("finds");
+        let uuid = "aaaaaaaa0000000000000000000000a1";
+
+        place_session(&cursor_dir, &encoded, uuid);
+
+        let sessions = scan_from(&cursor_dir).unwrap();
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].session_id, uuid);
+        assert_eq!(sessions[0].project_path, real_proj.to_str().unwrap());
+        assert_eq!(sessions[0].agent, Agent::CursorAgent);
+
+        let _ = fs::remove_dir_all(&cursor_dir);
+        let _ = fs::remove_dir_all(&real_proj);
+    }
+
+    #[test]
+    fn scan_from_ignores_txt_at_wrong_depth() {
+        let (cursor_dir, real_proj, encoded) = make_fixture("txtigno");
+
+        // Old (wrong) format: .txt directly inside agent-transcripts/
+        let transcripts_dir = cursor_dir
+            .join("projects")
+            .join(&encoded)
+            .join("agent-transcripts");
+        fs::create_dir_all(&transcripts_dir).unwrap();
+        fs::write(transcripts_dir.join("session.txt"), b"").unwrap();
+
+        assert!(scan_from(&cursor_dir).unwrap().is_empty());
+
+        let _ = fs::remove_dir_all(&cursor_dir);
+        let _ = fs::remove_dir_all(&real_proj);
+    }
+
+    #[test]
+    fn scan_from_ignores_jsonl_directly_in_agent_transcripts() {
+        let (cursor_dir, real_proj, encoded) = make_fixture("depth");
+
+        // .jsonl at depth 3 instead of 4 — must be ignored
+        let transcripts_dir = cursor_dir
+            .join("projects")
+            .join(&encoded)
+            .join("agent-transcripts");
+        fs::create_dir_all(&transcripts_dir).unwrap();
+        fs::write(transcripts_dir.join("session.jsonl"), b"{}").unwrap();
+
+        assert!(scan_from(&cursor_dir).unwrap().is_empty());
+
+        let _ = fs::remove_dir_all(&cursor_dir);
+        let _ = fs::remove_dir_all(&real_proj);
+    }
+
+    #[test]
+    fn scan_from_skips_var_folders_encoded_dirs() {
+        let (cursor_dir, real_proj, _) = make_fixture("varfold");
+        let uuid = "aaaaaaaa0000000000000000000000a2";
+
+        // Use a slug that starts with "var-folders" — must be skipped even if
+        // the session file is otherwise valid.
+        place_session(&cursor_dir, "var-folders-xx-yyyyyyyy", uuid);
+
+        assert!(scan_from(&cursor_dir).unwrap().is_empty());
+
+        let _ = fs::remove_dir_all(&cursor_dir);
+        let _ = fs::remove_dir_all(&real_proj);
+    }
+
+    #[test]
+    fn decode_dash_path_resolves_existing_directory() {
+        let pid = std::process::id();
+        let dir = std::env::temp_dir().join(format!("agfdecode{pid}"));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        let real = dir.canonicalize().unwrap();
+
+        let encoded = real
+            .to_str()
+            .unwrap()
+            .trim_start_matches('/')
+            .replace('/', "-");
+        assert_eq!(decode_dash_path(&encoded), Some(real));
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn decode_dash_path_returns_none_for_nonexistent() {
+        assert_eq!(
+            decode_dash_path("this-path-does-not-exist-anywhere-xyzabc999"),
+            None
+        );
+    }
 }

--- a/src/scanner/cursor_agent.rs
+++ b/src/scanner/cursor_agent.rs
@@ -88,7 +88,7 @@ fn scan_from(cursor_dir: &Path) -> Result<Vec<Session>, AgfError> {
         let (summary, timestamp) = match meta {
             Some(m) => (m.name, m.created_at),
             None => {
-                // Fall back to transcript file mtime
+                // Fall back to transcript file mtime + first user prompt as summary
                 let mtime = path
                     .metadata()
                     .ok()
@@ -96,7 +96,7 @@ fn scan_from(cursor_dir: &Path) -> Result<Vec<Session>, AgfError> {
                     .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
                     .map(|d| d.as_millis() as i64)
                     .unwrap_or(0);
-                (None, mtime)
+                (extract_first_prompt(path), mtime)
             }
         };
 
@@ -175,6 +175,60 @@ fn hex_decode(hex: &str) -> Option<Vec<u8>> {
         .step_by(2)
         .map(|i| u8::from_str_radix(&hex[i..i + 2], 16).ok())
         .collect()
+}
+
+/// Extract the first user-visible prompt from a Cursor agent transcript JSONL.
+///
+/// Each line is a JSON object with `{"role":"user"|"assistant","message":{"content":[...]}}`.
+/// User turns may contain a `<user_info>` system injection (always first) followed by
+/// the actual `<user_query>` prompt. We skip info blocks and strip the query tags.
+fn extract_first_prompt(jsonl_path: &Path) -> Option<String> {
+    use std::fs::File;
+    use std::io::{BufRead, BufReader};
+
+    let file = File::open(jsonl_path).ok()?;
+    let reader = BufReader::new(file);
+
+    for line in reader.lines().take(50) {
+        let line = line.ok()?;
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let value: serde_json::Value = serde_json::from_str(line).ok()?;
+        if value.get("role").and_then(|v| v.as_str()) != Some("user") {
+            continue;
+        }
+        let parts = value
+            .get("message")
+            .and_then(|m| m.get("content"))
+            .and_then(|c| c.as_array())?;
+
+        for part in parts {
+            if part.get("type").and_then(|t| t.as_str()) != Some("text") {
+                continue;
+            }
+            let text = match part.get("text").and_then(|t| t.as_str()) {
+                Some(t) => t,
+                None => continue,
+            };
+            if text.trim_start().starts_with("<user_info>") {
+                continue;
+            }
+            // Strip <user_query> wrapper if present
+            let prompt = if let (Some(s), Some(e)) =
+                (text.find("<user_query>"), text.find("</user_query>"))
+            {
+                text[s + "<user_query>".len()..e].trim()
+            } else {
+                text.trim()
+            };
+            if !prompt.is_empty() {
+                return Some(truncate(prompt, 100));
+            }
+        }
+    }
+    None
 }
 
 /// Backtracking path decoder: dash-encoded path -> filesystem path.
@@ -349,5 +403,70 @@ mod tests {
             decode_dash_path("this-path-does-not-exist-anywhere-xyzabc999"),
             None
         );
+    }
+
+    #[test]
+    fn extract_first_prompt_reads_user_query_tags() {
+        let pid = std::process::id();
+        let path = std::env::temp_dir().join(format!("agf-prompt-test-{pid}.jsonl"));
+        fs::write(
+            &path,
+            r#"{"role":"user","message":{"content":[{"type":"text","text":"<user_query>\nFix the bug\n</user_query>"}]}}"#,
+        )
+        .unwrap();
+        assert_eq!(extract_first_prompt(&path).as_deref(), Some("Fix the bug"));
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn extract_first_prompt_skips_user_info_block() {
+        let pid = std::process::id();
+        let path = std::env::temp_dir().join(format!("agf-prompt-info-{pid}.jsonl"));
+        fs::write(
+            &path,
+            "{\"role\":\"user\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"<user_info>OS: darwin</user_info>\"}]}}\n\
+             {\"role\":\"user\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"<user_query>\\nActual prompt\\n</user_query>\"}]}}",
+        )
+        .unwrap();
+        assert_eq!(
+            extract_first_prompt(&path).as_deref(),
+            Some("Actual prompt")
+        );
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn extract_first_prompt_returns_none_for_empty_jsonl() {
+        let pid = std::process::id();
+        let path = std::env::temp_dir().join(format!("agf-prompt-empty-{pid}.jsonl"));
+        fs::write(&path, b"{}").unwrap();
+        assert_eq!(extract_first_prompt(&path), None);
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn scan_from_finds_prompt_when_no_store_db() {
+        let (cursor_dir, real_proj, encoded) = make_fixture("nodb");
+        let uuid = "aaaaaaaa0000000000000000000000a3";
+
+        // Write a real JSONL with a user prompt (no store.db / chats dir)
+        let session_dir = cursor_dir
+            .join("projects")
+            .join(&encoded)
+            .join("agent-transcripts")
+            .join(uuid);
+        fs::create_dir_all(&session_dir).unwrap();
+        fs::write(
+            session_dir.join(format!("{uuid}.jsonl")),
+            r#"{"role":"user","message":{"content":[{"type":"text","text":"<user_query>\nhello world\n</user_query>"}]}}"#,
+        )
+        .unwrap();
+
+        let sessions = scan_from(&cursor_dir).unwrap();
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].summaries, vec!["hello world"]);
+
+        let _ = fs::remove_dir_all(&cursor_dir);
+        let _ = fs::remove_dir_all(&real_proj);
     }
 }

--- a/src/scanner/cursor_agent.rs
+++ b/src/scanner/cursor_agent.rs
@@ -102,12 +102,23 @@ fn scan_from(cursor_dir: &Path) -> Result<Vec<Session>, AgfError> {
 
         let project_path_str = project_path.to_string_lossy().to_string();
 
-        // Try to get metadata from store.db
-        let meta = if chats_dir.exists() {
-            find_store_db_metadata(&chats_dir, &session_id)
+        // Locate the matching store.db (if any). cursor-agent's `/resume` only
+        // surfaces sessions that have BOTH a transcript and a store.db entry
+        // under ~/.cursor/chats/<workspace>/<session_id>/, so for the .jsonl
+        // (Composer 2+) format we treat the absence of store.db as "orphaned"
+        // and skip the session — otherwise agf would show sessions that
+        // cursor-agent itself refuses to resume.
+        let store_db_path = if chats_dir.exists() {
+            find_store_db_path(&chats_dir, &session_id)
         } else {
             None
         };
+
+        if ext == Some("jsonl") && store_db_path.is_none() {
+            continue;
+        }
+
+        let meta = store_db_path.as_deref().and_then(read_store_db);
 
         let (summary, timestamp) = match meta {
             Some(m) => (m.name, m.created_at),
@@ -150,14 +161,16 @@ struct StoreMeta {
     created_at: i64,
 }
 
-/// Search ~/.cursor/chats/*/<session_id>/store.db and extract metadata.
-fn find_store_db_metadata(chats_dir: &Path, session_id: &str) -> Option<StoreMeta> {
-    // chats_dir contains workspace-hash directories
+/// Locate the first existing ~/.cursor/chats/<workspace>/<session_id>/store.db.
+///
+/// Presence of this file means cursor-agent considers the session resumable;
+/// the file is the source of truth for `/resume`.
+fn find_store_db_path(chats_dir: &Path, session_id: &str) -> Option<PathBuf> {
     let read_dir = std::fs::read_dir(chats_dir).ok()?;
     for workspace_entry in read_dir.filter_map(|e| e.ok()) {
         let store_path = workspace_entry.path().join(session_id).join("store.db");
         if store_path.exists() {
-            return read_store_db(&store_path);
+            return Some(store_path);
         }
     }
     None
@@ -340,18 +353,42 @@ mod tests {
         f.write_all(b"{}\n").unwrap();
     }
 
+    /// Create a stub store.db at `<cursor_dir>/chats/<workspace>/<uuid>/store.db`.
+    /// The file content is irrelevant; only its existence is checked.
+    fn place_store_db(cursor_dir: &Path, workspace: &str, uuid: &str) {
+        let dir = cursor_dir.join("chats").join(workspace).join(uuid);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("store.db"), b"").unwrap();
+    }
+
     #[test]
-    fn scan_from_finds_jsonl_session() {
+    fn scan_from_finds_jsonl_session_with_store_db() {
         let (cursor_dir, real_proj, encoded) = make_fixture("finds");
         let uuid = "aaaaaaaa0000000000000000000000a1";
 
         place_session(&cursor_dir, &encoded, uuid);
+        place_store_db(&cursor_dir, "anyworkspacehash", uuid);
 
         let sessions = scan_from(&cursor_dir).unwrap();
         assert_eq!(sessions.len(), 1);
         assert_eq!(sessions[0].session_id, uuid);
         assert_eq!(sessions[0].project_path, real_proj.to_str().unwrap());
         assert_eq!(sessions[0].agent, Agent::CursorAgent);
+
+        let _ = fs::remove_dir_all(&cursor_dir);
+        let _ = fs::remove_dir_all(&real_proj);
+    }
+
+    #[test]
+    fn scan_from_skips_orphan_jsonl_without_store_db() {
+        let (cursor_dir, real_proj, encoded) = make_fixture("orphan");
+        let uuid = "aaaaaaaa0000000000000000000000ad";
+
+        // Transcript exists but no store.db → cursor-agent /resume would NOT
+        // surface it, so agf must hide it too.
+        place_session(&cursor_dir, &encoded, uuid);
+
+        assert!(scan_from(&cursor_dir).unwrap().is_empty());
 
         let _ = fs::remove_dir_all(&cursor_dir);
         let _ = fs::remove_dir_all(&real_proj);
@@ -499,11 +536,11 @@ mod tests {
     }
 
     #[test]
-    fn scan_from_finds_prompt_when_no_store_db() {
+    fn scan_from_falls_back_to_prompt_when_store_db_lacks_meta() {
         let (cursor_dir, real_proj, encoded) = make_fixture("nodb");
         let uuid = "aaaaaaaa0000000000000000000000a3";
 
-        // Write a real JSONL with a user prompt (no store.db / chats dir)
+        // Real JSONL with a user prompt …
         let session_dir = cursor_dir
             .join("projects")
             .join(&encoded)
@@ -515,6 +552,10 @@ mod tests {
             r#"{"role":"user","message":{"content":[{"type":"text","text":"<user_query>\nhello world\n</user_query>"}]}}"#,
         )
         .unwrap();
+        // … plus a stub store.db (not a valid sqlite file, so read_store_db
+        // returns None) — the session is "resumable" so it must surface, and
+        // the summary must fall back to the extracted prompt.
+        place_store_db(&cursor_dir, "anyworkspacehash", uuid);
 
         let sessions = scan_from(&cursor_dir).unwrap();
         assert_eq!(sessions.len(), 1);

--- a/src/scanner/cursor_agent.rs
+++ b/src/scanner/cursor_agent.rs
@@ -142,9 +142,9 @@ fn read_store_db(store_path: &Path) -> Option<StoreMeta> {
     )
     .ok()?;
 
-    // The meta table typically has key-value rows with hex-encoded JSON
+    // Cursor CLI stores session metadata as hex-encoded JSON in meta WHERE key='0'
     let mut stmt = conn
-        .prepare("SELECT value FROM cursorDiskKV WHERE key = 'composerData'")
+        .prepare("SELECT value FROM meta WHERE key = '0'")
         .ok()?;
     let hex_value: String = stmt.query_row([], |row| row.get(0)).ok()?;
 

--- a/src/scanner/cursor_agent.rs
+++ b/src/scanner/cursor_agent.rs
@@ -22,32 +22,56 @@ fn scan_from(cursor_dir: &Path) -> Result<Vec<Session>, AgfError> {
     let chats_dir = cursor_dir.join("chats");
     let mut sessions = Vec::new();
 
-    // Walk ~/.cursor/projects/*/agent-transcripts/*/<session>.jsonl
+    // Single walk covers both storage formats:
+    //
+    //   Legacy  (Cursor ≤ 2.4.7):  projects/<slug>/agent-transcripts/<uuid>.txt      (depth 3)
+    //   Current (Composer 2 / 3+): projects/<slug>/agent-transcripts/<uuid>/<uuid>.jsonl (depth 4)
     for entry in WalkDir::new(&projects_dir)
-        .min_depth(4)
+        .min_depth(3)
         .max_depth(4)
         .into_iter()
         .filter_map(|e| e.ok())
     {
         let path = entry.path();
-
-        if !path.is_file() || path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
+        if !path.is_file() {
             continue;
         }
 
-        // Grandparent must be "agent-transcripts"
-        let agent_transcripts_dir = match path
-            .parent()
-            .and_then(|p| p.parent())
-            .filter(|p| p.file_name().and_then(|n| n.to_str()) == Some("agent-transcripts"))
-        {
-            Some(p) => p,
-            None => continue,
-        };
+        let ext = path.extension().and_then(|e| e.to_str());
 
-        let session_id = match path.file_stem().and_then(|n| n.to_str()) {
-            Some(id) => id.to_string(),
-            None => continue,
+        // Resolve (agent_transcripts_dir, session_id) for each format.
+        let (agent_transcripts_dir, session_id) = match ext {
+            Some("txt") => {
+                // Legacy: parent must be "agent-transcripts"
+                let parent = match path.parent().filter(|p| {
+                    p.file_name().and_then(|n| n.to_str()) == Some("agent-transcripts")
+                }) {
+                    Some(p) => p,
+                    None => continue,
+                };
+                let id = match path.file_stem().and_then(|n| n.to_str()) {
+                    Some(id) => id.to_string(),
+                    None => continue,
+                };
+                (parent, id)
+            }
+            Some("jsonl") => {
+                // Current: grandparent must be "agent-transcripts"
+                let grandparent = match path
+                    .parent()
+                    .and_then(|p| p.parent())
+                    .filter(|p| p.file_name().and_then(|n| n.to_str()) == Some("agent-transcripts"))
+                {
+                    Some(p) => p,
+                    None => continue,
+                };
+                let id = match path.file_stem().and_then(|n| n.to_str()) {
+                    Some(id) => id.to_string(),
+                    None => continue,
+                };
+                (grandparent, id)
+            }
+            _ => continue,
         };
 
         // Parent of agent-transcripts is the dash-encoded project path
@@ -60,7 +84,7 @@ fn scan_from(cursor_dir: &Path) -> Result<Vec<Session>, AgfError> {
             None => continue,
         };
 
-        // Skip temp directories
+        // Skip macOS temp directories
         if encoded_dir.starts_with("var-folders") {
             continue;
         }
@@ -88,7 +112,6 @@ fn scan_from(cursor_dir: &Path) -> Result<Vec<Session>, AgfError> {
         let (summary, timestamp) = match meta {
             Some(m) => (m.name, m.created_at),
             None => {
-                // Fall back to transcript file mtime + first user prompt as summary
                 let mtime = path
                     .metadata()
                     .ok()
@@ -96,7 +119,13 @@ fn scan_from(cursor_dir: &Path) -> Result<Vec<Session>, AgfError> {
                     .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
                     .map(|d| d.as_millis() as i64)
                     .unwrap_or(0);
-                (extract_first_prompt(path), mtime)
+                // Prompt extraction only applies to JSONL; .txt format is unknown
+                let prompt = if ext == Some("jsonl") {
+                    extract_first_prompt(path)
+                } else {
+                    None
+                };
+                (prompt, mtime)
             }
         };
 
@@ -329,16 +358,41 @@ mod tests {
     }
 
     #[test]
-    fn scan_from_ignores_txt_at_wrong_depth() {
+    fn scan_from_finds_legacy_txt_session() {
         let (cursor_dir, real_proj, encoded) = make_fixture("txtigno");
 
-        // Old (wrong) format: .txt directly inside agent-transcripts/
+        // Legacy format: <uuid>.txt directly inside agent-transcripts/
         let transcripts_dir = cursor_dir
             .join("projects")
             .join(&encoded)
             .join("agent-transcripts");
         fs::create_dir_all(&transcripts_dir).unwrap();
-        fs::write(transcripts_dir.join("session.txt"), b"").unwrap();
+        let uuid = "bbbbbbbb0000000000000000000000b1";
+        fs::write(transcripts_dir.join(format!("{uuid}.txt")), b"").unwrap();
+
+        let sessions = scan_from(&cursor_dir).unwrap();
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].session_id, uuid);
+        assert_eq!(sessions[0].project_path, real_proj.to_str().unwrap());
+        assert_eq!(sessions[0].agent, Agent::CursorAgent);
+
+        let _ = fs::remove_dir_all(&cursor_dir);
+        let _ = fs::remove_dir_all(&real_proj);
+    }
+
+    #[test]
+    fn scan_from_ignores_txt_nested_in_uuid_subdir() {
+        let (cursor_dir, real_proj, encoded) = make_fixture("txtwrong");
+
+        // .txt at depth 4 (inside a UUID subdir) is NOT the legacy format and must be ignored
+        let uuid = "cccccccc0000000000000000000000c1";
+        let session_dir = cursor_dir
+            .join("projects")
+            .join(&encoded)
+            .join("agent-transcripts")
+            .join(uuid);
+        fs::create_dir_all(&session_dir).unwrap();
+        fs::write(session_dir.join(format!("{uuid}.txt")), b"").unwrap();
 
         assert!(scan_from(&cursor_dir).unwrap().is_empty());
 


### PR DESCRIPTION
## Problem

`agf` was misrepresenting Cursor CLI sessions in several ways:

1. **No sessions discovered at all.** The scanner walked `~/.cursor/projects/*/agent-transcripts/*.txt` (depth 3, `.txt`), while Cursor's current Composer 2+ format stores transcripts at `~/.cursor/projects/*/agent-transcripts/<uuid>/<uuid>.jsonl` (depth 4, `.jsonl`).
2. **Wrong `store.db` query** for session metadata. `read_store_db` queried `SELECT value FROM cursorDiskKV WHERE key = 'composerData'`, but the actual cursor-agent schema uses a `meta` table with a numeric key: `SELECT value FROM meta WHERE key = '0'`. (The `cursorDiskKV / composerData:*` schema belongs to the Cursor IDE's `state.vscdb`, not the CLI's `store.db` — different stack entirely.)
3. **Blank summaries** when `store.db` had no usable metadata. A fallback parser now extracts the first user prompt from the `.jsonl` transcript.
4. **Orphan over-reporting.** `cursor-agent /resume` only surfaces sessions that have BOTH a transcript AND a matching `store.db` entry under `~/.cursor/chats/<workspace>/<session-id>/`. When cursor-agent reaps that directory (retention, etc.) but leaves the transcript behind, agf was listing dozens of "sessions" that cursor-agent itself refuses to resume. agf now skips these orphans.

## Solution

### `src/scanner/cursor_agent.rs`

- Walk `min_depth(3)..max_depth(4)` in a single pass to cover **both** storage formats:
  - **Legacy** (older Cursor versions): `agent-transcripts/<uuid>.txt` (depth 3)
  - **Current** (Composer 2+): `agent-transcripts/<uuid>/<uuid>.jsonl` (depth 4)
  - Files at unexpected depths or extensions are rejected.
- Fix `read_store_db` to query `SELECT value FROM meta WHERE key = '0'`.
- Add `extract_first_prompt` — reads `.jsonl` line-by-line, finds the first `role: user` text block, strips `<user_info>` / `<user_query>` tags, truncates to 100 chars. Used as fallback when `store.db` has no usable metadata.
- Split `find_store_db_metadata` into `find_store_db_path` + `read_store_db`. For `.jsonl` sessions, skip when no `store.db` exists anywhere under `~/.cursor/chats/` (matches cursor-agent's `/resume` behavior). `.txt` legacy sessions are unaffected.
- Refactor `scan()` → `scan_from(path)` for testability.

### `src/delete.rs`

- Fix `delete_cursor_agent_session` to remove the transcript *directory* (the UUID folder) instead of searching for a `.txt` file.

### `README.md`

- Cursor CLI doc link updated to `https://cursor.com/docs/cli/overview` (the previous `docs.cursor.com/agent` URL no longer resolves).
- Session-source columns now list both the Composer 2+ JSONL layout and the legacy `.txt` layout, and note that `store.db` is the metadata source required for a `.jsonl` session to be resumable.

### Tests

13 unit tests covering:
- `.jsonl` session **with** matching `store.db` is found.
- `.jsonl` session **without** `store.db` (orphan) is skipped — prevents listing sessions that cursor-agent `/resume` won't surface.
- Legacy `.txt` session at depth 3 is found (no `store.db` required).
- `.jsonl` at wrong depth (depth 3, directly in `agent-transcripts/`) is ignored.
- `.txt` at wrong depth (depth 4, inside a UUID subdir) is ignored.
- `var-folders` encoded dirs are skipped.
- `decode_dash_path` resolves and rejects paths correctly.
- `extract_first_prompt` reads `<user_query>` tags, skips `<user_info>` blocks, handles empty JSONL.
- `.jsonl` session with a `store.db` present but no readable `meta` row falls back to the prompt extracted from the transcript.
- Deletion removes transcript directory without affecting siblings.

## Verification (real workspaces)

| Workspace | Transcripts on disk | `chats/<md5(cwd)>/` entries | `cursor-agent /resume` | `agf list` (before) | `agf list` (after) |
|---|---|---|---|---|---|
| Project A (orphaned) | 35 | 0 (empty dir) | "No sessions or cloud agents found." | 35 entries | **0 entries** |
| Project B (healthy)  | 3  | 3 (UUIDs match 1:1)         | shows 3 sessions                     | 3 entries  | 3 entries |

## Background: format history

| Format | Path |
|--------|------|
| Legacy plain-text | `agent-transcripts/<uuid>.txt` |
| Composer 2+ JSONL | `agent-transcripts/<uuid>/<uuid>.jsonl` |

The exact Cursor version that cut over from `.txt` to the nested `.jsonl` layout is not documented in Cursor's public changelog. The `.txt` layout was still observed on Cursor 2.4.7 in early 2026 (per community forum reports), and the Composer 2 JSONL layout is documented externally (e.g. the `getagentseal/codeburn` CHANGELOG, which independently added support for both). agf supports both rather than gating on a version number.