### PR TITLE
chore(homebrew): bump formula to v0.13.0

### DIFF
--- a/homebrew/agf.rb
+++ b/homebrew/agf.rb
@@ -1,22 +1,22 @@
 class Agf < Formula
   desc "AI Agent Session Finder TUI — find, resume, and manage AI coding agent sessions"
   homepage "https://github.com/subinium/agf"
-  version "0.12.0"
+  version "0.13.0"
   license "MIT"
 
   on_macos do
     if Hardware::CPU.arm?
       url "https://github.com/subinium/agf/releases/download/v#{version}/agf-aarch64-apple-darwin.tar.gz"
-      sha256 "67c9d62e264bc5805f9101944c54f9de1a11ae0c74c20cb25db9449a8bbea1e1"
+      sha256 "61e4377dc4164fbb1009e467d1cfe1219d32bfa382a99c1b7f6c955576a78ba2"
     else
       url "https://github.com/subinium/agf/releases/download/v#{version}/agf-x86_64-apple-darwin.tar.gz"
-      sha256 "a0baf7dee812b00622735679c3fe8880cce500a8cadf0c73c52b508126e68b4e"
+      sha256 "9bdb2ad5c3ca46150f743ae00fc0848386a24f5cf1f0fe846d667838cb895864"
     end
   end
 
   on_linux do
     url "https://github.com/subinium/agf/releases/download/v#{version}/agf-x86_64-unknown-linux-gnu.tar.gz"
-    sha256 "fd26bf8e6c57c945d98957ff137248cf450f486e53592a90b2bc5d1f04a22e8b"
+    sha256 "11d0d8e43faf051066d391a9b4c7b4dec0418a9d2921ca00bfb8396efc3fe302"
   end
 
   def install


### PR DESCRIPTION
Bumps the Homebrew formula to v0.13.0: version + macOS (arm64/x64) and Linux sha256 taken from the release `checksums.txt`. The arm64 hash was verified locally against the published artifact (`shasum -a 256`), and the extracted binary reports `agf 0.13.0`.