### PR TITLE
chore(homebrew): bump formula to v0.12.0

### DIFF
--- a/homebrew/agf.rb
+++ b/homebrew/agf.rb
@@ -1,22 +1,22 @@
 class Agf < Formula
   desc "AI Agent Session Finder TUI — find, resume, and manage AI coding agent sessions"
   homepage "https://github.com/subinium/agf"
-  version "0.10.0"
+  version "0.12.0"
   license "MIT"
 
   on_macos do
     if Hardware::CPU.arm?
       url "https://github.com/subinium/agf/releases/download/v#{version}/agf-aarch64-apple-darwin.tar.gz"
-      sha256 "9a18208a2b1afc209758a0f91aed185313f5030790efd49f0d0f07955d31a468"
+      sha256 "67c9d62e264bc5805f9101944c54f9de1a11ae0c74c20cb25db9449a8bbea1e1"
     else
       url "https://github.com/subinium/agf/releases/download/v#{version}/agf-x86_64-apple-darwin.tar.gz"
-      sha256 "db084e4202cf9ca0fe199ca9cb1f50c7cffa3abb8a1687e00a12819aec34fb04"
+      sha256 "a0baf7dee812b00622735679c3fe8880cce500a8cadf0c73c52b508126e68b4e"
     end
   end
 
   on_linux do
     url "https://github.com/subinium/agf/releases/download/v#{version}/agf-x86_64-unknown-linux-gnu.tar.gz"
-    sha256 "da3a678be3e8496b55b66198726e97c702969aade0b1e8cbd6a8b7442d31a4c6"
+    sha256 "fd26bf8e6c57c945d98957ff137248cf450f486e53592a90b2bc5d1f04a22e8b"
   end
 
   def install


### PR DESCRIPTION
version 0.10.0 → 0.12.0 with the sha256s from the v0.12.0 release checksums.txt. The in-repo copy was missed during the 0.11.x releases; the tap is updated separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)