### PR TITLE
fix(shell): default to PowerShell on native Windows without the wrapper

### DIFF
--- a/src/shell.rs
+++ b/src/shell.rs
@@ -15,21 +15,49 @@ pub enum CommandShell {
 }
 
 impl CommandShell {
-    /// Resolve the active shell once per process. The wrapper sets
-    /// `AGF_SHELL` before exec'ing `agf`, so the value never changes for the
-    /// lifetime of this binary — caching avoids per-frame env lookups in the
-    /// TUI render path and per-call lookups in `action.rs`.
+    /// Resolve the active shell once per process. The wrapper sets `AGF_SHELL`
+    /// before exec'ing `agf`; without it we fall back to `default_shell`.
+    /// Cached so the TUI render path and `action.rs` don't re-read env.
     pub fn from_env() -> Self {
         static CACHE: OnceLock<CommandShell> = OnceLock::new();
-        *CACHE.get_or_init(|| Self::from_name(std::env::var("AGF_SHELL").ok().as_deref()))
+        *CACHE.get_or_init(|| match std::env::var("AGF_SHELL").ok().as_deref() {
+            Some(name) if !name.is_empty() => Self::from_name(Some(name)),
+            _ => Self::default_shell(
+                cfg!(windows),
+                std::env::var_os("MSYSTEM").is_some(),
+                std::env::var("SHELL").ok().as_deref(),
+            ),
+        })
     }
 
-    /// Pure helper behind `from_env` — classifies a shell name string.
+    /// Pure helper behind `from_env` — classifies an explicit shell name string.
     /// Exposed so tests can drive it without mutating process env.
     fn from_name(name: Option<&str>) -> Self {
         match name {
             Some("powershell") | Some("pwsh") => Self::PowerShell,
             _ => Self::Posix,
+        }
+    }
+
+    /// Default shell when `AGF_SHELL` is unset. Native Windows needs PowerShell
+    /// (no `sh`, no `&&`); a POSIX layer signals itself via `MSYSTEM` or, for
+    /// ones like Cygwin that don't, a `SHELL` that native shells never export.
+    /// Args are passed in so tests stay pure.
+    fn default_shell(is_windows: bool, msystem: bool, shell: Option<&str>) -> Self {
+        if !is_windows || msystem {
+            return Self::Posix;
+        }
+        // Classify SHELL's basename via `from_name` so shell names live in one place.
+        match shell {
+            Some(s) if !s.is_empty() => {
+                let base = s
+                    .rsplit(['/', '\\'])
+                    .next()
+                    .unwrap_or(s)
+                    .to_ascii_lowercase();
+                Self::from_name(Some(base.trim_end_matches(".exe")))
+            }
+            _ => Self::PowerShell,
         }
     }
 
@@ -335,6 +363,67 @@ mod tests {
         let pwsh = CommandShell::PowerShell;
         assert!(pwsh.is_cd_only("Set-Location '/tmp'"));
         assert!(!pwsh.is_cd_only("Set-Location '/tmp'; if ($?) { claude }"));
+    }
+
+    #[test]
+    fn default_shell_picks_powershell_on_native_windows() {
+        assert_eq!(
+            CommandShell::default_shell(true, false, None),
+            CommandShell::PowerShell
+        );
+    }
+
+    #[test]
+    fn default_shell_honors_posix_layer_on_windows() {
+        assert_eq!(
+            CommandShell::default_shell(true, true, None),
+            CommandShell::Posix
+        );
+        assert_eq!(
+            CommandShell::default_shell(true, false, Some("/usr/bin/bash")),
+            CommandShell::Posix
+        );
+        assert_eq!(
+            CommandShell::default_shell(true, false, Some("/bin/sh")),
+            CommandShell::Posix
+        );
+    }
+
+    #[test]
+    fn default_shell_classifies_shell_as_powershell_only_for_pwsh() {
+        assert_eq!(
+            CommandShell::default_shell(true, false, Some("pwsh")),
+            CommandShell::PowerShell
+        );
+        assert_eq!(
+            CommandShell::default_shell(true, false, Some("/bin/csh")),
+            CommandShell::Posix
+        );
+    }
+
+    #[test]
+    fn default_shell_matches_basename_not_path_substring() {
+        assert_eq!(
+            CommandShell::default_shell(true, false, Some(r"C:\Git\usr\bin\bash.exe")),
+            CommandShell::Posix
+        );
+        assert_eq!(
+            CommandShell::default_shell(true, false, Some(r"C:\Users\bashfan\bin\pwsh.exe")),
+            CommandShell::PowerShell
+        );
+    }
+
+    #[test]
+    fn default_shell_is_posix_off_windows() {
+        assert_eq!(
+            CommandShell::default_shell(false, false, None),
+            CommandShell::Posix
+        );
+        // Even a Windows-looking SHELL must not flip a non-Windows host.
+        assert_eq!(
+            CommandShell::default_shell(false, true, Some("pwsh")),
+            CommandShell::Posix
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Running the bare `agf` binary on Windows — without `agf setup` having installed the wrapper — crashes on any Resume / New Session / Open:

```
PS C:\...> agf
Error: program not found
```

## Cause

`deliver_command` is designed to exec the chosen action directly when no wrapper is present (the wrapper is only strictly needed to persist a bare `cd`). But `from_env` returned `Posix` whenever `AGF_SHELL` was unset — **on every OS**. So on native Windows it generated `cd '...' && claude` and exec'd it via `sh -c`; Windows has no `sh`, so the spawn failed with Rust's Windows `ErrorKind::NotFound`, whose message is literally `program not found`. POSIX hosts were unaffected (`sh` exists), so the intended no-wrapper behavior already worked everywhere except native Windows.

## Why `default_shell`

With `AGF_SHELL` absent there was no shell decision at all — just a blanket POSIX assumption. Fixing the crash means making that case an OS-aware choice (native Windows → PowerShell; Git Bash / MSYS2 / Cygwin → POSIX; else POSIX), which requires reading `MSYSTEM`/`SHELL` and must be unit-testable without mutating process-global env. So it's factored into a small **pure** function `default_shell(is_windows, msystem, shell)`, kept separate from `from_name` (an explicit user-supplied token) to avoid conflating "told us" with "inferred."

## Fix

`from_env` honors `AGF_SHELL` when set, else defers to `default_shell`. On Windows a present `SHELL` signals a POSIX layer (native shells don't export it); its basename is classified through `from_name` so the powershell/pwsh names stay in one place and any other shell is POSIX. The wrapper still sets `AGF_SHELL=powershell`, so the installed path is unchanged — this only fixes the no-wrapper fallback.

| no-wrapper, native Windows | before | after |
|---|---|---|
| Resume / New / Open | crash (`program not found`) | works |
| Cd (dir change only) | warns, doesn't persist | warns, doesn't persist¹ |

¹ Persisting a bare `cd` still requires the wrapper (a child process can't change the parent shell's directory) — unchanged, and this path already hints to run `agf setup`.

## Tests

Pure unit tests for `default_shell`: native Windows → PowerShell, `MSYSTEM`/unix `SHELL` → POSIX, PowerShell-only-for-pwsh, and basename-not-path-substring matching.
