### PR TITLE
release: agf v0.14.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,24 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  msrv:
+    name: MSRV 1.88
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.88.0
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo check --all-targets --all-features --locked
+
+  audit:
+    name: Security audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rustsec/audit-check@v2.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
@@ -23,7 +41,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       # --all-targets matches the local gate (lints tests too); clippy
       # subsumes cargo check, so there is no separate check job.
-      - run: cargo clippy --all-targets --locked -- -D warnings
+      - run: cargo clippy --all-targets --all-features --locked -- -D warnings
 
   fmt:
     name: Format
@@ -42,7 +60,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - run: cargo test --locked
+      - run: cargo test --all-features --locked
 
   windows:
     name: Windows
@@ -54,5 +72,5 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@v2
       # Lint here too so #[cfg(windows)]-gated code is covered.
-      - run: cargo clippy --all-targets --locked -- -D warnings
-      - run: cargo test --locked
+      - run: cargo clippy --all-targets --all-features --locked -- -D warnings
+      - run: cargo test --all-features --locked

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,9 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             artifact: agf-x86_64-unknown-linux-gnu
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-24.04-arm
+            artifact: agf-aarch64-unknown-linux-gnu
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             artifact: agf-x86_64-pc-windows-msvc
@@ -98,8 +101,8 @@ jobs:
           shopt -s nullglob
           files=(*/*.tar.gz */*.zip)
           # Keep in sync with the build matrix size.
-          if [ "${#files[@]}" -ne 4 ]; then
-            echo "expected 4 release archives, found ${#files[@]}: ${files[*]}" >&2
+          if [ "${#files[@]}" -ne 5 ]; then
+            echo "expected 5 release archives, found ${#files[@]}: ${files[*]}" >&2
             exit 1
           fi
           for f in "${files[@]}"; do

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-08-15
+
+### Added
+
+- **Prime Agent support** — discovers flat Prime Agent v3 JSONL sessions, resumes exact IDs with `prime-agent --resume`, honors environment/global session-root settings, and sorts by durable user/assistant activity. Named sessions, git state, and current recap metadata are surfaced. Deletion is fail-closed because upstream exposes no public safe delete command for active daemon sessions.
+- **Kiro v3 support** — discovers metadata/event pairs under `$KIRO_HOME/sessions/cli` in addition to the v2 SQLite store. Kiro resume now uses the selected conversation ID via `--resume-id`.
+- **Codex non-interactive filtering** — subagent and exec threads are hidden by default and can be included with `--include-non-interactive` or the matching setting.
+- Linux ARM64 release artifacts, an MSRV 1.88 CI lane, and a RustSec audit gate.
+
+### Fixed
+
+- Codex scans are now strictly read-only. Partial rollout walks can no longer delete valid rows from Codex-owned SQLite databases.
+- Cache invalidation uses nanosecond/size/path fingerprints, follows deeper Codex stores, and watches SQLite WAL files plus every secondary scanner input. Stale rows remain visible when a refresh fails and failed scans are never cached as successful emptiness.
+- Project View stores stable `(agent, session ID)` identities and rebuilds groups after streamed results, preventing wrong-session actions and out-of-bounds panics. `max_sessions` is now display-only and never truncates persistent cache data.
+- Time, name, and agent sorts use deterministic total ordering; timestamps are normalized globally and legacy Codex activity uses rollout mtime.
+- Exact quick-resume behavior: summary queries work, agent filters push down to one scanner, invalid permission modes fail clearly, and current Codex approval/sandbox flags replace removed aliases.
+- Terminal behavior: non-TTY TUI/watch calls fail cleanly, the session-row mouse offset is correct, shell wrappers preserve agent exit status, cwd-independent Hermes resumes execute, `NO_COLOR`/`TERM=dumb` are honored, and untrusted display metadata cannot emit terminal controls.
+- Deletes use collision-safe atomic writes and exact session matching; Claude append-only history is never rewritten while an agent may be writing it, Gemini duplicates are removed across stores, and Hermes prefix siblings survive.
+- Stats windows are cumulative and future/invalid timestamps are separate. Watch opens from cache immediately, preserves selection by identity, rejects zero intervals, and avoids repeated missing-`pgrep` probes.
+
+### Performance
+
+- Cursor store databases are indexed once instead of scanned once per transcript.
+- Pi, Cursor, Kiro, and Prime Agent JSONL parsing has total and per-line allocation bounds; Kiro v2 previews no longer materialize unlimited conversation blobs.
+- CLI commands reuse fresh per-agent cache entries and scan only stale/requested agents.
+- Text truncation is grapheme-aware, preserving emoji/ZWJ clusters while maintaining terminal-column alignment.
+
+### Changed
+
+- SuperLightTUI 0.20.1 → 0.22.3, including upstream terminal lifecycle, suspend/resume, bidi, and Unicode fixes.
+- Rusqlite is pinned to 0.39.0 so the declared Rust 1.88 MSRV remains buildable; the 0.40 transitive build script currently requires Rust 1.95 without declaring it.
+- Cache schema 8 → 9. Pin and summary state now use composite agent/session identities while legacy bare-ID pins remain readable.
+
 ## [0.13.1] - 2026-07-31
 
 Post-release audit of 0.13.0. No new features and no CLI changes; everything below is a correctness, durability, or performance fix found by reading the 0.13.0 diff and then the rest of the tree.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agf"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -19,6 +19,7 @@ dependencies = [
  "superlighttui",
  "thiserror",
  "toml",
+ "unicode-segmentation",
  "unicode-width",
  "walkdir",
 ]
@@ -84,9 +85,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "autocfg"
@@ -241,9 +242,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -425,17 +426,14 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
-dependencies = [
- "foldhash",
-]
 
 [[package]]
 name = "hashlink"
-version = "0.12.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5081f264ed7adee96ea4b4778b6bb9da0a7228b084587aa3bd3ff05da7c5a3b"
+checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
 dependencies = [
- "hashbrown 0.17.1",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -518,9 +516,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.38.1"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6c19a05435c21ac299d71b6a9c13db3e3f47c520517d58990a462a1397a61db"
+checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
 dependencies = [
  "cc",
  "pkg-config",
@@ -719,9 +717,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.40.1"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11438310b19e3109b6446c33d1ed5e889428cf2e278407bc7896bc4aaea43323"
+checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
 dependencies = [
  "bitflags",
  "fallible-iterator",
@@ -910,13 +908,16 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "superlighttui"
-version = "0.20.1"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1663c34928b1f1e320e42d8cca6b8c32a62510cc42c1940b5c7594d8c31738c0"
+checksum = "db7105405b3927996e82a009277fe2598119a5fdb49ac6644bc92027568be73d"
 dependencies = [
  "compact_str",
  "crossterm",
+ "signal-hook",
  "smallvec",
+ "unicode-bidi",
+ "unicode-segmentation",
  "unicode-width",
 ]
 
@@ -995,6 +996,12 @@ name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "agf"
-version = "0.13.1"
+version = "0.14.0"
 edition = "2024"
 # 1.88 = let-chains (edition 2024); also covers usize::is_multiple_of (1.87).
 rust-version = "1.88"
-description = "Find and resume local AI coding-agent sessions across Claude Code, Codex, Gemini, Cursor CLI, OpenCode, Kiro, pi, Hermes, Oh My Pi, and Yolop"
+description = "Find and resume local AI coding-agent sessions across Claude Code, Codex, Prime Agent, Gemini, Cursor CLI, OpenCode, Kiro, pi, Hermes, Oh My Pi, and Yolop"
 license = "MIT"
 repository = "https://github.com/subinium/agf"
 keywords = ["tui", "cli", "agent", "session", "claude"]
@@ -12,19 +12,22 @@ categories = ["command-line-utilities"]
 readme = "README.md"
 
 [dependencies]
-superlighttui = "0.20"
+superlighttui = "0.22.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-rusqlite = { version = "0.40", features = ["bundled"] }
+# 0.40's libsqlite3-sys currently uses std::cfg_select! (Rust 1.95) without
+# declaring that MSRV. Keep the crate's tested Rust 1.88 floor honest.
+rusqlite = { version = "=0.39.0", features = ["bundled"] }
 nucleo = "0.5"
 clap = { version = "4", features = ["derive"] }
 thiserror = "2"
-anyhow = "1"
+anyhow = "1.0.103"
 dirs = "6"
 chrono = { version = "0.4", features = ["serde"] }
 walkdir = "2"
 rayon = "1"
 unicode-width = "0.2"
+unicode-segmentation = "1.12"
 toml = "1"
 sha2 = "0.10"
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 > Find the AI coding session you meant to resume.
 
 `agf` is a local-first fuzzy finder for AI coding-agent sessions.
-Search local sessions across **Claude Code**, **Codex**, **Gemini CLI**, **Cursor CLI**, **OpenCode**, **Kiro**, **pi**, and **Hermes** — then resume the right one in a keystroke.
+Search local sessions across **Claude Code**, **Codex**, **Prime Agent**, **Gemini CLI**, **Cursor CLI**, **OpenCode**, **Kiro**, **pi**, and **Hermes** — then resume the right one in a keystroke.
 
 ![agf demo](./assets/demo.gif)
 
@@ -45,10 +45,11 @@ Then you either dig through history files or start over.
 |:---|:---|:---|
 | [Claude Code](https://github.com/anthropics/claude-code) | `claude --resume <id>` | `~/.claude/history.jsonl` + `~/.claude/projects/` |
 | [Codex](https://github.com/openai/codex) | `codex resume <id>` | `~/.codex/sessions/**/*.jsonl` |
+| [Prime Agent](https://github.com/PrimeIntellect-ai/prime-agent) | `prime-agent --resume <id>` | `~/.prime/agent/sessions/<id>.jsonl` |
 | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `gemini --resume <id>` | `~/.gemini/tmp/<project>/chats/session-*.json` |
 | [Cursor CLI](https://cursor.com/docs/cli/overview) | `cursor-agent --resume <id>` | `~/.cursor/projects/*/agent-transcripts/<id>/<id>.jsonl` (Composer 2+)<br>`~/.cursor/projects/*/agent-transcripts/<id>.txt` (legacy) |
 | [OpenCode](https://github.com/opencode-ai/opencode) | `opencode -s <id>` | `~/.local/share/opencode/opencode.db` |
-| [Kiro](https://kiro.dev) | `kiro-cli chat --resume` *(no per-session resume — always opens the latest session for the cwd)* | `~/Library/Application Support/kiro-cli/data.sqlite3` |
+| [Kiro](https://kiro.dev) | `kiro-cli chat --resume-id <id>` | Kiro v2 SQLite + Kiro v3 `~/.kiro/sessions/cli/` |
 | [pi](https://github.com/badlogic/pi-mono) | `pi --session <id>` | `~/.pi/agent/sessions/<cwd>/*.jsonl` |
 | [Hermes](https://github.com/NousResearch/hermes-agent) | `hermes --resume <id>` *(cwd-independent — resumes in your current shell directory)* | `~/.hermes/state.db` |
 | [Oh My Pi](https://github.com/can1357/oh-my-pi) | `omp --resume <id>` | `~/.omp/agent/sessions/<cwd>/*.jsonl` |
@@ -61,10 +62,11 @@ Then you either dig through history files or start over.
 |:---|:---|:---|
 | Claude Code | JSONL | `~/.claude/history.jsonl` (sessions)<br>`~/.claude/projects/*/` (worktree detection) |
 | Codex | JSONL | `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl` |
+| Prime Agent | JSONL | `~/.prime/agent/sessions/<id>.jsonl` (also honors Prime Agent environment/global settings overrides) |
 | OpenCode | SQLite | `~/.local/share/opencode/opencode.db` |
 | pi | JSONL | `~/.pi/agent/sessions/--<encoded-cwd>--/<ts>_<id>.jsonl` |
 | Oh My Pi | JSONL | `~/.omp/agent/sessions/<encoded-cwd>/<ts>_<id>.jsonl` |
-| Kiro | SQLite | macOS: `~/Library/Application Support/kiro-cli/data.sqlite3`<br>Linux: `~/.local/share/kiro-cli/data.sqlite3` |
+| Kiro | SQLite + JSON/JSONL | v2: macOS `~/Library/Application Support/kiro-cli/data.sqlite3`, Linux `~/.local/share/kiro-cli/data.sqlite3`<br>v3: `$KIRO_HOME/sessions/cli/` or `~/.kiro/sessions/cli/` |
 | Cursor CLI | SQLite + JSONL/TXT | `~/.cursor/chats/<workspace>/<id>/store.db` (metadata; required for `.jsonl` to be resumable)<br>`~/.cursor/projects/*/agent-transcripts/<id>/<id>.jsonl` (Composer 2+ transcript)<br>`~/.cursor/projects/*/agent-transcripts/<id>.txt` (legacy transcript) |
 | Gemini | JSON | `~/.gemini/tmp/<project>/chats/session-<date>-<id>.json`<br>`<project>` is a named dir or SHA-256 hash of the project path<br>Project paths resolved via `~/.gemini/projects.json` |
 | Hermes | SQLite | `~/.hermes/state.db` (sessions + messages)<br>JSON dumps in `~/.hermes/sessions/session_<id>.json`<br>Hermes is cwd-independent — resume runs in your current shell directory |
@@ -143,13 +145,14 @@ sort_by = "time"            # "time" | "name" | "agent"
 max_sessions = 200
 search_scope = "name_path"  # "name_path" (default) | "all" (include summaries)
 summary_search_count = 5    # number of summaries included when search_scope = "all"
+include_non_interactive = false # show Codex subagent/exec threads
 ```
 
 You can also edit `search_scope` and `summary_search_count` interactively by pressing `?` in the TUI.
 
 ## Shell integration
 
-`agf setup` auto-detects your shell and installs the wrapper. Supported shells:
+`agf setup` auto-detects your shell and installs the wrapper. Use `agf setup --shell powershell` (or another supported shell) when auto-detection is ambiguous.
 
 - **zsh / bash** — appends to `~/.zshrc` or `~/.bashrc`
 - **fish** — writes to `~/.config/fish/config.fish`
@@ -170,7 +173,7 @@ See [CHANGELOG.md](CHANGELOG.md) for release notes.
 ## Requirements
 
 - macOS, Linux, or Windows (PowerShell 5.1+ / PowerShell 7+)
-- One or more of: `claude`, `codex`, `opencode`, `pi`, `kiro-cli`, `cursor-agent`, `gemini`, `hermes`, `omp`, `yolop`
+- One or more of: `claude`, `codex`, `prime-agent`, `opencode`, `pi`, `kiro-cli`, `cursor-agent`, `gemini`, `hermes`, `omp`, `yolop`
 
 ## Install from source
 
@@ -184,6 +187,8 @@ agf setup
 ## Limitations
 
 `agf` works best with agents that store resumable sessions locally.
+
+Prime Agent session discovery and resume are supported, but deletion is intentionally disabled: Prime Agent has no public session-delete command and direct file deletion would bypass its active-daemon guard.
 
 **Amp** is not supported yet because its sessions are stored remotely, which makes it hard to reliably resolve local project paths from session metadata. We are monitoring upstream changes and will add support when feasible.
 

--- a/docs/adding-an-agent.md
+++ b/docs/adding-an-agent.md
@@ -40,12 +40,12 @@ Say the new agent is `Foo`, CLI `foo`, sessions under `~/.foo/sessions/`.
    - Bound reads on large transcripts with the shared `read_head_tail` / bounded-read
      helpers in `scanner/mod.rs`; never slurp multi-MB logs whole.
    - Skip malformed lines, don't panic on bad input.
-   - Register the module in **`src/scanner/mod.rs`**: add `pub mod foo;` **and** a
-     `thread::spawn(|| foo::scan().unwrap_or_default())` line in `scan_all()`
-     *(plain `Vec` — the compiler won't remind you)*.
+   - Register the module in **`src/scanner/mod.rs`**: add `pub mod foo;` and an
+     `Agent::Foo => foo::scan()` arm in `scan_agent()`. Do not erase errors into
+     empty success; stale cache rows are retained when a scanner fails.
 
-4. **`src/cache.rs`** — add the `Agent::Foo => scanner::foo::scan().unwrap_or_default()`
-   arm in `start_stale_scan()`. Bump `CACHE_VERSION` only if the cached payload
+4. **`src/cache.rs`** — no agent-specific dispatch is required; workers call the
+   common `scanner::scan_agent()`. Ensure `Session` cache fields round-trip. Bump `CACHE_VERSION` only if the cached payload
    *shape* can change within a single released package version (a new agent key
    alone doesn't require it — the `agf_version` stamp forces a rescan on upgrade).
 
@@ -69,14 +69,14 @@ Say the new agent is `Foo`, CLI `foo`, sessions under `~/.foo/sessions/`.
 
 ```bash
 cargo test --locked
-cargo clippy --locked --all-targets -- -D warnings
+cargo clippy --locked --all-targets --all-features -- -D warnings
 cargo fmt --all -- --check
 # Real-data smoke test (scans all agents regardless of install):
 AGF_DEBUG=1 cargo run -- list --agent foo --format json
 ```
 
-`agf list` runs every scanner unconditionally, so you can verify `foo` against a
-fixture `$HOME` without installing the CLI:
+An explicit `--agent foo` scans only Foo when its cache entry is stale, so you
+can verify it against a fixture `$HOME` without installing the other CLIs:
 
 ```bash
 HOME=/tmp/agf-fixture cargo run -- list --agent foo --format json

--- a/src/action.rs
+++ b/src/action.rs
@@ -12,7 +12,8 @@ pub fn generate_command(
     match action {
         Action::Resume => {
             let cmd = session.agent.resume_cmd(&session.session_id, &shell);
-            Some(shell.cd_and(&quoted_path, &cmd))
+            let resume_path = resume_launch_path(session);
+            Some(shell.cd_and(&shell.quote(resume_path), &cmd))
         }
         Action::NewSession => {
             let agent = new_agent.unwrap_or(session.agent);
@@ -83,9 +84,22 @@ pub fn detect_editor() -> String {
 
 pub fn resume_with_flags(session: &Session, flags: &str) -> String {
     let shell = CommandShell::from_env();
-    let quoted_path = shell.quote(&session.project_path);
+    let quoted_path = shell.quote(resume_launch_path(session));
     let base_cmd = session.agent.resume_cmd(&session.session_id, &shell);
     shell.cd_and(&quoted_path, &format!("{base_cmd}{flags}"))
+}
+
+fn resume_launch_path(session: &Session) -> &str {
+    if session.agent == Agent::PrimeAgent
+        && !session.project_path.is_empty()
+        && !std::path::Path::new(&session.project_path).is_dir()
+    {
+        // Prime Agent can resolve/fork an ID from another cwd. A guaranteed
+        // failing `cd` prevents its own recovery prompt from running at all.
+        ""
+    } else {
+        &session.project_path
+    }
 }
 
 pub fn new_session_with_flags(session: &Session, agent: Agent, flags: &str) -> String {
@@ -111,6 +125,7 @@ mod tests {
             git_branch: None,
             worktree: None,
             recap: None,
+            interactive: true,
         }
     }
 
@@ -140,6 +155,16 @@ mod tests {
         assert_eq!(
             action_preview(&session(""), Action::Cd),
             "no project directory"
+        );
+    }
+
+    #[test]
+    fn prime_resume_skips_a_deleted_stored_cwd() {
+        let mut s = session("/definitely/missing/agf-prime-project");
+        s.agent = Agent::PrimeAgent;
+        assert_eq!(
+            generate_command(&s, Action::Resume, None).unwrap(),
+            "prime-agent --resume 'sid'"
         );
     }
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -593,12 +593,16 @@ mod tests {
         let mut file = std::fs::File::create(&path).unwrap();
         file.write_all(b"a").unwrap();
         file.set_modified(
-            SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000) + Duration::from_nanos(1),
+            SystemTime::UNIX_EPOCH
+                + Duration::from_secs(1_700_000_000)
+                + Duration::from_millis(100),
         )
         .unwrap();
         let first = source_fingerprint(std::slice::from_ref(&path));
         file.set_modified(
-            SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000) + Duration::from_nanos(2),
+            SystemTime::UNIX_EPOCH
+                + Duration::from_secs(1_700_000_000)
+                + Duration::from_millis(200),
         )
         .unwrap();
         let second = source_fingerprint(std::slice::from_ref(&path));

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -56,7 +56,7 @@ use crate::model::{Agent, Session};
 // - Yolop timestamps are now clamped to a plausible window, so persisted
 //   far-future values must not survive the upgrade and keep pinning sessions
 //   to the top of the time sort.
-const CACHE_VERSION: u32 = 8;
+const CACHE_VERSION: u32 = 9;
 
 /// The binary version stamped into every cache write; any mismatch on read
 /// invalidates the whole cache (see `parse_cache`).
@@ -75,8 +75,22 @@ struct CacheFile {
 
 #[derive(Debug, Serialize, Deserialize)]
 struct AgentCache {
-    mtime: u64, // Unix seconds of data source last modification
+    fingerprint: SourceFingerprint,
     sessions: Vec<CachedSession>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct SourceFingerprint {
+    /// Lexical source identity catches configurable-root changes even when two
+    /// directories happen to have identical metadata.
+    sources: Vec<String>,
+    newest_mtime_ns: u64,
+    total_size: u64,
+    entries: u64,
+    /// Stable digest of every entry's path, type, mtime, and size. Aggregate
+    /// maxima/totals alone miss a same-size edit to an older file whenever a
+    /// different file still owns the newest mtime.
+    digest: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -90,6 +104,12 @@ struct CachedSession {
     git_branch: Option<String>,
     worktree: Option<String>,
     recap: Option<String>,
+    #[serde(default = "default_true")]
+    interactive: bool,
+}
+
+const fn default_true() -> bool {
+    true
 }
 
 fn cache_path() -> PathBuf {
@@ -97,6 +117,40 @@ fn cache_path() -> PathBuf {
         .unwrap_or_else(|| dirs::home_dir().unwrap_or_default().join(".cache"))
         .join("agf")
         .join("sessions.json")
+}
+
+struct CacheWriteLock(PathBuf);
+
+impl CacheWriteLock {
+    fn acquire(path: PathBuf) -> std::io::Result<Self> {
+        for _ in 0..200 {
+            match fs::create_dir(&path) {
+                Ok(()) => return Ok(Self(path)),
+                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                    let stale = fs::metadata(&path)
+                        .and_then(|metadata| metadata.modified())
+                        .and_then(|modified| modified.elapsed().map_err(std::io::Error::other))
+                        .is_ok_and(|age| age > std::time::Duration::from_secs(300));
+                    if stale {
+                        let _ = fs::remove_dir(&path);
+                        continue;
+                    }
+                    std::thread::sleep(std::time::Duration::from_millis(10));
+                }
+                Err(error) => return Err(error),
+            }
+        }
+        Err(std::io::Error::new(
+            std::io::ErrorKind::WouldBlock,
+            "timed out waiting for cache write lock",
+        ))
+    }
+}
+
+impl Drop for CacheWriteLock {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir(&self.0);
+    }
 }
 
 /// True when the `AGF_DEBUG` env var is set (any value), probed once per process.
@@ -116,6 +170,7 @@ fn to_cached(s: &Session) -> CachedSession {
         git_branch: s.git_branch.clone(),
         worktree: s.worktree.clone(),
         recap: s.recap.clone(),
+        interactive: s.interactive,
     }
 }
 
@@ -126,35 +181,79 @@ fn from_cached(c: &CachedSession) -> Session {
         project_name: c.project_name.clone(),
         project_path: c.project_path.clone(),
         summaries: c.summaries.clone(),
-        timestamp: c.timestamp,
+        timestamp: crate::model::normalize_timestamp(c.timestamp, 0),
         git_branch: c.git_branch.clone(),
         worktree: c.worktree.clone(),
         recap: c.recap.clone(),
+        interactive: c.interactive,
     }
 }
 
-fn get_max_mtime(paths: &[PathBuf]) -> u64 {
+fn source_fingerprint(paths: &[PathBuf]) -> SourceFingerprint {
+    use sha2::{Digest, Sha256};
     use walkdir::WalkDir;
-    let mut max = 0u64;
+    let mut fingerprint = SourceFingerprint {
+        sources: paths
+            .iter()
+            .map(|path| path.to_string_lossy().into_owned())
+            .collect(),
+        ..SourceFingerprint::default()
+    };
+    fingerprint.sources.sort();
+    let mut entry_fingerprints = Vec::new();
     for p in paths {
         if !p.exists() {
             continue;
         }
         for entry in WalkDir::new(p)
-            .max_depth(4)
+            .max_depth(8)
             .follow_links(false)
             .into_iter()
             .filter_map(|e| e.ok())
         {
-            if let Ok(m) = entry.metadata()
-                && let Ok(t) = m.modified()
-                && let Ok(d) = t.duration_since(std::time::SystemTime::UNIX_EPOCH)
-            {
-                max = max.max(d.as_secs());
+            if let Ok(m) = entry.metadata() {
+                let mtime_ns = m
+                    .modified()
+                    .ok()
+                    .and_then(|time| time.duration_since(std::time::SystemTime::UNIX_EPOCH).ok())
+                    .map(|duration| u64::try_from(duration.as_nanos()).unwrap_or(u64::MAX))
+                    .unwrap_or(0);
+                fingerprint.newest_mtime_ns = fingerprint.newest_mtime_ns.max(mtime_ns);
+                fingerprint.total_size = fingerprint.total_size.saturating_add(m.len());
+                fingerprint.entries = fingerprint.entries.saturating_add(1);
+                let file_type = if m.is_dir() {
+                    1
+                } else if m.is_file() {
+                    2
+                } else if m.file_type().is_symlink() {
+                    3
+                } else {
+                    4
+                };
+                entry_fingerprints.push((
+                    entry.path().to_string_lossy().into_owned(),
+                    file_type,
+                    mtime_ns,
+                    m.len(),
+                ));
             }
         }
     }
-    max
+    entry_fingerprints.sort_unstable();
+    let mut hasher = Sha256::new();
+    for (path, file_type, mtime_ns, size) in entry_fingerprints {
+        hasher.update((path.len() as u64).to_le_bytes());
+        hasher.update(path.as_bytes());
+        hasher.update([file_type]);
+        hasher.update(mtime_ns.to_le_bytes());
+        hasher.update(size.to_le_bytes());
+    }
+    fingerprint.digest = format!("{:x}", hasher.finalize());
+    fingerprint
+}
+
+pub(crate) fn agent_fingerprint(agent: Agent) -> SourceFingerprint {
+    source_fingerprint(&config::data_sources(agent))
 }
 
 /// Validate raw cache-file content. The cache is usable only when (a) it
@@ -190,7 +289,7 @@ pub fn load_cache() -> (Vec<Session>, Vec<Agent>) {
     let path = cache_path();
     let content = match fs::read_to_string(&path) {
         Ok(c) => c,
-        Err(_) => return (Vec::new(), Agent::all().to_vec()),
+        Err(_) => return (Vec::new(), config::installed_agents()),
     };
 
     let cache = match parse_cache(&content, AGF_VERSION) {
@@ -199,7 +298,7 @@ pub fn load_cache() -> (Vec<Session>, Vec<Agent>) {
             if debug_enabled() {
                 eprintln!("[agf] {why} → rescanning");
             }
-            return (Vec::new(), Agent::all().to_vec());
+            return (Vec::new(), config::installed_agents());
         }
     };
 
@@ -207,20 +306,22 @@ pub fn load_cache() -> (Vec<Session>, Vec<Agent>) {
     let mut stale = Vec::new();
 
     for agent in config::installed_agents() {
-        let current_mtime = get_max_mtime(&config::data_sources(agent));
+        let current_fingerprint = source_fingerprint(&config::data_sources(agent));
 
         match cache.agents.get(&agent) {
-            Some(ac) if ac.mtime >= current_mtime && current_mtime > 0 => {
-                // Cache is fresh
+            Some(ac) => {
+                // Stale-while-revalidate: cached payload remains visible until
+                // a successful worker result replaces it.
                 sessions.extend(ac.sessions.iter().map(from_cached));
+                if ac.fingerprint != current_fingerprint {
+                    stale.push(agent);
+                }
             }
-            _ => {
-                stale.push(agent);
-            }
+            None => stale.push(agent),
         }
     }
 
-    sessions.sort_by_key(|s| std::cmp::Reverse(s.timestamp));
+    sessions.sort_by(|a, b| crate::model::compare_sessions(a, b, crate::model::SortMode::Time));
     (sessions, stale)
 }
 
@@ -231,33 +332,55 @@ pub fn load_cache() -> (Vec<Session>, Vec<Agent>) {
 /// we preserve the prior cache entry verbatim so we don't accidentally
 /// persist an empty session list with a fresh `mtime`, which would mark the
 /// agent "fresh" on the next launch and hide its sessions.
-pub fn write_cache(sessions: &[Session], skip_agents: &std::collections::HashSet<Agent>) {
+pub fn write_cache(
+    sessions: &[Session],
+    skip_agents: &std::collections::HashSet<Agent>,
+    invalidate_agents: &std::collections::HashSet<Agent>,
+    observed_fingerprints: &HashMap<Agent, SourceFingerprint>,
+) {
     let path = cache_path();
     if let Some(parent) = path.parent() {
         let _ = fs::create_dir_all(parent);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = fs::set_permissions(parent, fs::Permissions::from_mode(0o700));
+        }
     }
+    let lock_path = path.with_file_name(".sessions-write.lock");
+    let Ok(_write_lock) = CacheWriteLock::acquire(lock_path) else {
+        return;
+    };
 
     let mut agents: HashMap<Agent, AgentCache> = HashMap::new();
 
-    // Carry over prior cache entries for in-flight agents. `parse_cache`
+    // Start from prior entries. Agents not scanned by this process must remain
+    // byte-for-byte associated with the fingerprint they were loaded under;
+    // recomputing a newer fingerprint beside old payload would make stale data
+    // appear fresh after an append-vs-exit race.
     // gates this on schema AND binary version: entries written by another
     // binary are exactly the stale data issue #37 is about, so on upgrade we
     // drop them and let the next launch rescan those agents instead.
-    if !skip_agents.is_empty()
-        && let Ok(content) = fs::read_to_string(&path)
+    if let Ok(content) = fs::read_to_string(&path)
         && let Ok(mut prior) = parse_cache(&content, AGF_VERSION)
     {
-        for skip in skip_agents {
-            // `prior` is owned and dropped right after this block, so move
-            // the carried-over entries out instead of cloning them.
-            if let Some(entry) = prior.agents.remove(skip) {
-                agents.insert(*skip, entry);
-            }
-        }
+        agents.extend(prior.agents.drain());
+    }
+    for agent in invalidate_agents {
+        agents.remove(agent);
     }
 
     for agent in config::installed_agents() {
-        if skip_agents.contains(&agent) {
+        if skip_agents.contains(&agent) || invalidate_agents.contains(&agent) {
+            continue;
+        }
+        let Some(observed) = observed_fingerprints.get(&agent) else {
+            continue;
+        };
+        // A source changed after the worker's final fingerprint and before
+        // cache persistence. Preserve the prior stale entry; the next launch
+        // will rescan instead of blessing pre-change payload as current.
+        if &agent_fingerprint(agent) != observed {
             continue;
         }
         let agent_sessions: Vec<CachedSession> = sessions
@@ -265,11 +388,10 @@ pub fn write_cache(sessions: &[Session], skip_agents: &std::collections::HashSet
             .filter(|s| s.agent == agent)
             .map(to_cached)
             .collect();
-        let mtime = get_max_mtime(&config::data_sources(agent));
         agents.insert(
             agent,
             AgentCache {
-                mtime,
+                fingerprint: observed.clone(),
                 sessions: agent_sessions,
             },
         );
@@ -284,14 +406,20 @@ pub fn write_cache(sessions: &[Session], skip_agents: &std::collections::HashSet
     if let Ok(json) = serde_json::to_string(&cache) {
         // Best-effort: a cache we failed to persist just costs the next launch
         // a rescan, so there is nothing actionable to report here.
-        let _ = crate::fsx::write_atomic(&path, json.as_bytes());
+        if crate::fsx::write_atomic(&path, json.as_bytes()).is_ok() {
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let _ = fs::set_permissions(&path, fs::Permissions::from_mode(0o600));
+            }
+        }
     }
 }
 
 /// One agent's scan result, streamed back from a worker thread.
 pub struct ScanResult {
     pub agent: Agent,
-    pub sessions: Vec<Session>,
+    pub sessions: Result<crate::scanner::CompletedScan, String>,
 }
 
 /// Spawn one worker thread per stale agent. Each worker sends its result on
@@ -319,25 +447,24 @@ pub fn start_stale_scan(stale: &[Agent]) -> std::sync::mpsc::Receiver<ScanResult
         let tx = tx.clone();
         thread::spawn(move || {
             let start = Instant::now();
-            let sessions = match agent {
-                Agent::ClaudeCode => crate::scanner::claude::scan().unwrap_or_default(),
-                Agent::Codex => crate::scanner::codex::scan().unwrap_or_default(),
-                Agent::OpenCode => crate::scanner::opencode::scan().unwrap_or_default(),
-                Agent::Pi => crate::scanner::pi::scan().unwrap_or_default(),
-                Agent::OhMyPi => crate::scanner::oh_my_pi::scan().unwrap_or_default(),
-                Agent::Kiro => crate::scanner::kiro::scan().unwrap_or_default(),
-                Agent::CursorAgent => crate::scanner::cursor_agent::scan().unwrap_or_default(),
-                Agent::Gemini => crate::scanner::gemini::scan().unwrap_or_default(),
-                Agent::Hermes => crate::scanner::hermes::scan().unwrap_or_default(),
-                Agent::Yolop => crate::scanner::yolop::scan().unwrap_or_default(),
-            };
+            let sessions =
+                std::panic::catch_unwind(|| crate::scanner::scan_agent_consistent(agent))
+                    .map_err(|_| "scanner panicked".to_string())
+                    .and_then(|result| result);
             if debug {
-                eprintln!(
-                    "[agf] {:?} scan: {} sessions in {:?}",
-                    agent,
-                    sessions.len(),
-                    start.elapsed()
-                );
+                match &sessions {
+                    Ok(scan) => eprintln!(
+                        "[agf] {:?} scan: {} sessions in {:?}",
+                        agent,
+                        scan.sessions.len(),
+                        start.elapsed()
+                    ),
+                    Err(error) => eprintln!(
+                        "[agf] {:?} scan failed in {:?}: {error}",
+                        agent,
+                        start.elapsed()
+                    ),
+                }
             }
             // Receiver dropped (TUI exited): silently ignore.
             let _ = tx.send(ScanResult { agent, sessions });
@@ -351,6 +478,18 @@ pub fn start_stale_scan(stale: &[Agent]) -> std::sync::mpsc::Receiver<ScanResult
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Write;
+    use std::time::{Duration, SystemTime};
+
+    fn temp_source(label: &str) -> PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "agf-cache-{label}-{}-{}",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("unnamed")
+        ));
+        let _ = std::fs::remove_file(&path);
+        path
+    }
 
     fn cache_json(version: u32, agf_version: Option<&str>) -> String {
         let mut v = serde_json::json!({
@@ -412,7 +551,13 @@ mod tests {
         agents.insert(
             Agent::ClaudeCode,
             AgentCache {
-                mtime: 42,
+                fingerprint: SourceFingerprint {
+                    sources: vec!["/source".to_string()],
+                    newest_mtime_ns: 42,
+                    total_size: 7,
+                    entries: 1,
+                    digest: "fixture".to_string(),
+                },
                 sessions: vec![CachedSession {
                     agent: Agent::ClaudeCode,
                     session_id: "sid".to_string(),
@@ -423,6 +568,7 @@ mod tests {
                     git_branch: Some("main".to_string()),
                     worktree: None,
                     recap: None,
+                    interactive: true,
                 }],
             },
         );
@@ -437,10 +583,86 @@ mod tests {
 
         let parsed = parse_cache(&json, AGF_VERSION).expect("round-trip parse");
         let entry = &parsed.agents[&Agent::ClaudeCode];
-        assert_eq!(entry.mtime, 42);
+        assert_eq!(entry.fingerprint.newest_mtime_ns, 42);
+        assert_eq!(entry.fingerprint.digest, "fixture");
         assert_eq!(entry.sessions.len(), 1);
         assert_eq!(entry.sessions[0].agent, Agent::ClaudeCode);
         assert_eq!(entry.sessions[0].session_id, "sid");
         assert_eq!(entry.sessions[0].git_branch.as_deref(), Some("main"));
+    }
+
+    #[test]
+    fn fingerprint_distinguishes_changes_within_one_second() {
+        let path = temp_source("nanoseconds");
+        let mut file = std::fs::File::create(&path).unwrap();
+        file.write_all(b"a").unwrap();
+        file.set_modified(
+            SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000) + Duration::from_nanos(1),
+        )
+        .unwrap();
+        let first = source_fingerprint(std::slice::from_ref(&path));
+        file.set_modified(
+            SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000) + Duration::from_nanos(2),
+        )
+        .unwrap();
+        let second = source_fingerprint(std::slice::from_ref(&path));
+        assert_ne!(first, second);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn fingerprint_includes_source_identity_and_wal_size() {
+        let db = temp_source("db");
+        let wal = temp_source("db-wal");
+        std::fs::write(&db, b"db").unwrap();
+        let before = source_fingerprint(&[db.clone(), wal.clone()]);
+        std::fs::write(&wal, b"new wal contents").unwrap();
+        let after = source_fingerprint(&[db.clone(), wal.clone()]);
+        assert_ne!(before, after);
+        let other = source_fingerprint(std::slice::from_ref(&db));
+        assert_ne!(after.sources, other.sources);
+        let _ = std::fs::remove_file(db);
+        let _ = std::fs::remove_file(wal);
+    }
+
+    #[test]
+    fn fingerprint_detects_same_size_edit_to_non_newest_entry() {
+        let dir = temp_source("non-newest");
+        std::fs::create_dir_all(&dir).unwrap();
+        let older = dir.join("older");
+        let newest = dir.join("newest");
+        std::fs::write(&older, b"old").unwrap();
+        std::fs::write(&newest, b"top").unwrap();
+        let base = SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000);
+        std::fs::File::options()
+            .write(true)
+            .open(&older)
+            .unwrap()
+            .set_modified(base + Duration::from_secs(1))
+            .unwrap();
+        std::fs::File::options()
+            .write(true)
+            .open(&newest)
+            .unwrap()
+            .set_modified(base + Duration::from_secs(3))
+            .unwrap();
+        let first = source_fingerprint(std::slice::from_ref(&dir));
+
+        // Same total size and still older than `newest`: aggregate
+        // newest-mtime/size/count fingerprints cannot see this change.
+        std::fs::write(&older, b"new").unwrap();
+        std::fs::File::options()
+            .write(true)
+            .open(&older)
+            .unwrap()
+            .set_modified(base + Duration::from_secs(2))
+            .unwrap();
+        let second = source_fingerprint(std::slice::from_ref(&dir));
+
+        assert_eq!(first.newest_mtime_ns, second.newest_mtime_ns);
+        assert_eq!(first.total_size, second.total_size);
+        assert_eq!(first.entries, second.entries);
+        assert_ne!(first.digest, second.digest);
+        let _ = std::fs::remove_dir_all(dir);
     }
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -482,11 +482,7 @@ mod tests {
     use std::time::{Duration, SystemTime};
 
     fn temp_source(label: &str) -> PathBuf {
-        let path = std::env::temp_dir().join(format!(
-            "agf-cache-{label}-{}-{}",
-            std::process::id(),
-            std::thread::current().name().unwrap_or("unnamed")
-        ));
+        let path = std::env::temp_dir().join(format!("agf-cache-{label}-{}", std::process::id()));
         let _ = std::fs::remove_file(&path);
         path
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -47,6 +47,89 @@ pub fn yolop_sessions_dir() -> Result<PathBuf, AgfError> {
         .ok_or(AgfError::NoDataDir)
 }
 
+pub fn prime_agent_dir() -> Result<PathBuf, AgfError> {
+    if let Some(path) = std::env::var_os("PRIME_AGENT_CODING_AGENT_DIR")
+        && !path.is_empty()
+    {
+        return expand_tilde(PathBuf::from(path));
+    }
+    Ok(home_dir()?.join(".prime/agent"))
+}
+
+pub fn prime_sessions_dir() -> Result<PathBuf, AgfError> {
+    for key in [
+        "PRIME_AGENT_SESSION_DIR",
+        "PRIME_AGENT_CODING_AGENT_SESSION_DIR",
+    ] {
+        if let Some(path) = std::env::var_os(key)
+            && !path.is_empty()
+        {
+            return resolve_configured_path(PathBuf::from(path));
+        }
+    }
+
+    let agent_dir = prime_agent_dir()?;
+    let cwd = std::env::current_dir()?;
+    prime_sessions_dir_from_settings(&agent_dir, &cwd)
+}
+
+fn prime_sessions_dir_from_settings(
+    agent_dir: &std::path::Path,
+    cwd: &std::path::Path,
+) -> Result<PathBuf, AgfError> {
+    let global = agent_dir.join("settings.json");
+    let project = cwd.join(".prime/agent/settings.json");
+    // Prime Agent merges project settings over global settings. Keep the last
+    // configured value so a project-local sessionDir gets the same precedence.
+    let configured = [global, project]
+        .into_iter()
+        .rev()
+        .find_map(|settings_path| {
+            let content = std::fs::read_to_string(&settings_path).ok()?;
+            let settings = serde_json::from_str::<serde_json::Value>(&content).ok()?;
+            settings
+                .get("sessionDir")
+                .and_then(|value| value.as_str())
+                .map(str::trim)
+                .filter(|path| !path.is_empty())
+                .map(PathBuf::from)
+        });
+    match configured {
+        // Prime expands `~` in SettingsManager but otherwise passes relative
+        // paths unchanged to Node's filesystem APIs, so both global and
+        // project settings resolve from the agent process cwd.
+        Some(path) => resolve_configured_path_from(path, cwd),
+        None => Ok(agent_dir.join("sessions")),
+    }
+}
+
+fn resolve_configured_path(path: PathBuf) -> Result<PathBuf, AgfError> {
+    let cwd = std::env::current_dir()?;
+    resolve_configured_path_from(path, &cwd)
+}
+
+fn resolve_configured_path_from(path: PathBuf, cwd: &std::path::Path) -> Result<PathBuf, AgfError> {
+    let expanded = expand_tilde(path)?;
+    if expanded.is_absolute() {
+        Ok(expanded)
+    } else {
+        Ok(cwd.join(expanded))
+    }
+}
+
+fn expand_tilde(path: PathBuf) -> Result<PathBuf, AgfError> {
+    let Some(text) = path.to_str() else {
+        return Ok(path);
+    };
+    if text == "~" {
+        return home_dir();
+    }
+    if let Some(rest) = text.strip_prefix("~/") {
+        return Ok(home_dir()?.join(rest));
+    }
+    Ok(path)
+}
+
 pub fn kiro_data_dir() -> Result<PathBuf, AgfError> {
     // Kiro CLI stores data via dirs::data_local_dir()
     // macOS: ~/Library/Application Support/kiro-cli/
@@ -54,6 +137,26 @@ pub fn kiro_data_dir() -> Result<PathBuf, AgfError> {
     dirs::data_local_dir()
         .map(|d| d.join("kiro-cli"))
         .ok_or(AgfError::NoDataDir)
+}
+
+pub fn kiro_sessions_dir() -> Result<PathBuf, AgfError> {
+    let home = std::env::var_os("KIRO_HOME")
+        .filter(|path| !path.is_empty())
+        .map(PathBuf::from)
+        .map(expand_tilde)
+        .transpose()?
+        .unwrap_or(home_dir()?.join(".kiro"));
+    Ok(home.join("sessions/cli"))
+}
+
+fn sqlite_sources(path: PathBuf) -> Vec<PathBuf> {
+    let wal = path.with_file_name(format!(
+        "{}-wal",
+        path.file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or_default()
+    ));
+    vec![path, wal]
 }
 
 /// Paths whose newest mtime decides whether `agent`'s cache entry is still
@@ -74,25 +177,60 @@ pub fn data_sources(agent: Agent) -> Vec<PathBuf> {
         Agent::ClaudeCode => claude_dir()
             .map(|d| vec![d.join("history.jsonl"), d.join("projects")])
             .unwrap_or_default(),
-        Agent::Codex => codex_dir().map(|d| vec![d]).unwrap_or_default(),
+        Agent::Codex => codex_dir()
+            .map(|dir| {
+                let mut sources = vec![dir.join("sessions"), dir.join("history.jsonl")];
+                if let Ok(entries) = std::fs::read_dir(&dir) {
+                    for path in entries.flatten().map(|entry| entry.path()).filter(|path| {
+                        path.file_name()
+                            .and_then(|name| name.to_str())
+                            .is_some_and(|name| {
+                                name.starts_with("state_") && name.ends_with(".sqlite")
+                            })
+                    }) {
+                        sources.extend(sqlite_sources(path));
+                    }
+                }
+                sources
+            })
+            .unwrap_or_default(),
         Agent::OpenCode => opencode_data_dir()
-            .map(|d| vec![d.join("opencode.db")])
+            .map(|d| sqlite_sources(d.join("opencode.db")))
             .unwrap_or_default(),
         Agent::Pi => pi_sessions_dir().map(|d| vec![d]).unwrap_or_default(),
         Agent::OhMyPi => oh_my_pi_sessions_dir().map(|d| vec![d]).unwrap_or_default(),
-        Agent::Kiro => kiro_data_dir()
-            .map(|d| vec![d.join("data.sqlite3")])
-            .unwrap_or_default(),
+        Agent::Kiro => {
+            let mut sources = kiro_data_dir()
+                .map(|d| sqlite_sources(d.join("data.sqlite3")))
+                .unwrap_or_default();
+            if let Ok(dir) = kiro_sessions_dir() {
+                sources.push(dir);
+            }
+            sources
+        }
         Agent::CursorAgent => cursor_dir()
             .map(|d| vec![d.join("chats"), d.join("projects")])
             .unwrap_or_default(),
         Agent::Gemini => gemini_dir()
-            .map(|d| vec![d.join("tmp")])
+            .map(|d| vec![d.join("tmp"), d.join("projects.json")])
             .unwrap_or_default(),
         Agent::Hermes => hermes_dir()
-            .map(|d| vec![d.join("state.db")])
+            .map(|d| sqlite_sources(d.join("state.db")))
             .unwrap_or_default(),
         Agent::Yolop => yolop_sessions_dir().map(|d| vec![d]).unwrap_or_default(),
+        Agent::PrimeAgent => {
+            let mut sources = Vec::new();
+            if let Ok(dir) = prime_agent_dir() {
+                sources.push(dir.join("settings.json"));
+            }
+            if let Ok(cwd) = std::env::current_dir() {
+                sources.push(cwd.join(".prime/agent/settings.json"));
+            }
+            if let Ok(dir) = prime_sessions_dir() {
+                sources.push(dir);
+            }
+            sources
+        }
     }
 }
 
@@ -108,7 +246,9 @@ fn path_executables() -> &'static HashSet<String> {
             for dir in std::env::split_paths(&path) {
                 if let Ok(entries) = std::fs::read_dir(&dir) {
                     for entry in entries.flatten() {
-                        if let Some(name) = entry.file_name().to_str() {
+                        if is_executable_path(&entry.path())
+                            && let Some(name) = entry.file_name().to_str()
+                        {
                             insert_executable_name(&mut set, name, &pathext);
                         }
                     }
@@ -117,6 +257,24 @@ fn path_executables() -> &'static HashSet<String> {
         }
         set
     })
+}
+
+fn is_executable_path(path: &std::path::Path) -> bool {
+    let Ok(metadata) = std::fs::metadata(path) else {
+        return false;
+    };
+    if !metadata.is_file() {
+        return false;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        metadata.permissions().mode() & 0o111 != 0
+    }
+    #[cfg(not(unix))]
+    {
+        true
+    }
 }
 
 /// Return the list of PATHEXT suffixes (lower-cased, each beginning with `.`)
@@ -141,10 +299,10 @@ fn insert_executable_name(set: &mut HashSet<String>, filename: &str, pathext: &[
         for ext in pathext {
             if let Some(stem) = lower.strip_suffix(ext.as_str()) {
                 set.insert(stem.to_string());
+                set.insert(lower);
                 break;
             }
         }
-        set.insert(lower);
     } else {
         set.insert(filename.to_string());
     }
@@ -171,6 +329,58 @@ pub fn installed_agents() -> Vec<Agent> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn prime_project_settings_override_global_and_resolve_from_cwd() {
+        let root = std::env::temp_dir().join(format!(
+            "agf-prime-settings-{}-{}",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("unnamed")
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        let agent_dir = root.join("global-agent");
+        let cwd = root.join("project");
+        std::fs::create_dir_all(cwd.join(".prime/agent")).unwrap();
+        std::fs::create_dir_all(&agent_dir).unwrap();
+        std::fs::write(
+            agent_dir.join("settings.json"),
+            r#"{"sessionDir":"global-sessions"}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            cwd.join(".prime/agent/settings.json"),
+            r#"{"sessionDir":"project-sessions"}"#,
+        )
+        .unwrap();
+
+        let resolved = prime_sessions_dir_from_settings(&agent_dir, &cwd).unwrap();
+        assert_eq!(resolved, cwd.join("project-sessions"));
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn prime_global_relative_session_dir_resolves_from_process_cwd() {
+        let root = std::env::temp_dir().join(format!(
+            "agf-prime-global-settings-{}-{}",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("unnamed")
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        let agent_dir = root.join("global-agent");
+        let cwd = root.join("project");
+        std::fs::create_dir_all(&agent_dir).unwrap();
+        std::fs::create_dir_all(&cwd).unwrap();
+        std::fs::write(
+            agent_dir.join("settings.json"),
+            r#"{"sessionDir":"global-sessions"}"#,
+        )
+        .unwrap();
+
+        let resolved = prime_sessions_dir_from_settings(&agent_dir, &cwd).unwrap();
+        assert_eq!(resolved, cwd.join("global-sessions"));
+        let _ = std::fs::remove_dir_all(root);
+    }
 
     #[test]
     #[cfg(windows)]
@@ -184,6 +394,29 @@ mod tests {
         // Full lower-cased name and stem both present.
         assert!(set.contains("claude.exe"));
         assert!(set.contains("claude"));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn executable_detection_rejects_plain_files_and_accepts_exec_bits() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = std::env::temp_dir().join(format!(
+            "agf-executable-test-{}-{}",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("unnamed")
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("agent");
+        std::fs::File::create(&path)
+            .unwrap()
+            .write_all(b"#!/bin/sh\n")
+            .unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
+        assert!(!is_executable_path(&path));
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o700)).unwrap();
+        assert!(is_executable_path(&path));
+        let _ = std::fs::remove_dir_all(dir);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -329,7 +329,6 @@ pub fn installed_agents() -> Vec<Agent> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::Write;
 
     #[test]
     fn prime_project_settings_override_global_and_resolve_from_cwd() {
@@ -399,6 +398,7 @@ mod tests {
     #[test]
     #[cfg(unix)]
     fn executable_detection_rejects_plain_files_and_accepts_exec_bits() {
+        use std::io::Write;
         use std::os::unix::fs::PermissionsExt;
         let dir = std::env::temp_dir().join(format!(
             "agf-executable-test-{}-{}",
@@ -421,12 +421,11 @@ mod tests {
 
     #[test]
     #[cfg(windows)]
-    fn insert_executable_name_no_stem_when_ext_missing() {
+    fn insert_executable_name_ignores_non_pathext_files() {
         let pathext: Vec<String> = [".exe"].iter().map(|s| s.to_string()).collect();
         let mut set = HashSet::new();
         insert_executable_name(&mut set, "README.md", &pathext);
-        assert!(set.contains("readme.md"));
-        // No bare "readme" stem should be inserted — .md is not in PATHEXT.
+        assert!(!set.contains("readme.md"));
         assert!(!set.contains("readme"));
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -332,11 +332,7 @@ mod tests {
 
     #[test]
     fn prime_project_settings_override_global_and_resolve_from_cwd() {
-        let root = std::env::temp_dir().join(format!(
-            "agf-prime-settings-{}-{}",
-            std::process::id(),
-            std::thread::current().name().unwrap_or("unnamed")
-        ));
+        let root = std::env::temp_dir().join(format!("agf-prime-settings-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&root);
         let agent_dir = root.join("global-agent");
         let cwd = root.join("project");
@@ -360,11 +356,8 @@ mod tests {
 
     #[test]
     fn prime_global_relative_session_dir_resolves_from_process_cwd() {
-        let root = std::env::temp_dir().join(format!(
-            "agf-prime-global-settings-{}-{}",
-            std::process::id(),
-            std::thread::current().name().unwrap_or("unnamed")
-        ));
+        let root =
+            std::env::temp_dir().join(format!("agf-prime-global-settings-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&root);
         let agent_dir = root.join("global-agent");
         let cwd = root.join("project");
@@ -400,11 +393,7 @@ mod tests {
     fn executable_detection_rejects_plain_files_and_accepts_exec_bits() {
         use std::io::Write;
         use std::os::unix::fs::PermissionsExt;
-        let dir = std::env::temp_dir().join(format!(
-            "agf-executable-test-{}-{}",
-            std::process::id(),
-            std::thread::current().name().unwrap_or("unnamed")
-        ));
+        let dir = std::env::temp_dir().join(format!("agf-executable-test-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
         let path = dir.join("agent");

--- a/src/delete.rs
+++ b/src/delete.rs
@@ -13,7 +13,15 @@ use crate::scanner::{read_first_line, read_head_lines};
 /// Only removes session data, NOT the project directory.
 pub fn delete_session(session: &Session) -> Result<(), io::Error> {
     let ids = HashSet::from([session.session_id.as_str()]);
-    delete_agent_sessions(session.agent, &ids)
+    let deleted = delete_agent_sessions(session.agent, &ids)?;
+    if deleted.contains(&session.session_id) {
+        Ok(())
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("session data was not found: {}", session.session_id),
+        ))
+    }
 }
 
 /// Delete every session named in `selection`, doing **one** filesystem or
@@ -36,8 +44,10 @@ pub fn delete_selection(
             continue;
         }
         let borrowed: HashSet<&str> = ids.iter().map(String::as_str).collect();
-        if delete_agent_sessions(agent, &borrowed).is_ok() {
-            deleted.insert(agent, ids.clone());
+        if let Ok(actually_deleted) = delete_agent_sessions(agent, &borrowed) {
+            if !actually_deleted.is_empty() {
+                deleted.insert(agent, actually_deleted);
+            }
             continue;
         }
         // The batch aborted somewhere, and a batch cannot say how far it got.
@@ -46,8 +56,12 @@ pub fn delete_selection(
         // pass per id, but only on the error path.
         let individually: HashSet<String> = ids
             .iter()
-            .filter(|id| delete_agent_sessions(agent, &HashSet::from([id.as_str()])).is_ok())
-            .cloned()
+            .filter_map(|id| {
+                delete_agent_sessions(agent, &HashSet::from([id.as_str()]))
+                    .ok()
+                    .filter(|removed| removed.contains(id))
+                    .map(|_| id.clone())
+            })
             .collect();
         if !individually.is_empty() {
             deleted.insert(agent, individually);
@@ -56,7 +70,7 @@ pub fn delete_selection(
     deleted
 }
 
-fn delete_agent_sessions(agent: Agent, ids: &HashSet<&str>) -> Result<(), io::Error> {
+fn delete_agent_sessions(agent: Agent, ids: &HashSet<&str>) -> Result<HashSet<String>, io::Error> {
     // Refuse the whole batch if any id is unsafe: acting on part of a delete
     // whose input we distrust is worse than refusing all of it.
     if let Some(bad) = ids.iter().find(|id| !is_safe_session_id(id)) {
@@ -81,6 +95,10 @@ fn delete_agent_sessions(agent: Agent, ids: &HashSet<&str>) -> Result<(), io::Er
         Agent::Gemini => delete_gemini_sessions(ids),
         Agent::Hermes => delete_hermes_sessions(ids),
         Agent::Yolop => delete_yolop_sessions(ids),
+        Agent::PrimeAgent => Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "Prime Agent deletion is disabled: use Prime Agent's /resume picker so active daemon sessions are protected",
+        )),
     }
 }
 
@@ -106,49 +124,6 @@ fn is_safe_session_id(id: &str) -> bool {
 // Shared helpers
 // ---------------------------------------------------------------------------
 
-/// Rewrite a JSONL file, excluding every line whose `json_key` is in `values`.
-///
-/// Skips the write entirely when nothing matched, so a bulk delete that touches
-/// one agent does not rewrite another's multi-MB history file for nothing.
-fn rewrite_jsonl_excluding(
-    path: &Path,
-    json_key: &str,
-    values: &HashSet<&str>,
-) -> Result<(), io::Error> {
-    let content = fs::read_to_string(path)?;
-    let mut kept = String::with_capacity(content.len());
-    let mut dropped_any = false;
-
-    for line in content.lines() {
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-        if line_field_matches_any(trimmed, json_key, values) {
-            dropped_any = true;
-            continue;
-        }
-        kept.push_str(line);
-        kept.push('\n');
-    }
-
-    if !dropped_any {
-        return Ok(());
-    }
-    crate::fsx::write_atomic(path, kept.as_bytes())
-}
-
-/// Check whether a JSON line's `key` holds any of `values`.
-fn line_field_matches_any(line: &str, key: &str, values: &HashSet<&str>) -> bool {
-    let Ok(parsed) = serde_json::from_str::<serde_json::Value>(line) else {
-        return false;
-    };
-    parsed
-        .get(key)
-        .and_then(|v| v.as_str())
-        .is_some_and(|v| values.contains(v))
-}
-
 /// Single walk of `base` removing every directory named in `dir_names` and
 /// every regular file named in `file_names`.
 ///
@@ -159,11 +134,13 @@ fn remove_matching_entries(
     base: &Path,
     dir_names: &HashSet<&str>,
     file_names: &HashSet<&str>,
-) -> Result<(), io::Error> {
+) -> Result<HashSet<String>, io::Error> {
+    let mut deleted = HashSet::new();
     if !base.is_dir() {
-        return Ok(());
+        return Ok(deleted);
     }
-    for entry in WalkDir::new(base).into_iter().flatten() {
+    for entry in WalkDir::new(base) {
+        let entry = entry.map_err(io::Error::other)?;
         // `entry.file_type()` reuses the readdir result; `path.is_dir()` would
         // pay a fresh stat for every file in the tree.
         let file_type = entry.file_type();
@@ -174,31 +151,31 @@ fn remove_matching_entries(
         if file_type.is_dir() {
             if dir_names.contains(name) {
                 fs::remove_dir_all(path)?;
+                deleted.insert(name.to_string());
             }
         } else if file_type.is_file() && file_names.contains(name) {
             fs::remove_file(path)?;
+            if let Some(stem) = path.file_stem().and_then(|stem| stem.to_str()) {
+                deleted.insert(stem.to_string());
+            }
         }
     }
-    Ok(())
+    Ok(deleted)
 }
 
 // ---------------------------------------------------------------------------
 // Claude Code
 // ---------------------------------------------------------------------------
 
-/// Claude sessions are listed as lines in `~/.claude/history.jsonl`.
-/// We rewrite the file excluding all lines whose `sessionId` matches, and
-/// remove any project-specific session directory under `~/.claude/projects/`.
-fn delete_claude_sessions(ids: &HashSet<&str>) -> Result<(), io::Error> {
+/// Claude history is append-only and may have a live writer, so deletion never
+/// rewrites it. Removing the exact transcript is sufficient: the scanner's
+/// live-set filter ignores retained history summaries without a transcript.
+fn delete_claude_sessions(ids: &HashSet<&str>) -> Result<HashSet<String>, io::Error> {
     let claude_dir = config::claude_dir().map_err(io::Error::other)?;
-
-    let history_path = claude_dir.join("history.jsonl");
-    if history_path.exists() {
-        rewrite_jsonl_excluding(&history_path, "sessionId", ids)?;
-    }
-
     let projects_dir = claude_dir.join("projects");
-    remove_matching_entries(&projects_dir, ids, &HashSet::new())
+    let transcript_names: Vec<String> = ids.iter().map(|id| format!("{id}.jsonl")).collect();
+    let transcript_names: HashSet<&str> = transcript_names.iter().map(String::as_str).collect();
+    remove_matching_entries(&projects_dir, ids, &transcript_names)
 }
 
 // ---------------------------------------------------------------------------
@@ -209,36 +186,39 @@ fn delete_claude_sessions(ids: &HashSet<&str>) -> Result<(), io::Error> {
 /// depending on Codex CLI version):
 ///   * `state_*.sqlite` `threads` row (primary source for current Codex CLI),
 ///   * `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl` rollout file,
-///   * `~/.codex/history.jsonl` per-prompt summary entries.
+///   * `~/.codex/history.jsonl` per-prompt summary entries (left append-only).
 ///
 /// We delete from all three so the session does not reappear after the next
 /// `agf` scan via the SQLite path.
-fn delete_codex_sessions(ids: &HashSet<&str>) -> Result<(), io::Error> {
+fn delete_codex_sessions(ids: &HashSet<&str>) -> Result<HashSet<String>, io::Error> {
     let codex_dir = config::codex_dir().map_err(io::Error::other)?;
 
-    delete_codex_sqlite_rows(&codex_dir, ids)?;
+    let mut deleted = delete_codex_sqlite_rows(&codex_dir, ids)?;
 
     let sessions_dir = codex_dir.join("sessions");
     if sessions_dir.exists() {
-        delete_codex_session_files(&sessions_dir, ids)?;
+        deleted.extend(delete_codex_session_files(&sessions_dir, ids)?);
     }
 
-    let history_path = codex_dir.join("history.jsonl");
-    if history_path.exists() {
-        rewrite_jsonl_excluding(&history_path, "session_id", ids)?;
-    }
-
-    Ok(())
+    Ok(deleted)
 }
 
 /// Remove the `threads` rows matching `ids` from every `state_*.sqlite` in
-/// `codex_dir`. Missing tables / open errors on a single file are swallowed so
-/// one corrupt or older-schema db cannot block the delete on the others.
-fn delete_codex_sqlite_rows(codex_dir: &Path, ids: &HashSet<&str>) -> Result<(), io::Error> {
-    let Ok(entries) = fs::read_dir(codex_dir) else {
-        return Ok(());
+/// `codex_dir`. Older schemas without `threads` are ignored, but lock/open/
+/// write failures are surfaced so the UI never reports a deletion that did
+/// not actually reach the current Codex database.
+fn delete_codex_sqlite_rows(
+    codex_dir: &Path,
+    ids: &HashSet<&str>,
+) -> Result<HashSet<String>, io::Error> {
+    let mut deleted = HashSet::new();
+    let entries = match fs::read_dir(codex_dir) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(deleted),
+        Err(error) => return Err(error),
     };
-    for entry in entries.flatten() {
+    for entry in entries {
+        let entry = entry?;
         let path = entry.path();
         let is_state_db = path
             .file_name()
@@ -247,25 +227,33 @@ fn delete_codex_sqlite_rows(codex_dir: &Path, ids: &HashSet<&str>) -> Result<(),
         if !is_state_db {
             continue;
         }
-        let Ok(conn) = rusqlite::Connection::open(&path) else {
-            continue;
-        };
-        // `threads` is the only table the Codex scanner reads from. Older
-        // Codex CLI versions may not have this table — ignore the error.
+        let mut conn = rusqlite::Connection::open(&path)
+            .map_err(|error| io::Error::other(format!("{}: {error}", path.display())))?;
+        let tx = conn.transaction().map_err(io::Error::other)?;
         for id in ids {
-            let _ = conn.execute("DELETE FROM threads WHERE id = ?1", [*id]);
+            match tx.execute("DELETE FROM threads WHERE id = ?1", [*id]) {
+                Ok(count) => {
+                    if count > 0 {
+                        deleted.insert((*id).to_string());
+                    }
+                }
+                Err(error) if error.to_string().contains("no such table") => break,
+                Err(error) => return Err(io::Error::other(error)),
+            }
         }
+        tx.commit().map_err(io::Error::other)?;
     }
-    Ok(())
+    Ok(deleted)
 }
 
 /// Find and delete the Codex rollout JSONL files matching `ids`.
-fn delete_codex_session_files(sessions_dir: &Path, ids: &HashSet<&str>) -> Result<(), io::Error> {
-    let mut remaining = ids.len();
-    for entry in WalkDir::new(sessions_dir).into_iter().flatten() {
-        if remaining == 0 {
-            break;
-        }
+fn delete_codex_session_files(
+    sessions_dir: &Path,
+    ids: &HashSet<&str>,
+) -> Result<HashSet<String>, io::Error> {
+    let mut deleted = HashSet::new();
+    for entry in WalkDir::new(sessions_dir) {
+        let entry = entry.map_err(io::Error::other)?;
         let path = entry.path();
         if !entry.file_type().is_file()
             || path.extension().and_then(|e| e.to_str()) != Some("jsonl")
@@ -288,10 +276,10 @@ fn delete_codex_session_files(sessions_dir: &Path, ids: &HashSet<&str>) -> Resul
             .unwrap_or_default();
         if ids.contains(payload_id) {
             fs::remove_file(path)?;
-            remaining -= 1;
+            deleted.insert(payload_id.to_string());
         }
     }
-    Ok(())
+    Ok(deleted)
 }
 
 // ---------------------------------------------------------------------------
@@ -300,11 +288,11 @@ fn delete_codex_session_files(sessions_dir: &Path, ids: &HashSet<&str>) -> Resul
 
 /// OpenCode sessions are stored in a SQLite database at
 /// `~/.local/share/opencode/opencode.db`.
-fn delete_opencode_sessions(ids: &HashSet<&str>) -> Result<(), io::Error> {
+fn delete_opencode_sessions(ids: &HashSet<&str>) -> Result<HashSet<String>, io::Error> {
     let opencode_dir = config::opencode_data_dir().map_err(io::Error::other)?;
     let db_path = opencode_dir.join("opencode.db");
     if !db_path.exists() {
-        return Ok(());
+        return Ok(HashSet::new());
     }
 
     let mut conn = rusqlite::Connection::open(&db_path)
@@ -312,9 +300,14 @@ fn delete_opencode_sessions(ids: &HashSet<&str>) -> Result<(), io::Error> {
     let tx = conn
         .transaction()
         .map_err(|e| io::Error::other(format!("SQLite begin tx error: {e}")))?;
+    let mut deleted = HashSet::new();
     for id in ids {
-        tx.execute("DELETE FROM session WHERE id = ?1", [*id])
+        let count = tx
+            .execute("DELETE FROM session WHERE id = ?1", [*id])
             .map_err(|e| io::Error::other(format!("SQLite delete error: {e}")))?;
+        if count > 0 {
+            deleted.insert((*id).to_string());
+        }
     }
     tx.commit()
         .map_err(|e| io::Error::other(format!("SQLite commit error: {e}")))?;
@@ -336,7 +329,7 @@ fn delete_opencode_sessions(ids: &HashSet<&str>) -> Result<(), io::Error> {
         }
     }
 
-    Ok(())
+    Ok(deleted)
 }
 
 // ---------------------------------------------------------------------------
@@ -351,16 +344,17 @@ const PI_HEADER_SCAN_BYTES: u64 = 64 * 1024;
 
 /// pi and Oh My Pi both store sessions as JSONL files under
 /// `<root>/<encoded-cwd>/<timestamp>_<sessionId>.jsonl`.
-fn delete_pi_style_sessions(sessions_dir: &Path, ids: &HashSet<&str>) -> Result<(), io::Error> {
+fn delete_pi_style_sessions(
+    sessions_dir: &Path,
+    ids: &HashSet<&str>,
+) -> Result<HashSet<String>, io::Error> {
+    let mut deleted = HashSet::new();
     if !sessions_dir.exists() {
-        return Ok(());
+        return Ok(deleted);
     }
 
-    let mut remaining = ids.len();
-    for entry in WalkDir::new(sessions_dir).into_iter().flatten() {
-        if remaining == 0 {
-            break;
-        }
+    for entry in WalkDir::new(sessions_dir) {
+        let entry = entry.map_err(io::Error::other)?;
         let path = entry.path();
         if !entry.file_type().is_file()
             || path.extension().and_then(|e| e.to_str()) != Some("jsonl")
@@ -368,30 +362,34 @@ fn delete_pi_style_sessions(sessions_dir: &Path, ids: &HashSet<&str>) -> Result<
             continue;
         }
 
-        let matches = read_head_lines(path, PI_HEADER_SCAN_LINES, PI_HEADER_SCAN_BYTES)
+        let matching_id = read_head_lines(path, PI_HEADER_SCAN_LINES, PI_HEADER_SCAN_BYTES)
             .iter()
-            .any(|line| pi_header_matches(line, ids));
-        if matches {
+            .find_map(|line| pi_header_id(line, ids));
+        if let Some(id) = matching_id {
             fs::remove_file(path)?;
-            remaining -= 1;
+            deleted.insert(id);
         }
     }
 
-    Ok(())
+    Ok(deleted)
 }
 
-fn pi_header_matches(line: &str, ids: &HashSet<&str>) -> bool {
+fn pi_header_id(line: &str, ids: &HashSet<&str>) -> Option<String> {
     if line.is_empty() {
-        return false;
+        return None;
     }
     let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
-        return false;
+        return None;
     };
-    value.get("type").and_then(|v| v.as_str()) == Some("session")
-        && value
-            .get("id")
-            .and_then(|v| v.as_str())
-            .is_some_and(|id| ids.contains(id))
+    (value.get("type").and_then(|v| v.as_str()) == Some("session"))
+        .then(|| {
+            value
+                .get("id")
+                .and_then(|v| v.as_str())
+                .filter(|id| ids.contains(*id))
+                .map(str::to_string)
+        })
+        .flatten()
 }
 
 // ---------------------------------------------------------------------------
@@ -401,27 +399,61 @@ fn pi_header_matches(line: &str, ids: &HashSet<&str>) -> bool {
 /// Kiro sessions are stored in a SQLite database at
 /// `~/Library/Application Support/kiro-cli/data.sqlite3` (macOS) or
 /// `~/.local/share/kiro-cli/data.sqlite3` (Linux).
-fn delete_kiro_sessions(ids: &HashSet<&str>) -> Result<(), io::Error> {
+fn delete_kiro_sessions(ids: &HashSet<&str>) -> Result<HashSet<String>, io::Error> {
+    let mut deleted = HashSet::new();
     let data_dir = config::kiro_data_dir().map_err(io::Error::other)?;
     let db_path = data_dir.join("data.sqlite3");
-    if !db_path.exists() {
-        return Ok(());
+    if db_path.exists() {
+        let mut conn = rusqlite::Connection::open(&db_path)
+            .map_err(|e| io::Error::other(format!("SQLite open error: {e}")))?;
+        let tx = conn
+            .transaction()
+            .map_err(|e| io::Error::other(format!("SQLite begin tx error: {e}")))?;
+        for id in ids {
+            match tx.execute(
+                "DELETE FROM conversations_v2 WHERE conversation_id = ?1",
+                [*id],
+            ) {
+                Ok(count) => {
+                    if count > 0 {
+                        deleted.insert((*id).to_string());
+                    }
+                }
+                Err(error) if error.to_string().contains("no such table") => break,
+                Err(error) => {
+                    return Err(io::Error::other(format!("SQLite delete error: {error}")));
+                }
+            }
+        }
+        tx.commit()
+            .map_err(|e| io::Error::other(format!("SQLite commit error: {e}")))?;
     }
 
-    let mut conn = rusqlite::Connection::open(&db_path)
-        .map_err(|e| io::Error::other(format!("SQLite open error: {e}")))?;
-    let tx = conn
-        .transaction()
-        .map_err(|e| io::Error::other(format!("SQLite begin tx error: {e}")))?;
-    for id in ids {
-        tx.execute(
-            "DELETE FROM conversations_v2 WHERE conversation_id = ?1",
-            [*id],
-        )
-        .map_err(|e| io::Error::other(format!("SQLite delete error: {e}")))?;
+    let sessions_dir = config::kiro_sessions_dir().map_err(io::Error::other)?;
+    if sessions_dir.is_dir() {
+        for entry in fs::read_dir(&sessions_dir)? {
+            let entry = entry?;
+            let metadata_path = entry.path();
+            if !entry.file_type()?.is_file()
+                || metadata_path.extension().and_then(|ext| ext.to_str()) != Some("json")
+            {
+                continue;
+            }
+            let Some(id) = crate::scanner::kiro::v3_session_id(&metadata_path)
+                .map_err(io::Error::other)?
+                .filter(|id| ids.contains(id.as_str()))
+            else {
+                continue;
+            };
+            fs::remove_file(&metadata_path)?;
+            let event_path = metadata_path.with_extension("jsonl");
+            if event_path.is_file() {
+                fs::remove_file(event_path)?;
+            }
+            deleted.insert(id);
+        }
     }
-    tx.commit()
-        .map_err(|e| io::Error::other(format!("SQLite commit error: {e}")))
+    Ok(deleted)
 }
 
 // ---------------------------------------------------------------------------
@@ -439,17 +471,22 @@ fn delete_kiro_sessions(ids: &HashSet<&str>) -> Result<(), io::Error> {
 /// Both shapes are still surfaced by the scanner (see `scan_from`), so delete
 /// must remove the directory AND the file form — otherwise legacy sessions
 /// silently no-op and the next scan resurrects the orphan.
-fn delete_cursor_agent_sessions(ids: &HashSet<&str>) -> Result<(), io::Error> {
+fn delete_cursor_agent_sessions(ids: &HashSet<&str>) -> Result<HashSet<String>, io::Error> {
     let cursor_dir = config::cursor_dir().map_err(io::Error::other)?;
 
     // 1. Chat metadata: ~/.cursor/chats/*/<session_id>/
-    remove_matching_entries(&cursor_dir.join("chats"), ids, &HashSet::new())?;
+    let mut deleted = remove_matching_entries(&cursor_dir.join("chats"), ids, &HashSet::new())?;
 
     // 2. Transcript: directory form (JSONL) and file form (legacy .txt), in a
     //    single traversal of the projects tree.
     let legacy_names: Vec<String> = ids.iter().map(|id| format!("{id}.txt")).collect();
     let legacy_names: HashSet<&str> = legacy_names.iter().map(String::as_str).collect();
-    remove_matching_entries(&cursor_dir.join("projects"), ids, &legacy_names)
+    deleted.extend(remove_matching_entries(
+        &cursor_dir.join("projects"),
+        ids,
+        &legacy_names,
+    )?);
+    Ok(deleted)
 }
 
 // ---------------------------------------------------------------------------
@@ -458,50 +495,38 @@ fn delete_cursor_agent_sessions(ids: &HashSet<&str>) -> Result<(), io::Error> {
 
 /// Gemini sessions are stored as JSON files under
 /// `~/.gemini/tmp/<project-name-or-hash>/chats/session-<date>-<short-id>.json`.
-fn delete_gemini_sessions(ids: &HashSet<&str>) -> Result<(), io::Error> {
+fn delete_gemini_sessions(ids: &HashSet<&str>) -> Result<HashSet<String>, io::Error> {
+    let mut deleted = HashSet::new();
     let gemini_dir = config::gemini_dir().map_err(io::Error::other)?;
     let tmp_dir = gemini_dir.join("tmp");
     if !tmp_dir.exists() {
-        return Ok(());
+        return Ok(deleted);
     }
 
-    let mut remaining = ids.len();
-    for project_entry in fs::read_dir(&tmp_dir)?.flatten() {
-        if remaining == 0 {
-            break;
-        }
+    for project_entry in fs::read_dir(&tmp_dir)? {
+        let project_entry = project_entry?;
         let chats_dir = project_entry.path().join("chats");
         if !chats_dir.is_dir() {
             continue;
         }
 
-        for chat_entry in fs::read_dir(&chats_dir)?.flatten() {
-            if remaining == 0 {
-                break;
-            }
+        for chat_entry in fs::read_dir(&chats_dir)? {
+            let chat_entry = chat_entry?;
             let path = chat_entry.path();
             if path.extension().and_then(|e| e.to_str()) != Some("json") {
                 continue;
             }
 
-            let Ok(content) = fs::read_to_string(&path) else {
-                continue;
-            };
-            let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) else {
-                continue;
-            };
-            if json
-                .get("sessionId")
-                .and_then(|v| v.as_str())
-                .is_some_and(|id| ids.contains(id))
+            if let Some(id) = read_top_level_json_string_prefix(&path, "sessionId", 64 * 1024)?
+                && ids.contains(id.as_str())
             {
                 fs::remove_file(&path)?;
-                remaining -= 1;
+                deleted.insert(id);
             }
         }
     }
 
-    Ok(())
+    Ok(deleted)
 }
 
 // ---------------------------------------------------------------------------
@@ -514,11 +539,12 @@ fn delete_gemini_sessions(ids: &HashSet<&str>) -> Result<(), io::Error> {
 /// single transaction so a mid-cascade failure can't leave the DB in
 /// an inconsistent state (e.g. orphan messages whose sessions row is
 /// gone, which would surface as ghost rows on the next scan).
-fn delete_hermes_sessions(ids: &HashSet<&str>) -> Result<(), io::Error> {
+fn delete_hermes_sessions(ids: &HashSet<&str>) -> Result<HashSet<String>, io::Error> {
+    let mut deleted = HashSet::new();
     let hermes_dir = config::hermes_dir().map_err(io::Error::other)?;
     let db_path = hermes_dir.join("state.db");
     if !db_path.exists() {
-        return Ok(());
+        return Ok(deleted);
     }
 
     let mut conn = rusqlite::Connection::open(&db_path)
@@ -545,8 +571,12 @@ fn delete_hermes_sessions(ids: &HashSet<&str>) -> Result<(), io::Error> {
             .map_err(|e| io::Error::other(format!("SQLite delete child sessions error: {e}")))?;
 
         // Delete the parent session.
-        tx.execute("DELETE FROM sessions WHERE id = ?1", [*id])
+        let count = tx
+            .execute("DELETE FROM sessions WHERE id = ?1", [*id])
             .map_err(|e| io::Error::other(format!("SQLite delete session error: {e}")))?;
+        if count > 0 {
+            deleted.insert((*id).to_string());
+        }
     }
 
     tx.commit()
@@ -560,31 +590,133 @@ fn delete_hermes_sessions(ids: &HashSet<&str>) -> Result<(), io::Error> {
         for entry in entries.flatten() {
             if let Some(name) = entry.file_name().to_str()
                 && name.ends_with(".json")
-                && ids
-                    .iter()
-                    .any(|id| name.starts_with(&format!("session_{id}")))
+                && ids.iter().any(|id| name == format!("session_{id}.json"))
             {
                 let _ = fs::remove_file(entry.path());
             }
         }
     }
 
-    Ok(())
+    Ok(deleted)
+}
+
+fn read_top_level_json_string_prefix(
+    path: &Path,
+    field: &str,
+    max_bytes: u64,
+) -> Result<Option<String>, io::Error> {
+    use std::io::Read;
+    let file = fs::File::open(path)?;
+    let mut prefix = Vec::new();
+    file.take(max_bytes).read_to_end(&mut prefix)?;
+
+    let mut index = 0usize;
+    while prefix.get(index).is_some_and(u8::is_ascii_whitespace) {
+        index += 1;
+    }
+    if prefix.get(index) != Some(&b'{') {
+        return Ok(None);
+    }
+    let mut depth = 1usize;
+    let mut expect_key = true;
+    index += 1;
+    while index < prefix.len() {
+        match prefix[index] {
+            b'"' => {
+                let start = index;
+                index += 1;
+                let mut escaped = false;
+                while index < prefix.len() {
+                    let byte = prefix[index];
+                    index += 1;
+                    if escaped {
+                        escaped = false;
+                    } else if byte == b'\\' {
+                        escaped = true;
+                    } else if byte == b'"' {
+                        break;
+                    }
+                }
+                if index > prefix.len() || prefix.get(index.saturating_sub(1)) != Some(&b'"') {
+                    return Ok(None);
+                }
+                if depth == 1 && expect_key {
+                    let Ok(key) = serde_json::from_slice::<String>(&prefix[start..index]) else {
+                        return Ok(None);
+                    };
+                    while prefix.get(index).is_some_and(u8::is_ascii_whitespace) {
+                        index += 1;
+                    }
+                    if prefix.get(index) != Some(&b':') {
+                        return Ok(None);
+                    }
+                    index += 1;
+                    while prefix.get(index).is_some_and(u8::is_ascii_whitespace) {
+                        index += 1;
+                    }
+                    expect_key = false;
+                    if key == field {
+                        if prefix.get(index) != Some(&b'"') {
+                            return Ok(None);
+                        }
+                        let value_start = index;
+                        index += 1;
+                        let mut escaped = false;
+                        while index < prefix.len() {
+                            let byte = prefix[index];
+                            index += 1;
+                            if escaped {
+                                escaped = false;
+                            } else if byte == b'\\' {
+                                escaped = true;
+                            } else if byte == b'"' {
+                                return Ok(serde_json::from_slice::<String>(
+                                    &prefix[value_start..index],
+                                )
+                                .ok());
+                            }
+                        }
+                        return Ok(None);
+                    }
+                }
+            }
+            b'{' | b'[' => {
+                depth = depth.saturating_add(1);
+                index += 1;
+            }
+            b'}' | b']' => {
+                depth = depth.saturating_sub(1);
+                index += 1;
+                if depth == 0 {
+                    break;
+                }
+            }
+            b',' if depth == 1 => {
+                expect_key = true;
+                index += 1;
+            }
+            _ => index += 1,
+        }
+    }
+    Ok(None)
 }
 
 // ---------------------------------------------------------------------------
 // Yolop
 // ---------------------------------------------------------------------------
 
-fn delete_yolop_sessions(ids: &HashSet<&str>) -> Result<(), io::Error> {
+fn delete_yolop_sessions(ids: &HashSet<&str>) -> Result<HashSet<String>, io::Error> {
+    let mut deleted = HashSet::new();
     let sessions_dir = config::yolop_sessions_dir().map_err(io::Error::other)?;
     for id in ids {
-        delete_yolop_session_from(&sessions_dir, id)?;
+        if delete_yolop_session_from(&sessions_dir, id)? {
+            deleted.insert((*id).to_string());
+        }
     }
-    Ok(())
+    Ok(deleted)
 }
 
-fn delete_yolop_session_from(sessions_dir: &Path, session_id: &str) -> Result<(), io::Error> {
+fn delete_yolop_session_from(sessions_dir: &Path, session_id: &str) -> Result<bool, io::Error> {
     // Yolop is the only agent whose delete joins the id straight onto a
     // directory and calls `remove_dir_all`, so it re-checks the id against the
     // exact `session_<32 hex>` shape its scanner emits — a stricter gate than
@@ -595,15 +727,18 @@ fn delete_yolop_session_from(sessions_dir: &Path, session_id: &str) -> Result<()
             format!("not a Yolop session id: {session_id:?}"),
         ));
     }
+    let mut deleted = false;
     let session_dir = sessions_dir.join(session_id);
     if session_dir.is_dir() {
         fs::remove_dir_all(session_dir)?;
+        deleted = true;
     }
     let legacy_log = sessions_dir.join(format!("{session_id}.jsonl"));
     if legacy_log.is_file() {
         fs::remove_file(legacy_log)?;
+        deleted = true;
     }
-    Ok(())
+    Ok(deleted)
 }
 
 #[cfg(test)]
@@ -772,40 +907,40 @@ mod tests {
         let _ = fs::remove_dir_all(dir);
     }
 
-    // -- shared jsonl rewrite ------------------------------------------------
-
     #[test]
-    fn rewrite_jsonl_excluding_drops_every_id_in_the_batch() {
-        let dir = make_dir("agf-test-history-rewrite");
-        let path = dir.join("history.jsonl");
+    fn bounded_json_field_reader_handles_whitespace_and_escapes() {
+        let dir = make_dir("agf-test-json-prefix");
+        let path = dir.join("session.json");
         fs::write(
             &path,
-            concat!(
-                "{\"sessionId\":\"a\",\"display\":\"one\"}\n",
-                "{\"sessionId\":\"keep\",\"display\":\"two\"}\n",
-                "{\"sessionId\":\"b\",\"display\":\"three\"}\n",
-            ),
+            b"{\n  \"sessionId\" : \"id-\\\"quoted\",\n  \"messages\": [",
         )
         .unwrap();
 
-        rewrite_jsonl_excluding(&path, "sessionId", &ids(&["a", "b"])).unwrap();
-
-        let out = fs::read_to_string(&path).unwrap();
-        assert_eq!(out, "{\"sessionId\":\"keep\",\"display\":\"two\"}\n");
-        let _ = fs::remove_dir_all(dir);
+        assert_eq!(
+            read_top_level_json_string_prefix(&path, "sessionId", 1024)
+                .unwrap()
+                .as_deref(),
+            Some("id-\"quoted")
+        );
     }
 
     #[test]
-    fn rewrite_jsonl_excluding_leaves_file_untouched_when_nothing_matches() {
-        let dir = make_dir("agf-test-history-noop");
-        let path = dir.join("history.jsonl");
-        let original = "{\"sessionId\":\"keep\"}\n\n{\"sessionId\":\"other\"}\n";
-        fs::write(&path, original).unwrap();
+    fn top_level_json_reader_ignores_nested_session_id() {
+        let dir = make_dir("agf-test-json-nested-id");
+        let path = dir.join("session.json");
+        fs::write(
+            &path,
+            br#"{"metadata":{"sessionId":"wrong"},"sessionId":"right"}"#,
+        )
+        .unwrap();
 
-        rewrite_jsonl_excluding(&path, "sessionId", &ids(&["absent"])).unwrap();
-
-        // Byte-identical: no rewrite happened at all, blank line included.
-        assert_eq!(fs::read_to_string(&path).unwrap(), original);
+        assert_eq!(
+            read_top_level_json_string_prefix(&path, "sessionId", 1024)
+                .unwrap()
+                .as_deref(),
+            Some("right")
+        );
         let _ = fs::remove_dir_all(dir);
     }
 
@@ -899,7 +1034,7 @@ mod tests {
     /// The batch entry point must report per agent, and an agent whose pass
     /// was refused must not appear as deleted — the TUI keeps those rows.
     #[test]
-    fn delete_selection_reports_only_agents_whose_pass_succeeded() {
+    fn delete_selection_reports_only_sessions_with_backing_data() {
         let good = "session_019e3db018a17450aba5407af5777237";
         let selection = HashMap::from([
             (Agent::Yolop, HashSet::from([good.to_string()])),
@@ -912,15 +1047,12 @@ mod tests {
 
         let deleted = delete_selection(&selection);
 
-        assert_eq!(
-            deleted.get(&Agent::Yolop),
-            Some(&HashSet::from([good.to_string()]))
-        );
+        assert_eq!(deleted.get(&Agent::Yolop), None);
         assert_eq!(deleted.get(&Agent::ClaudeCode), None);
     }
 
-    /// A batch that aborts must not take healthy siblings down with it: the
-    /// per-id retry recovers exactly the ones whose data really is gone.
+    /// A batch that aborts must not turn a merely valid-looking ID into a
+    /// successful deletion when no authoritative backing data was present.
     #[test]
     fn delete_selection_falls_back_to_per_session_truth_when_the_batch_fails() {
         let good = "session_019e3db018a17450aba5407af5777237";
@@ -933,11 +1065,7 @@ mod tests {
 
         let deleted = delete_selection(&selection);
 
-        assert_eq!(
-            deleted.get(&Agent::Yolop),
-            Some(&HashSet::from([good.to_string()])),
-            "the valid session must still be reported as deleted"
-        );
+        assert!(deleted.is_empty());
     }
 
     #[test]

--- a/src/fsx.rs
+++ b/src/fsx.rs
@@ -3,6 +3,7 @@
 use std::fs;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 /// Write `contents` to `path` atomically: a sibling temp file is written and
 /// flushed to disk, then renamed over the destination.
@@ -16,40 +17,85 @@ use std::path::{Path, PathBuf};
 /// `rename(2)` is atomic within a filesystem, so a concurrent reader sees
 /// either the old file or the complete new one, never a torn prefix.
 pub fn write_atomic(path: &Path, contents: &[u8]) -> io::Result<()> {
-    let mut tmp_name = path
-        .file_name()
-        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "path has no file name"))?
-        .to_os_string();
-    tmp_name.push(".agf-tmp");
-    // Same directory as the destination: `rename` is only atomic within one
-    // filesystem, so a temp in /tmp could silently degrade to copy+delete.
-    let tmp = match path.parent().filter(|p| !p.as_os_str().is_empty()) {
-        Some(dir) => dir.join(&tmp_name),
-        None => PathBuf::from(&tmp_name),
-    };
-
-    if let Err(e) = fill_temp(&tmp, contents) {
+    let destination = resolve_symlink_target(path)?;
+    let (tmp, mut file) = create_unique_temp(&destination)?;
+    if let Err(error) = file.write_all(contents).and_then(|()| file.sync_all()) {
+        drop(file);
         let _ = fs::remove_file(&tmp);
-        return Err(e);
+        return Err(error);
     }
+    drop(file);
 
     // Carry over the destination's mode so a restrictive history file does not
     // widen to whatever the umask grants a freshly created temp.
-    if let Ok(meta) = fs::metadata(path) {
+    if let Ok(meta) = fs::metadata(&destination) {
         let _ = fs::set_permissions(&tmp, meta.permissions());
     }
 
-    fs::rename(&tmp, path).inspect_err(|_| {
+    fs::rename(&tmp, &destination).inspect_err(|_| {
         let _ = fs::remove_file(&tmp);
     })
 }
 
-fn fill_temp(tmp: &Path, contents: &[u8]) -> io::Result<()> {
-    let mut file = fs::File::create(tmp)?;
-    file.write_all(contents)?;
-    // `rename` only orders the directory entry; without this the rename can
-    // land while the new contents are still sitting in the page cache.
-    file.sync_all()
+/// Atomic rename replaces a directory entry, so renaming over a symlink would
+/// destroy the link instead of updating its target. Resolve link chains first
+/// (including relative dotfile-manager links) and create the sibling temp next
+/// to the real destination.
+fn resolve_symlink_target(path: &Path) -> io::Result<PathBuf> {
+    let mut current = path.to_path_buf();
+    for _ in 0..40 {
+        match fs::symlink_metadata(&current) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                let target = fs::read_link(&current)?;
+                current = if target.is_absolute() {
+                    target
+                } else {
+                    current
+                        .parent()
+                        .unwrap_or_else(|| Path::new("."))
+                        .join(target)
+                };
+            }
+            Ok(_) => return Ok(current),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(current),
+            Err(error) => return Err(error),
+        }
+    }
+    Err(io::Error::new(
+        io::ErrorKind::InvalidInput,
+        "atomic-write symlink chain is too deep",
+    ))
+}
+
+fn create_unique_temp(path: &Path) -> io::Result<(PathBuf, fs::File)> {
+    static NEXT_TEMP_ID: AtomicU64 = AtomicU64::new(0);
+    let file_name = path
+        .file_name()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "path has no file name"))?
+        .to_string_lossy();
+    let parent = path.parent().filter(|p| !p.as_os_str().is_empty());
+
+    for _ in 0..128 {
+        let id = NEXT_TEMP_ID.fetch_add(1, Ordering::Relaxed);
+        let name = format!(".{file_name}.agf-tmp-{}-{id}", std::process::id());
+        let tmp = parent.map_or_else(|| PathBuf::from(&name), |dir| dir.join(&name));
+        let mut options = fs::OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        match options.open(&tmp) {
+            Ok(file) => return Ok((tmp, file)),
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(error),
+        }
+    }
+    Err(io::Error::new(
+        io::ErrorKind::AlreadyExists,
+        "could not allocate a unique atomic-write temporary file",
+    ))
 }
 
 #[cfg(test)]
@@ -87,7 +133,7 @@ mod tests {
             .unwrap()
             .flatten()
             .map(|e| e.file_name())
-            .filter(|n| n.to_string_lossy().contains(".agf-tmp"))
+            .filter(|n| n.to_string_lossy().contains(".agf-tmp-"))
             .collect();
         assert!(leftovers.is_empty(), "temp file left behind: {leftovers:?}");
         let _ = fs::remove_dir_all(dir);
@@ -101,6 +147,54 @@ mod tests {
         // destination is never truncated on the way to that failure.
         assert!(write_atomic(&path, b"x").is_err());
         assert!(!path.exists());
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn concurrent_atomic_writers_do_not_share_a_temp_file() {
+        let dir = temp_dir("concurrent");
+        let path = dir.join("cache.json");
+        let handles: Vec<_> = (0..16)
+            .map(|i| {
+                let path = path.clone();
+                std::thread::spawn(move || write_atomic(&path, format!("writer-{i}").as_bytes()))
+            })
+            .collect();
+        for handle in handles {
+            handle.join().unwrap().unwrap();
+        }
+        let content = fs::read_to_string(&path).unwrap();
+        assert!(content.starts_with("writer-"));
+        let leftovers = fs::read_dir(&dir)
+            .unwrap()
+            .flatten()
+            .filter(|entry| entry.file_name().to_string_lossy().contains(".agf-tmp-"))
+            .count();
+        assert_eq!(leftovers, 0);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn write_atomic_preserves_symlink_and_updates_target() {
+        use std::os::unix::fs::symlink;
+
+        let dir = temp_dir("symlink");
+        let target_dir = dir.join("dotfiles");
+        fs::create_dir_all(&target_dir).unwrap();
+        let target = target_dir.join("zshrc");
+        fs::write(&target, b"old\n").unwrap();
+        let link = dir.join(".zshrc");
+        symlink("dotfiles/zshrc", &link).unwrap();
+
+        write_atomic(&link, b"new\n").unwrap();
+
+        assert!(
+            fs::symlink_metadata(&link)
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+        assert_eq!(fs::read_to_string(&target).unwrap(), "new\n");
         let _ = fs::remove_dir_all(dir);
     }
 }

--- a/src/list.rs
+++ b/src/list.rs
@@ -1,4 +1,4 @@
-use std::io::{self, IsTerminal, Write};
+use std::io::{self, Write};
 
 use crate::model::Session;
 use crate::text;
@@ -34,7 +34,7 @@ struct Ansi {
 impl Ansi {
     fn new() -> Self {
         Self {
-            enabled: io::stdout().is_terminal(),
+            enabled: text::color_enabled(),
         }
     }
     fn rgb(&self, r: u8, g: u8, b: u8, text: &str) -> String {
@@ -77,7 +77,7 @@ fn print_table(sessions: &[Session]) {
 
     let max_project = sessions
         .iter()
-        .map(|s| text::width(&s.project_name))
+        .map(|s| text::width(&text::sanitize_terminal(&s.project_name)))
         .max()
         .unwrap_or(7)
         .clamp(7, 25);
@@ -117,15 +117,18 @@ fn print_table(sessions: &[Session]) {
     );
 
     for (i, s) in sessions.iter().enumerate() {
-        let path = s.display_path();
+        let path = text::sanitize_terminal(&s.display_path());
         let (r, g, b_val) = s.agent.color();
         // `text::fit`, not `format!("{:<n$}", …)`: the column budget is in
         // terminal columns but `{:<n$}` pads by char count, so a CJK project
         // name would push every column after it out of alignment.
-        let project = text::fit(&s.project_name, max_project);
+        let project = text::fit(&text::sanitize_terminal(&s.project_name), max_project);
         let agent = text::fit(&s.agent.to_string(), max_agent);
         let time = text::fit(&s.time_display(), 14);
-        let branch = text::fit(s.git_branch.as_deref().unwrap_or("—"), 10);
+        let branch = text::fit(
+            &text::sanitize_terminal(s.git_branch.as_deref().unwrap_or("—")),
+            10,
+        );
         let num = format!("{:>3}", i + 1);
 
         let _ = writeln!(
@@ -156,21 +159,25 @@ fn print_json(sessions: &[Session]) {
                 "git_branch": s.git_branch,
                 "worktree": s.worktree,
                 "summaries": s.summaries,
+                "interactive": s.interactive,
             })
         })
         .collect();
     if let Ok(json) = serde_json::to_string_pretty(&items) {
-        println!("{json}");
+        let mut out = io::stdout().lock();
+        let _ = writeln!(out, "{json}");
     }
 }
 
 fn print_csv(sessions: &[Session]) {
-    println!("project,agent,time,path,session_id,branch");
+    let mut out = io::stdout().lock();
+    let _ = writeln!(out, "project,agent,time,path,session_id,branch");
     for s in sessions {
         // Every field goes through `csv_escape`. Branch names in particular
         // may legally contain commas, which would silently shift every later
         // column in the consuming spreadsheet/script.
-        println!(
+        let _ = writeln!(
+            out,
             "{},{},{},{},{},{}",
             csv_escape(&s.project_name),
             csv_escape(&s.agent.to_string()),
@@ -188,22 +195,6 @@ fn csv_escape(s: &str) -> String {
     } else {
         s.to_string()
     }
-}
-
-pub fn filter_by_agent(sessions: Vec<Session>, agent_name: &str) -> Vec<Session> {
-    let agent_lower = agent_name.to_lowercase();
-    sessions
-        .into_iter()
-        .filter(|s| {
-            s.agent.cli_name().to_lowercase() == agent_lower
-                || s.agent.to_string().to_lowercase() == agent_lower
-                || s.agent
-                    .to_string()
-                    .to_lowercase()
-                    .replace(' ', "")
-                    .contains(&agent_lower)
-        })
-        .collect()
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ mod tui;
 mod watch;
 
 use std::io::IsTerminal;
+use std::io::Write;
 
 use clap::{Parser, Subcommand};
 
@@ -38,10 +39,15 @@ enum Commands {
     /// Output shell wrapper function for the given shell
     Init {
         /// Shell type: zsh, bash, fish, or powershell (alias: pwsh)
+        #[arg(value_parser = ["zsh", "bash", "fish", "powershell", "pwsh"])]
         shell: String,
     },
-    /// Auto-detect shell and add agf to your shell config
-    Setup,
+    /// Add agf to a shell config (auto-detected unless --shell is supplied)
+    Setup {
+        /// Shell type: zsh, bash, fish, or powershell
+        #[arg(long)]
+        shell: Option<String>,
+    },
     /// Fuzzy-match a session and resume it directly (no TUI)
     Resume {
         /// Fuzzy query to match a session (project name, path, summary)
@@ -55,6 +61,9 @@ enum Commands {
         /// Permission/approval mode (e.g. acceptEdits, yolo, full-auto)
         #[arg(long)]
         mode: Option<String>,
+        /// Include Codex subagents and non-interactive exec sessions
+        #[arg(long)]
+        include_non_interactive: bool,
     },
     /// List sessions as plain text (for scripting)
     List {
@@ -67,18 +76,27 @@ enum Commands {
         /// Output format: table, json, csv
         #[arg(long, default_value = "table")]
         format: String,
+        /// Include Codex subagents and non-interactive exec sessions
+        #[arg(long)]
+        include_non_interactive: bool,
     },
     /// Show session statistics
     Stats {
         /// Output as JSON
         #[arg(long)]
         json: bool,
+        /// Include Codex subagents and non-interactive exec sessions
+        #[arg(long)]
+        include_non_interactive: bool,
     },
     /// Live dashboard showing agent sessions with auto-refresh
     Watch {
         /// Refresh interval in seconds
-        #[arg(long, default_value = "5")]
+        #[arg(long, default_value = "5", value_parser = clap::value_parser!(u64).range(1..))]
         interval: u64,
+        /// Include Codex subagents and non-interactive exec sessions
+        #[arg(long)]
+        include_non_interactive: bool,
     },
 }
 
@@ -87,7 +105,7 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 fn main() -> anyhow::Result<()> {
     // Handle --version / -V manually (clap hides it due to args_conflicts_with_subcommands)
     if std::env::args().any(|a| a == "--version" || a == "-V") {
-        println!("agf {VERSION}");
+        write_stdout(format!("agf {VERSION}\n").as_bytes())?;
         return Ok(());
     }
 
@@ -95,11 +113,11 @@ fn main() -> anyhow::Result<()> {
 
     match cli.command {
         Some(Commands::Init { shell }) => {
-            print!("{}", shell::shell_init(&shell));
+            write_stdout(shell::shell_init(&shell).as_bytes())?;
             return Ok(());
         }
-        Some(Commands::Setup) => {
-            shell::setup()?;
+        Some(Commands::Setup { shell }) => {
+            shell::setup(shell.as_deref())?;
             return Ok(());
         }
         Some(Commands::Resume {
@@ -107,15 +125,13 @@ fn main() -> anyhow::Result<()> {
             agent,
             list: list_count,
             mode,
+            include_non_interactive,
         }) => {
             let query = query.join(" ");
-            let mut sessions = scanner::scan_all();
-            if let Some(ref agent_name) = agent {
-                sessions = list::filter_by_agent(sessions, agent_name);
-            }
+            let sessions = scan_for_cli(agent.as_deref(), include_non_interactive)?;
             let mut fuzzy = fuzzy::FuzzyMatcher::new();
             let all_indices: Vec<usize> = (0..sessions.len()).collect();
-            let results = fuzzy.filter(&sessions, &all_indices, &query, 5, false);
+            let results = fuzzy.filter(&sessions, &all_indices, &query, 5, true);
 
             if results.is_empty() {
                 eprintln!("No session matching '{query}'");
@@ -123,6 +139,9 @@ fn main() -> anyhow::Result<()> {
             }
 
             let chosen = if let Some(n) = list_count {
+                if !std::io::stdin().is_terminal() || !std::io::stdout().is_terminal() {
+                    anyhow::bail!("resume --list requires an interactive terminal");
+                }
                 // Interactive: show top N and let user pick. `n.max(1)` guards
                 // `--list 0`: an empty top_n would underflow `top_n.len() - 1`
                 // below (results is already non-empty here).
@@ -133,14 +152,20 @@ fn main() -> anyhow::Result<()> {
                         "  {}) {} | {} | {}",
                         i + 1,
                         s.agent,
-                        s.project_name,
+                        text::sanitize_terminal(&s.project_name),
                         s.time_display()
                     );
                 }
                 eprint!("Select [1-{}]: ", top_n.len());
                 let mut input = String::new();
                 std::io::stdin().read_line(&mut input)?;
-                let pick: usize = input.trim().parse().unwrap_or(1);
+                let pick: usize = input
+                    .trim()
+                    .parse()
+                    .map_err(|_| anyhow::anyhow!("invalid selection"))?;
+                if !(1..=top_n.len()).contains(&pick) {
+                    anyhow::bail!("selection must be between 1 and {}", top_n.len());
+                }
                 let idx = pick.saturating_sub(1).min(top_n.len() - 1);
                 &sessions[all_indices[top_n[idx].index]]
             } else {
@@ -148,17 +173,28 @@ fn main() -> anyhow::Result<()> {
             };
 
             // Build resume command with optional mode flags
-            let flags = mode
-                .as_deref()
-                .and_then(|m| {
-                    chosen
-                        .agent
-                        .resume_mode_options()
-                        .iter()
-                        .find(|(label, _)| label.to_lowercase().contains(&m.to_lowercase()))
-                        .map(|(_, f)| *f)
-                })
-                .unwrap_or("");
+            let flags = match mode.as_deref() {
+                None => "",
+                Some(requested) => chosen
+                    .agent
+                    .resume_mode_options()
+                    .iter()
+                    .find(|(label, _)| label.eq_ignore_ascii_case(requested))
+                    .map(|(_, flags)| *flags)
+                    .ok_or_else(|| {
+                        let available = chosen
+                            .agent
+                            .resume_mode_options()
+                            .iter()
+                            .map(|(label, _)| *label)
+                            .collect::<Vec<_>>()
+                            .join(", ");
+                        anyhow::anyhow!(
+                            "unsupported mode {requested:?} for {}; expected one of: {available}",
+                            chosen.agent
+                        )
+                    })?,
+            };
 
             let cmd = action::resume_with_flags(chosen, flags);
             return deliver_command(&cmd);
@@ -167,11 +203,9 @@ fn main() -> anyhow::Result<()> {
             agent,
             limit,
             format,
+            include_non_interactive,
         }) => {
-            let mut sessions = scanner::scan_all();
-            if let Some(ref agent_name) = agent {
-                sessions = list::filter_by_agent(sessions, agent_name);
-            }
+            let mut sessions = scan_for_cli(agent.as_deref(), include_non_interactive)?;
             sessions.truncate(limit);
             if sessions.is_empty() {
                 eprintln!("No sessions found.");
@@ -180,35 +214,40 @@ fn main() -> anyhow::Result<()> {
             list::list_sessions(&sessions, list::OutputFormat::parse(&format));
             return Ok(());
         }
-        Some(Commands::Stats { json }) => {
-            let sessions = scanner::scan_all();
+        Some(Commands::Stats {
+            json,
+            include_non_interactive,
+        }) => {
+            let sessions = scan_for_cli(None, include_non_interactive)?;
             stats::print_stats(&sessions, json);
             return Ok(());
         }
-        Some(Commands::Watch { interval }) => {
-            watch::run_watch(interval)?;
+        Some(Commands::Watch {
+            interval,
+            include_non_interactive,
+        }) => {
+            watch::run_watch(interval, include_non_interactive)?;
             return Ok(());
         }
         None => {}
     }
 
+    if !std::io::stdin().is_terminal() || !std::io::stdout().is_terminal() {
+        return Err(anyhow::anyhow!(
+            "interactive TUI requires terminal stdin and stdout; use `agf list` for pipelines"
+        ));
+    }
+
     let config = settings::Settings::load();
 
-    // Enter alt-screen BEFORE scanning so the user doesn't see their shell prompt
-    // during the first-run scan (which can take 200ms-3s). The guard is scoped so
-    // it drops before `deliver_command()` runs — that path may `exec sh -c` and
-    // inherits terminal state.
     let cmd_opt = {
-        let guard = AltScreenGuard::new();
-
         // Load whatever the cache has — even if stale, we open the TUI on it
         // immediately so cold starts feel instant. Stale agents refresh in
         // the background and stream their results into the running TUI.
-        let (mut sessions, stale_agents) = cache::load_cache();
+        let (sessions, stale_agents) = cache::load_cache();
 
         // Cold cache + no installed agents: nothing we can ever scan.
         if sessions.is_empty() && stale_agents.is_empty() {
-            drop(guard);
             eprintln!("No agent sessions found.");
             return Ok(());
         }
@@ -220,15 +259,6 @@ fn main() -> anyhow::Result<()> {
         };
         let scanning_agents: std::collections::HashSet<model::Agent> =
             stale_agents.iter().copied().collect();
-
-        // Apply max_sessions limit from config (the streamed-in agents will
-        // also re-truncate after each ingest in App::ingest_scan_result).
-        if let Some(max) = config.max_sessions {
-            sessions.truncate(max);
-        }
-
-        // Keep the guard alive for the full TUI session.
-        let _guard = guard;
 
         let cwd = std::env::current_dir()
             .ok()
@@ -263,7 +293,14 @@ fn main() -> anyhow::Result<()> {
         // the next launch reflects all scans that completed before exit.
         // Agents still scanning at exit keep their prior cache entry so we
         // don't accidentally persist "empty + fresh-mtime" for them.
-        cache::write_cache(&app.sessions, &app.scanning_agents);
+        let cache_skip_agents = app.cache_skip_agents();
+        let cache_invalidate_agents = app.cache_invalidate_agents();
+        cache::write_cache(
+            &app.sessions,
+            &cache_skip_agents,
+            &cache_invalidate_agents,
+            &app.scan_fingerprints,
+        );
         result
     };
 
@@ -274,35 +311,76 @@ fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// RAII guard that enters the alternate screen and hides the cursor on
-/// construction, and restores both on drop. Uses raw ANSI escape codes to
-/// avoid taking a direct dependency on crossterm.
-///
-/// Safe to nest: SLT's `run_with` also enters the alt-screen via the same
-/// VT control sequence; entering twice is idempotent at the terminal level.
-struct AltScreenGuard;
-
-impl AltScreenGuard {
-    fn new() -> Self {
-        use std::io::Write;
-        let mut out = std::io::stdout();
-        // ESC[?1049h  enter alt-screen buffer
-        // ESC[?25l    hide cursor
-        let _ = out.write_all(b"\x1b[?1049h\x1b[?25l");
-        let _ = out.flush();
-        Self
+fn write_stdout(content: &[u8]) -> anyhow::Result<()> {
+    match std::io::stdout().lock().write_all(content) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::BrokenPipe => Ok(()),
+        Err(error) => Err(error.into()),
     }
 }
 
-impl Drop for AltScreenGuard {
-    fn drop(&mut self) {
-        use std::io::Write;
-        let mut out = std::io::stdout();
-        // ESC[?1049l  leave alt-screen buffer
-        // ESC[?25h    show cursor
-        let _ = out.write_all(b"\x1b[?1049l\x1b[?25h");
-        let _ = out.flush();
+fn scan_for_cli(
+    agent_name: Option<&str>,
+    include_non_interactive: bool,
+) -> anyhow::Result<Vec<model::Session>> {
+    let include_non_interactive =
+        include_non_interactive || settings::Settings::load().include_non_interactive;
+    let requested = agent_name
+        .map(|name| {
+            model::Agent::parse(name).ok_or_else(|| anyhow::anyhow!("unknown agent {name:?}"))
+        })
+        .transpose()?;
+    let (mut sessions, stale) = cache::load_cache();
+    let agents_to_scan = match requested {
+        Some(agent) if stale.contains(&agent) || !config::is_agent_installed(agent) => vec![agent],
+        Some(_) => Vec::new(),
+        None => stale,
+    };
+    if !agents_to_scan.is_empty() {
+        let mut succeeded = std::collections::HashSet::new();
+        let mut observed_fingerprints = std::collections::HashMap::new();
+        let mut failures = Vec::new();
+        for (agent, result) in scanner::scan_agents_detailed(&agents_to_scan) {
+            match result {
+                Ok(scan) => {
+                    sessions.retain(|session| session.agent != agent);
+                    sessions.extend(scan.sessions);
+                    if let Some(fingerprint) = scan.fingerprint {
+                        observed_fingerprints.insert(agent, fingerprint);
+                    }
+                    succeeded.insert(agent);
+                }
+                Err(error) => failures.push((agent, error)),
+            }
+        }
+        if let Some(agent) = requested
+            && let Some((_, error)) = failures.iter().find(|(failed, _)| *failed == agent)
+        {
+            return Err(anyhow::anyhow!("{agent} scanner failed: {error}"));
+        }
+        for (agent, error) in &failures {
+            eprintln!("[agf] {agent} scanner failed; keeping cached rows: {error}");
+        }
+        sessions.sort_by(|a, b| model::compare_sessions(a, b, model::SortMode::Time));
+
+        let skip_agents: std::collections::HashSet<_> = config::installed_agents()
+            .into_iter()
+            .filter(|agent| !succeeded.contains(agent))
+            .collect();
+        cache::write_cache(
+            &sessions,
+            &skip_agents,
+            &std::collections::HashSet::new(),
+            &observed_fingerprints,
+        );
     }
+    if let Some(agent) = requested {
+        sessions.retain(|session| session.agent == agent);
+    }
+    if !include_non_interactive {
+        sessions.retain(|session| session.interactive);
+    }
+    Ok(sessions)
 }
 
 /// Deliver a generated shell command to the parent context.
@@ -331,7 +409,7 @@ fn deliver_command(cmd: &str) -> anyhow::Result<()> {
         return Ok(());
     }
 
-    if std::io::stdout().is_terminal() {
+    if std::io::stdin().is_terminal() && std::io::stdout().is_terminal() {
         return exec_via_shell(cmd, shell);
     }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -5,7 +5,9 @@ use crate::shell::CommandShell;
 // Serde derives are load-bearing for the session cache: unit variants
 // serialize as their exact variant names ("ClaudeCode", "Codex", ...), which
 // is the on-disk format of ~/.cache/agf/sessions.json.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
+)]
 #[allow(clippy::enum_variant_names)]
 pub enum Agent {
     ClaudeCode,
@@ -18,6 +20,7 @@ pub enum Agent {
     Gemini,
     Hermes,
     Yolop,
+    PrimeAgent,
 }
 
 impl fmt::Display for Agent {
@@ -33,6 +36,7 @@ impl fmt::Display for Agent {
             Agent::Gemini => write!(f, "Gemini"),
             Agent::Hermes => write!(f, "Hermes"),
             Agent::Yolop => write!(f, "Yolop"),
+            Agent::PrimeAgent => write!(f, "Prime Agent"),
         }
     }
 }
@@ -50,6 +54,7 @@ impl Agent {
             Agent::Gemini => (66, 133, 244),     // #4285F4 Google blue
             Agent::Hermes => (168, 85, 247),     // #A855F7 purple (Nous Research)
             Agent::Yolop => (34, 197, 94),       // #22C55E green
+            Agent::PrimeAgent => (99, 102, 241), // #6366F1 indigo
         }
     }
 
@@ -65,6 +70,7 @@ impl Agent {
             Agent::Gemini,
             Agent::Hermes,
             Agent::Yolop,
+            Agent::PrimeAgent,
         ]
     }
 
@@ -81,6 +87,7 @@ impl Agent {
             Agent::Gemini => "gemini",
             Agent::Hermes => "hermes",
             Agent::Yolop => "yolop",
+            Agent::PrimeAgent => "prime-agent",
         }
     }
 
@@ -98,13 +105,12 @@ impl Agent {
             Agent::OpenCode => format!("opencode -s {id}"),
             Agent::Pi => format!("pi --session {id}"),
             Agent::OhMyPi => format!("omp --resume {id}"),
-            // Kiro CLI has no per-session resume flag — `--resume` always
-            // reopens the latest session for the cwd, so session_id is unused.
-            Agent::Kiro => "kiro-cli chat --resume".to_string(),
+            Agent::Kiro => format!("kiro-cli chat --resume-id {id}"),
             Agent::CursorAgent => format!("cursor-agent --resume {id}"),
             Agent::Gemini => format!("gemini --resume {id}"),
             Agent::Hermes => format!("hermes --resume {id}"),
             Agent::Yolop => format!("yolop --session {id}"),
+            Agent::PrimeAgent => format!("prime-agent --resume {id}"),
         }
     }
 
@@ -119,8 +125,8 @@ impl Agent {
             ],
             Agent::Codex => &[
                 ("default", ""),
-                ("auto-edit", " -a untrusted"),
-                ("full-auto", " --full-auto"),
+                ("workspace-write", " -a on-request -s workspace-write"),
+                ("full-auto", " -a never -s workspace-write"),
                 (
                     "bypass sandbox",
                     " --dangerously-bypass-approvals-and-sandbox",
@@ -150,6 +156,42 @@ impl Agent {
             Agent::Gemini => "gemini",
             Agent::Hermes => "hermes",
             Agent::Yolop => "yolop",
+            Agent::PrimeAgent => "prime-agent",
+        }
+    }
+
+    /// Stable lowercase identifier used in settings and CLI filters.
+    pub fn slug(self) -> &'static str {
+        match self {
+            Agent::ClaudeCode => "claude",
+            Agent::Codex => "codex",
+            Agent::OpenCode => "opencode",
+            Agent::Pi => "pi",
+            Agent::OhMyPi => "oh-my-pi",
+            Agent::Kiro => "kiro",
+            Agent::CursorAgent => "cursor",
+            Agent::Gemini => "gemini",
+            Agent::Hermes => "hermes",
+            Agent::Yolop => "yolop",
+            Agent::PrimeAgent => "prime-agent",
+        }
+    }
+
+    pub fn parse(name: &str) -> Option<Self> {
+        let normalized = name.trim().to_ascii_lowercase().replace([' ', '_'], "-");
+        match normalized.as_str() {
+            "claude" | "claude-code" => Some(Agent::ClaudeCode),
+            "codex" => Some(Agent::Codex),
+            "opencode" | "open-code" => Some(Agent::OpenCode),
+            "pi" => Some(Agent::Pi),
+            "omp" | "oh-my-pi" | "ohmypi" => Some(Agent::OhMyPi),
+            "kiro" | "kiro-cli" => Some(Agent::Kiro),
+            "cursor" | "cursor-cli" | "cursor-agent" => Some(Agent::CursorAgent),
+            "gemini" => Some(Agent::Gemini),
+            "hermes" => Some(Agent::Hermes),
+            "yolop" => Some(Agent::Yolop),
+            "prime" | "prime-agent" | "prime-intellect" => Some(Agent::PrimeAgent),
+            _ => None,
         }
     }
 }
@@ -190,13 +232,22 @@ pub struct Session {
     pub git_branch: Option<String>,
     pub worktree: Option<String>,
     pub recap: Option<String>, // Claude Code away_summary, optionally prefixed with aiTitle
+    /// Whether this is a top-level interactive session. Internal subagents and
+    /// non-interactive exec runs remain discoverable but are hidden by default.
+    pub interactive: bool,
 }
 
 impl Session {
     /// Short relative time without "ago": `now`, `3m`, `2h`, `5d`, `2w`, `1mo`
     pub fn relative_time_short(&self) -> String {
+        if self.timestamp < 946_684_800_000 {
+            return "unknown".to_string();
+        }
         let now = chrono::Utc::now().timestamp_millis();
         let diff_secs = (now - self.timestamp) / 1000;
+        if diff_secs < -300 {
+            return "future".to_string();
+        }
         if diff_secs < 0 {
             return "now".to_string();
         }
@@ -214,6 +265,9 @@ impl Session {
     /// Absolute date: `MM/DD` or `MM/DD/YY` if different year
     pub fn date_str(&self) -> String {
         use chrono::{Local, TimeZone};
+        if self.timestamp < 946_684_800_000 {
+            return "—".to_string();
+        }
         let dt = match Local.timestamp_millis_opt(self.timestamp) {
             chrono::LocalResult::Single(dt) => dt,
             _ => return String::new(),
@@ -239,11 +293,16 @@ impl Session {
             return "—".to_string();
         }
         if let Some(home) = dirs::home_dir()
-            && let Some(rest) = self.project_path.strip_prefix(home.to_str().unwrap_or(""))
+            && let Ok(rest) = std::path::Path::new(&self.project_path).strip_prefix(&home)
         {
-            return format!("~{rest}");
+            let display = if rest.as_os_str().is_empty() {
+                "~".to_string()
+            } else {
+                format!("~/{}", rest.to_string_lossy())
+            };
+            return crate::text::sanitize_terminal(&display);
         }
-        self.project_path.clone()
+        crate::text::sanitize_terminal(&self.project_path)
     }
 
     pub fn search_text(&self, max_summaries: usize, include_summaries: bool) -> String {
@@ -259,6 +318,78 @@ impl Session {
             text.push_str(branch);
         }
         text
+    }
+
+    pub fn identity(&self) -> SessionIdentity {
+        SessionIdentity {
+            agent: self.agent,
+            session_id: self.session_id.clone(),
+        }
+    }
+
+    pub fn settings_key(&self) -> String {
+        format!("{}:{}", self.agent.slug(), self.session_id)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SessionIdentity {
+    pub agent: Agent,
+    pub session_id: String,
+}
+
+/// Deterministic total ordering for every non-fuzzy view.
+pub fn compare_sessions(a: &Session, b: &Session, mode: SortMode) -> std::cmp::Ordering {
+    let identity = || {
+        a.agent
+            .cmp(&b.agent)
+            .then_with(|| a.project_path.cmp(&b.project_path))
+            .then_with(|| a.session_id.cmp(&b.session_id))
+    };
+    match mode {
+        SortMode::Time => b.timestamp.cmp(&a.timestamp).then_with(identity),
+        SortMode::Name => compare_lowercase(&a.project_name, &b.project_name)
+            .then_with(|| b.timestamp.cmp(&a.timestamp))
+            .then_with(identity),
+        SortMode::Agent => a
+            .agent
+            .cmp(&b.agent)
+            .then_with(|| b.timestamp.cmp(&a.timestamp))
+            .then_with(identity),
+    }
+}
+
+fn compare_lowercase(a: &str, b: &str) -> std::cmp::Ordering {
+    let mut a = a.chars().flat_map(char::to_lowercase);
+    let mut b = b.chars().flat_map(char::to_lowercase);
+    loop {
+        match (a.next(), b.next()) {
+            (Some(left), Some(right)) => match left.cmp(&right) {
+                std::cmp::Ordering::Equal => {}
+                ordering => return ordering,
+            },
+            (Some(_), None) => return std::cmp::Ordering::Greater,
+            (None, Some(_)) => return std::cmp::Ordering::Less,
+            (None, None) => return std::cmp::Ordering::Equal,
+        }
+    }
+}
+
+/// Clamp scanner timestamps to a plausible activity range. A corrupt future
+/// timestamp must not pin a session to the top or be rendered deceptively as
+/// `now`; callers provide their best durable fallback (often file mtime).
+pub fn normalize_timestamp(candidate: i64, fallback: i64) -> i64 {
+    const MIN_VALID_MS: i64 = 946_684_800_000; // 2000-01-01
+    const FUTURE_SKEW_MS: i64 = 5 * 60 * 1000;
+    let now = chrono::Utc::now().timestamp_millis();
+    let valid =
+        |timestamp: i64| (MIN_VALID_MS..=now.saturating_add(FUTURE_SKEW_MS)).contains(&timestamp);
+    if valid(candidate) {
+        candidate
+    } else if valid(fallback) {
+        fallback
+    } else {
+        0
     }
 }
 
@@ -340,6 +471,19 @@ mod tests {
     }
 
     #[test]
+    fn kiro_and_prime_resume_commands_keep_the_selected_id() {
+        let shell = CommandShell::Posix;
+        assert_eq!(
+            Agent::Kiro.resume_cmd("older-session", &shell),
+            "kiro-cli chat --resume-id 'older-session'"
+        );
+        assert_eq!(
+            Agent::PrimeAgent.resume_cmd("prime-session", &shell),
+            "prime-agent --resume 'prime-session'"
+        );
+    }
+
+    #[test]
     fn oh_my_pi_resume_command_uses_selected_session_id() {
         assert_eq!(
             Agent::OhMyPi.resume_cmd(
@@ -347,6 +491,81 @@ mod tests {
                 &crate::shell::CommandShell::Posix
             ),
             "omp --resume '019e14f4-c9a5-76dc-b7b6-0613e602a620'"
+        );
+    }
+
+    #[test]
+    fn time_sort_has_a_deterministic_identity_tie_breaker() {
+        let make = |agent, id: &str| Session {
+            agent,
+            session_id: id.into(),
+            project_name: "project".into(),
+            project_path: "/tmp/project".into(),
+            summaries: Vec::new(),
+            timestamp: 1_800_000_000_000,
+            git_branch: None,
+            worktree: None,
+            recap: None,
+            interactive: true,
+        };
+        let mut sessions = [
+            make(Agent::Codex, "b"),
+            make(Agent::ClaudeCode, "z"),
+            make(Agent::Codex, "a"),
+        ];
+        sessions.sort_by(|a, b| compare_sessions(a, b, SortMode::Time));
+        let identities: Vec<_> = sessions
+            .iter()
+            .map(|session| (session.agent, session.session_id.as_str()))
+            .collect();
+        assert_eq!(
+            identities,
+            [
+                (Agent::ClaudeCode, "z"),
+                (Agent::Codex, "a"),
+                (Agent::Codex, "b")
+            ]
+        );
+    }
+
+    #[test]
+    fn display_path_does_not_tilde_a_home_name_sibling() {
+        let Some(home) = dirs::home_dir() else {
+            return;
+        };
+        let session = Session {
+            agent: Agent::Codex,
+            session_id: "id".into(),
+            project_name: "project".into(),
+            project_path: format!("{}2/repo", home.display()),
+            summaries: Vec::new(),
+            timestamp: 0,
+            git_branch: None,
+            worktree: None,
+            recap: None,
+            interactive: true,
+        };
+        assert_eq!(session.display_path(), format!("{}2/repo", home.display()));
+    }
+
+    #[test]
+    fn invalid_and_future_times_are_visible_not_disguised_as_now() {
+        let make = |timestamp| Session {
+            agent: Agent::Codex,
+            session_id: "id".into(),
+            project_name: "p".into(),
+            project_path: "/p".into(),
+            summaries: Vec::new(),
+            timestamp,
+            git_branch: None,
+            worktree: None,
+            recap: None,
+            interactive: true,
+        };
+        assert_eq!(make(0).relative_time_short(), "unknown");
+        assert_eq!(
+            make(chrono::Utc::now().timestamp_millis() + 10 * 60_000).relative_time_short(),
+            "future"
         );
     }
 }

--- a/src/scanner/claude.rs
+++ b/src/scanner/claude.rs
@@ -1,6 +1,5 @@
 use std::collections::{HashMap, HashSet};
 use std::fs;
-use std::io::BufRead;
 
 use rayon::prelude::*;
 
@@ -9,7 +8,7 @@ use serde_json::Value;
 
 use crate::error::AgfError;
 use crate::model::{Agent, Session};
-use crate::scanner::{collapse_whitespace, read_head_tail};
+use crate::scanner::{collapse_whitespace, for_each_bounded_line_with_overflow, read_head_tail};
 
 /// Per-file I/O cap for `scan_session_metadata`. Files larger than the sum
 /// fall back to head + tail reads; smaller files are read in full. Sized so
@@ -29,6 +28,8 @@ use crate::scanner::{collapse_whitespace, read_head_tail};
 /// `~/.claude/projects` trees (tens of MB read for an off-by-default recap).
 const HEAD_BYTES: u64 = 16 * 1024;
 const TAIL_BYTES: u64 = 32 * 1024;
+const HISTORY_LINE_BYTES: usize = 2 * 1024 * 1024;
+const MAX_SUMMARIES: usize = 10;
 
 #[derive(Deserialize)]
 struct ClaudeEntry {
@@ -56,23 +57,26 @@ struct SessionMeta {
 ///
 /// Callers (orphan filtering + `scan_session_metadata`) share this so the
 /// directory tree is only read once per scan.
-fn list_session_files(claude_dir: &std::path::Path) -> Vec<(String, std::path::PathBuf)> {
+fn list_session_files(
+    claude_dir: &std::path::Path,
+) -> Result<Vec<(String, std::path::PathBuf)>, AgfError> {
     let projects_dir = claude_dir.join("projects");
 
-    let Ok(proj_entries) = fs::read_dir(&projects_dir) else {
-        return Vec::new();
-    };
+    if !projects_dir.exists() {
+        return Ok(Vec::new());
+    }
+    let proj_entries = fs::read_dir(&projects_dir)?;
 
     let mut file_paths: Vec<(String, std::path::PathBuf)> = Vec::new();
-    for proj_entry in proj_entries.flatten() {
+    for proj_entry in proj_entries {
+        let proj_entry = proj_entry?;
         let proj_path = proj_entry.path();
         if !proj_path.is_dir() {
             continue;
         }
-        let Ok(session_files) = fs::read_dir(&proj_path) else {
-            continue;
-        };
-        for session_file in session_files.flatten() {
+        let session_files = fs::read_dir(&proj_path)?;
+        for session_file in session_files {
+            let session_file = session_file?;
             let file_path = session_file.path();
             if file_path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
                 continue;
@@ -87,7 +91,7 @@ fn list_session_files(claude_dir: &std::path::Path) -> Vec<(String, std::path::P
         }
     }
 
-    file_paths
+    Ok(file_paths)
 }
 
 /// Scan ~/.claude/projects/*/<sessionId>.jsonl to detect worktree sessions
@@ -97,11 +101,13 @@ fn list_session_files(claude_dir: &std::path::Path) -> Vec<(String, std::path::P
 /// worktree sessions looks like `<project>/.claude/worktrees/<name>`.
 fn scan_session_metadata(
     file_paths: Vec<(String, std::path::PathBuf)>,
-) -> HashMap<String, SessionMeta> {
-    file_paths
+) -> Result<HashMap<String, SessionMeta>, AgfError> {
+    let entries: Result<Vec<Option<(String, SessionMeta)>>, std::io::Error> = file_paths
         .into_par_iter()
-        .filter_map(|(session_id, file_path)| {
-            let ht = read_head_tail(&file_path, HEAD_BYTES, TAIL_BYTES)?;
+        .map(|(session_id, file_path)| {
+            let ht = read_head_tail(&file_path, HEAD_BYTES, TAIL_BYTES).ok_or_else(|| {
+                std::io::Error::other(format!("could not read {}", file_path.display()))
+            })?;
 
             let mut worktree: Option<String> = None;
             let mut ai_title: Option<String> = None;
@@ -144,12 +150,13 @@ fn scan_session_metadata(
             };
 
             if worktree.is_some() || recap.is_some() {
-                Some((session_id, SessionMeta { worktree, recap }))
+                Ok(Some((session_id, SessionMeta { worktree, recap })))
             } else {
-                None
+                Ok(None)
             }
         })
-        .collect()
+        .collect();
+    Ok(entries?.into_iter().flatten().collect())
 }
 
 fn extract_worktree(val: &Value, worktree: &mut Option<String>) {
@@ -227,63 +234,83 @@ pub fn scan() -> Result<Vec<Session>, AgfError> {
         return Ok(Vec::new());
     }
 
-    let session_files = list_session_files(&claude_dir);
+    let session_files = list_session_files(&claude_dir)?;
     let existing_ids: HashSet<String> = session_files.iter().map(|(id, _)| id.clone()).collect();
-    let session_meta = scan_session_metadata(session_files);
+    let session_meta = scan_session_metadata(session_files)?;
     let mut branch_cache: HashMap<String, Option<String>> = HashMap::new();
     let mut sessions_map: HashMap<String, SessionData> = HashMap::new();
 
-    let file = fs::File::open(&path)?;
-    for line in std::io::BufReader::new(file).lines() {
-        let line = match line {
-            Ok(l) => l,
-            Err(_) => continue,
-        };
-        let line = line.trim();
-        if line.is_empty() {
-            continue;
-        }
-        let entry: ClaudeEntry = match serde_json::from_str(line) {
-            Ok(e) => e,
-            Err(_) => continue,
-        };
-        let session_id = match &entry.session_id {
-            Some(id) if !id.is_empty() => id.clone(),
-            _ => continue,
-        };
-        if !existing_ids.contains(&session_id) {
-            // Orphans (no per-session JSONL under ~/.claude/projects/) are
-            // dropped by the final filter anyway; skip early so unbounded
-            // history.jsonl growth (#27) doesn't accumulate dead SessionData
-            // and summary tuples for the whole scan. Mirrors the
-            // codex::read_history_summaries pre-filter from v0.11.4.
-            continue;
-        }
-        let ts = entry.timestamp.unwrap_or(0.0);
-
-        let data = sessions_map
-            .entry(session_id)
-            .or_insert_with(|| SessionData {
-                project: entry.project.clone().unwrap_or_default(),
-                timestamp: ts,
-                summaries: Vec::new(),
-            });
-
-        // Keep the latest timestamp and project
-        if ts >= data.timestamp {
-            data.timestamp = ts;
-            if let Some(ref proj) = entry.project {
-                data.project = proj.clone();
+    let completed = for_each_bounded_line_with_overflow(
+        &path,
+        usize::MAX,
+        HISTORY_LINE_BYTES,
+        |line, tail, oversized| {
+            if line.iter().all(u8::is_ascii_whitespace) {
+                return;
             }
-        }
-
-        if let Some(display) = entry.display {
-            // Collapse multi-line content (e.g. pasted text) into a single line.
-            let display = collapse_whitespace(&display);
-            if !display.is_empty() {
-                data.summaries.push((ts, display));
+            let entry: ClaudeEntry = if oversized {
+                ClaudeEntry {
+                    display: Some("(large prompt)".to_string()),
+                    timestamp: json_number_from_fragment(tail, "timestamp"),
+                    project: json_string_from_fragment(tail, "project"),
+                    session_id: json_string_from_fragment(tail, "sessionId"),
+                }
+            } else {
+                match serde_json::from_slice(line) {
+                    Ok(entry) => entry,
+                    Err(_) => return,
+                }
+            };
+            let session_id = match &entry.session_id {
+                Some(id) if !id.is_empty() => id.clone(),
+                _ => return,
+            };
+            if !existing_ids.contains(&session_id) {
+                // Orphans (no per-session JSONL under ~/.claude/projects/) are
+                // dropped by the final filter anyway; skip early so unbounded
+                // history.jsonl growth (#27) doesn't accumulate dead SessionData
+                // and summary tuples for the whole scan. Mirrors the
+                // codex::read_history_summaries pre-filter from v0.11.4.
+                return;
             }
-        }
+            let ts = entry.timestamp.unwrap_or(0.0);
+
+            let data = sessions_map
+                .entry(session_id)
+                .or_insert_with(|| SessionData {
+                    project: entry.project.clone().unwrap_or_default(),
+                    timestamp: ts,
+                    summaries: Vec::new(),
+                });
+
+            // Keep the latest timestamp and project
+            if ts >= data.timestamp {
+                data.timestamp = ts;
+                if let Some(ref proj) = entry.project {
+                    data.project = proj.clone();
+                }
+            }
+
+            if let Some(display) = entry.display {
+                // Collapse multi-line content (e.g. pasted text) into a single line.
+                let display = collapse_whitespace(&display);
+                if !display.is_empty() {
+                    if data.summaries.len() < MAX_SUMMARIES {
+                        data.summaries.push((ts, display));
+                    } else if let Some((oldest_index, _)) =
+                        data.summaries.iter().enumerate().min_by(|(_, a), (_, b)| {
+                            a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal)
+                        })
+                        && ts > data.summaries[oldest_index].0
+                    {
+                        data.summaries[oldest_index] = (ts, display);
+                    }
+                }
+            }
+        },
+    );
+    if !completed {
+        return Err(std::io::Error::other(format!("could not read {}", path.display())).into());
     }
 
     let mut sessions: Vec<Session> = sessions_map
@@ -338,12 +365,57 @@ pub fn scan() -> Result<Vec<Session>, AgfError> {
                 git_branch,
                 worktree,
                 recap,
+                interactive: true,
             })
         })
         .collect();
 
     sessions.sort_by_key(|s| std::cmp::Reverse(s.timestamp));
     Ok(sessions)
+}
+
+fn json_string_from_fragment(fragment: &[u8], field: &str) -> Option<String> {
+    let text = std::str::from_utf8(fragment).ok()?;
+    let key = format!("\"{field}\"");
+    // The authoritative envelope follows display/pasted payload fields. A
+    // pasted string can itself contain key-looking text, so the last
+    // occurrence is the one Claude wrote at the top level.
+    let after_key = text.rfind(&key)? + key.len();
+    let rest = text
+        .get(after_key..)?
+        .trim_start()
+        .strip_prefix(':')?
+        .trim_start();
+    let encoded = rest.strip_prefix('"')?;
+    let mut escaped = false;
+    for (index, ch) in encoded.char_indices() {
+        if escaped {
+            escaped = false;
+        } else if ch == '\\' {
+            escaped = true;
+        } else if ch == '"' {
+            return serde_json::from_str::<String>(&rest[..index + 2]).ok();
+        }
+    }
+    None
+}
+
+fn json_number_from_fragment(fragment: &[u8], field: &str) -> Option<f64> {
+    let text = std::str::from_utf8(fragment).ok()?;
+    let key = format!("\"{field}\"");
+    let after_key = text.rfind(&key)? + key.len();
+    let rest = text
+        .get(after_key..)?
+        .trim_start()
+        .strip_prefix(':')?
+        .trim_start();
+    let len = rest
+        .bytes()
+        .take_while(|byte| {
+            byte.is_ascii_digit() || matches!(byte, b'+' | b'-' | b'.' | b'e' | b'E')
+        })
+        .count();
+    rest.get(..len)?.parse().ok()
 }
 
 #[cfg(test)]
@@ -376,6 +448,7 @@ mod tests {
         fs::write(claude_dir.join("projects/-home-foo/notes.txt"), "x").unwrap();
 
         let ids: HashSet<String> = list_session_files(&claude_dir)
+            .unwrap()
             .into_iter()
             .map(|(id, _)| id)
             .collect();
@@ -394,7 +467,7 @@ mod tests {
         let dir = std::env::temp_dir().join("agf-test-no-projects");
         let _ = fs::remove_dir_all(&dir);
         fs::create_dir_all(&dir).unwrap();
-        assert!(list_session_files(&dir).is_empty());
+        assert!(list_session_files(&dir).unwrap().is_empty());
     }
 
     #[test]
@@ -436,7 +509,7 @@ mod tests {
         )
         .unwrap();
 
-        let meta = scan_session_metadata(vec![(sid.to_string(), path)]);
+        let meta = scan_session_metadata(vec![(sid.to_string(), path)]).unwrap();
         let m = meta
             .get(sid)
             .expect("metadata should be present for large file");
@@ -444,5 +517,22 @@ mod tests {
         assert_eq!(m.recap.as_deref(), Some("recap: latest recap"));
 
         let _ = fs::remove_dir_all(&claude_dir);
+    }
+
+    #[test]
+    fn oversized_history_tail_recovers_session_activity_envelope() {
+        let tail = br#"\"project\":\"fake\",\"sessionId\":\"fake\",\"timestamp\":1","project":"/tmp/project","sessionId":"large-id","timestamp":1785542405000}"#;
+        assert_eq!(
+            json_string_from_fragment(tail, "project").as_deref(),
+            Some("/tmp/project")
+        );
+        assert_eq!(
+            json_string_from_fragment(tail, "sessionId").as_deref(),
+            Some("large-id")
+        );
+        assert_eq!(
+            json_number_from_fragment(tail, "timestamp"),
+            Some(1_785_542_405_000.0)
+        );
     }
 }

--- a/src/scanner/codex.rs
+++ b/src/scanner/codex.rs
@@ -1,29 +1,55 @@
-use std::collections::{HashMap, HashSet};
-use std::fs::File;
-use std::io::{BufRead, BufReader};
-
 use rusqlite::Connection;
+use std::collections::{HashMap, HashSet};
 use walkdir::WalkDir;
 
 use crate::error::AgfError;
 use crate::model::{Agent, Session};
-use crate::scanner::{first_line_truncated, project_name_from_path, read_first_line};
+use crate::scanner::{
+    first_line_truncated, for_each_bounded_line, project_name_from_path, read_first_line,
+    read_first_line_result,
+};
+
+const HISTORY_LINE_BYTES: usize = 2 * 1024 * 1024;
+const MAX_SUMMARIES: usize = 10;
 
 pub fn scan() -> Result<Vec<Session>, AgfError> {
     let codex_dir = crate::config::codex_dir()?;
 
+    // SQLite is the current Codex source of truth and already stores title /
+    // first prompt metadata. Query it first; opening every rollout merely to
+    // reconstruct the same live-id set made a 4k-session store pay thousands
+    // of file opens on every cold CLI scan.
+    let has_rollout_path = state_db_has_rollout_path(&codex_dir)?;
+    let live_session_ids = if has_rollout_path {
+        None
+    } else {
+        collect_live_session_ids(&codex_dir)
+    };
+    if let Some(mut sessions) = scan_sqlite(&codex_dir, &HashMap::new(), live_session_ids.as_ref())?
+    {
+        let live_ids: HashSet<String> = sessions
+            .iter()
+            .map(|session| session.session_id.clone())
+            .collect();
+        let summaries = read_history_summaries(&codex_dir, Some(&live_ids))?;
+        for session in &mut sessions {
+            if let Some(history) = summaries.get(&session.session_id) {
+                session.summaries.clone_from(history);
+            }
+        }
+        sessions.sort_by(|a, b| crate::model::compare_sessions(a, b, crate::model::SortMode::Time));
+        return Ok(sessions);
+    }
+
     // Build the set of session IDs whose rollout JSONL still exists on disk.
-    // Used to filter out — and prune from SQLite — `threads` rows that were
-    // left behind when the JSONL was deleted manually (e.g. the user wiped
-    // `~/.codex/sessions/`). Without pruning, those stale rows keep showing
-    // up in `agf list`/`agf stats` forever and cannot be revived.
+    // This is only a read-side visibility filter: scans must never mutate
+    // Codex's own state database. Destructive cleanup belongs behind AGF's
+    // explicit delete flow, not list/resume/stats/watch.
     //
     // `None` means we could not read the sessions tree reliably (permission
     // denied, transient I/O). In that case we fall back to the legacy
-    // behavior — surface every SQLite row, prune nothing — to avoid
-    // wiping live rows on a flaky filesystem read.
-    let live_session_ids = collect_live_session_ids(&codex_dir);
-
+    // behavior — surface every SQLite row — to avoid hiding live rows on a
+    // flaky or partially-readable filesystem.
     // Collect summaries from history.jsonl, pre-filtered against the live set
     // when known. `history.jsonl` is append-only and grows unbounded — power
     // users hit tens of MB after months of daily use — so keeping every
@@ -32,15 +58,10 @@ pub fn scan() -> Result<Vec<Session>, AgfError> {
     // v0.11.3 post-ship audit; the `CACHE_VERSION=6` bump forces a cold
     // rescan on every upgrader, which would otherwise pay this cost on first
     // launch.)
-    let summaries = read_history_summaries(&codex_dir, live_session_ids.as_ref());
+    let summaries = read_history_summaries(&codex_dir, live_session_ids.as_ref())?;
 
-    // Primary: read from SQLite (state_*.sqlite)
-    let mut sessions = scan_sqlite(&codex_dir, &summaries, live_session_ids.as_ref());
-
-    // Fallback: if SQLite found nothing, try JSONL walkdir
-    if sessions.is_empty() {
-        sessions = scan_jsonl(&codex_dir, &summaries);
-    }
+    // Legacy fallback for installs without a usable state database.
+    let mut sessions = scan_jsonl(&codex_dir, &summaries)?;
 
     sessions.sort_by_key(|s| std::cmp::Reverse(s.timestamp));
     Ok(sessions)
@@ -51,10 +72,10 @@ pub fn scan() -> Result<Vec<Session>, AgfError> {
 /// filename is `rollout-*.jsonl` (no session_id in the path), so we have to
 /// open each file's first line to get the id.
 ///
-/// Returns `None` only when the sessions directory exists but cannot be
-/// traversed — a transient I/O error there must NOT be interpreted as
-/// "all rows are orphaned", since prune would then nuke the entire
-/// `threads` table. A missing directory is a legitimate empty-set result.
+/// Returns `None` whenever the tree cannot be enumerated *completely*.
+/// A partial set is not trustworthy enough to hide SQLite rows: one unreadable
+/// or malformed rollout must fail closed to the unfiltered SQLite view.
+/// A missing directory is a legitimate empty-set result.
 fn collect_live_session_ids(codex_dir: &std::path::Path) -> Option<HashSet<String>> {
     let sessions_dir = codex_dir.join("sessions");
     let mut ids = HashSet::new();
@@ -62,10 +83,10 @@ fn collect_live_session_ids(codex_dir: &std::path::Path) -> Option<HashSet<Strin
         return Some(ids);
     }
     let walker = WalkDir::new(&sessions_dir).into_iter();
-    let mut had_walk_error = false;
+    let mut complete = true;
     for entry in walker {
         let Ok(entry) = entry else {
-            had_walk_error = true;
+            complete = false;
             continue;
         };
         let path = entry.path();
@@ -73,96 +94,83 @@ fn collect_live_session_ids(codex_dir: &std::path::Path) -> Option<HashSet<Strin
             continue;
         }
         let Some(first_line) = read_first_line(path) else {
+            complete = false;
             continue;
         };
-        if let Ok(value) = serde_json::from_str::<serde_json::Value>(first_line.trim())
-            && let Some(id) = value
-                .get("payload")
-                .and_then(|p| p.get("id"))
-                .and_then(|v| v.as_str())
-            && !id.is_empty()
-        {
-            ids.insert(id.to_string());
-        }
-    }
-    // If the walk itself failed (permission denied, transient I/O), treat
-    // the live-set as unknown: caller must skip pruning rather than risk
-    // wiping live rows.
-    if had_walk_error && ids.is_empty() {
-        return None;
-    }
-    Some(ids)
-}
-
-/// Delete `threads` rows whose `id` is in `orphan_ids` from every
-/// `state_*.sqlite` under `codex_dir`. Errors on a single db are swallowed
-/// so a corrupt or older-schema file cannot block pruning the others.
-fn prune_orphan_threads(codex_dir: &std::path::Path, orphan_ids: &[String]) {
-    if orphan_ids.is_empty() {
-        return;
-    }
-    let Ok(entries) = std::fs::read_dir(codex_dir) else {
-        return;
-    };
-    for entry in entries.filter_map(|e| e.ok()) {
-        let path = entry.path();
-        let is_state_db = path
-            .file_name()
-            .and_then(|n| n.to_str())
-            .map(|n| n.starts_with("state_") && n.ends_with(".sqlite"))
-            .unwrap_or(false);
-        if !is_state_db {
-            continue;
-        }
-        let Ok(conn) = Connection::open(&path) else {
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(first_line.trim()) else {
+            complete = false;
             continue;
         };
-        let Ok(tx) = conn.unchecked_transaction() else {
+        let Some(id) = value
+            .get("payload")
+            .and_then(|p| p.get("id"))
+            .and_then(|v| v.as_str())
+            .filter(|id| !id.is_empty())
+        else {
+            complete = false;
             continue;
         };
-        for id in orphan_ids {
-            let _ = tx.execute("DELETE FROM threads WHERE id = ?1", [id]);
-        }
-        let _ = tx.commit();
+        ids.insert(id.to_string());
     }
+    complete.then_some(ids)
 }
 
 /// Read sessions from Codex SQLite database (state_*.sqlite).
 /// This is the primary source — covers CLI, desktop app (vscode), and exec sessions.
 ///
 /// `live_session_ids` is the set of session IDs whose rollout JSONL exists on
-/// disk. Rows whose id is *not* in this set are treated as orphans (the user
-/// — or some other tool — deleted the JSONL but the SQLite row was left
-/// behind), excluded from the returned list, and pruned from every
-/// `state_*.sqlite` so they do not reappear on the next scan. Orphan rows
-/// are dead weight regardless: Codex cannot resume them once the rollout
-/// JSONL is gone, so removing them from SQLite is not data loss.
+/// disk. Rows whose id is *not* in a complete set are hidden from the result,
+/// but never deleted from Codex's database.
 fn scan_sqlite(
     codex_dir: &std::path::Path,
     summaries: &HashMap<String, Vec<String>>,
     live_session_ids: Option<&HashSet<String>>,
-) -> Vec<Session> {
+) -> Result<Option<Vec<Session>>, AgfError> {
     // Find the latest state_*.sqlite file
-    let Some(db_path) = find_state_db(codex_dir) else {
-        return Vec::new();
+    let Some(db_path) = find_state_db(codex_dir)? else {
+        return Ok(None);
     };
 
-    let Ok(conn) =
-        Connection::open_with_flags(&db_path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
-    else {
-        return Vec::new();
-    };
+    let conn = Connection::open_with_flags(&db_path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)?;
 
-    let Ok(mut stmt) = conn.prepare(
-        "SELECT id, cwd, title, updated_at, git_branch, first_user_message
-         FROM threads
-         WHERE archived = 0 AND cwd != ''
-         ORDER BY updated_at DESC",
-    ) else {
-        return Vec::new();
+    let columns = table_columns(&conn, "threads")?;
+    if columns.is_empty() {
+        return Ok(None);
+    }
+    let source_column = if columns.contains("source") {
+        "source"
+    } else {
+        "''"
     };
+    let thread_source_column = if columns.contains("thread_source") {
+        "thread_source"
+    } else {
+        "NULL"
+    };
+    let agent_role_column = if columns.contains("agent_role") {
+        "agent_role"
+    } else {
+        "NULL"
+    };
+    let rollout_path_column = if columns.contains("rollout_path") {
+        "rollout_path"
+    } else {
+        "NULL"
+    };
+    let requires_rollout_path = columns.contains("rollout_path");
+    let timestamp_column = if columns.contains("updated_at_ms") {
+        "COALESCE(NULLIF(updated_at_ms, 0), updated_at * 1000)"
+    } else {
+        "updated_at * 1000"
+    };
+    let query = format!(
+        "SELECT id, cwd, title, {timestamp_column}, git_branch, first_user_message, \
+         {source_column}, {thread_source_column}, {agent_role_column}, {rollout_path_column} \
+         FROM threads WHERE archived = 0 AND cwd != '' ORDER BY {timestamp_column} DESC"
+    );
+    let mut stmt = conn.prepare(&query)?;
 
-    let Ok(rows) = stmt.query_map([], |row| {
+    let rows = stmt.query_map([], |row| {
         Ok((
             row.get::<_, String>(0)?,
             row.get::<_, String>(1)?,
@@ -170,36 +178,50 @@ fn scan_sqlite(
             row.get::<_, i64>(3).unwrap_or(0),
             row.get::<_, Option<String>>(4)?,
             row.get::<_, String>(5).unwrap_or_default(),
+            row.get::<_, String>(6).unwrap_or_default(),
+            row.get::<_, Option<String>>(7).unwrap_or_default(),
+            row.get::<_, Option<String>>(8).unwrap_or_default(),
+            row.get::<_, Option<String>>(9).unwrap_or_default(),
         ))
-    }) else {
-        return Vec::new();
-    };
+    })?;
 
     let mut sessions = Vec::new();
-    let mut orphan_ids: Vec<String> = Vec::new();
-    for row in rows.flatten() {
-        let (session_id, cwd, title, updated_at, git_branch, first_msg) = row;
+    for row in rows {
+        let (
+            session_id,
+            cwd,
+            title,
+            timestamp,
+            git_branch,
+            first_msg,
+            source,
+            thread_source,
+            agent_role,
+            rollout_path,
+        ) = row?;
 
         if session_id.is_empty() || cwd.is_empty() {
             continue;
         }
 
-        // Only filter/prune when we have a trustworthy live set. If the
+        if requires_rollout_path
+            && !rollout_path
+                .as_deref()
+                .is_some_and(|path| !path.is_empty() && std::path::Path::new(path).is_file())
+        {
+            continue;
+        }
+
+        // Only filter when we have a trustworthy live set. If the
         // sessions tree could not be enumerated (`None`), surface the row
-        // as-is — better stale than nuked.
+        // as-is — better stale than hidden.
         if let Some(live) = live_session_ids
             && !live.contains(&session_id)
         {
-            orphan_ids.push(session_id);
             continue;
         }
 
         let project_name = project_name_from_path(&cwd);
-
-        // updated_at is Unix seconds — convert to millis. Saturate so a
-        // corrupt/tampered value can't overflow i64 and wrap to a garbage
-        // (often negative) timestamp that jumps the session to a list extreme.
-        let timestamp = updated_at.saturating_mul(1000);
 
         // Build summaries: prefer history.jsonl, fall back to title/first_msg
         let session_summaries = if let Some(s) = summaries.get(&session_id) {
@@ -224,26 +246,56 @@ fn scan_sqlite(
             git_branch,
             worktree: None,
             recap: None,
+            interactive: is_interactive_source(
+                &source,
+                thread_source.as_deref(),
+                agent_role.as_deref(),
+            ),
         });
     }
 
-    // Drop the read-only connection before re-opening read-write for prune.
-    drop(stmt);
-    drop(conn);
+    Ok(Some(sessions))
+}
 
-    if !orphan_ids.is_empty() {
-        prune_orphan_threads(codex_dir, &orphan_ids);
+fn table_columns(conn: &Connection, table: &str) -> Result<HashSet<String>, rusqlite::Error> {
+    let mut statement = conn.prepare(&format!("PRAGMA table_info({table})"))?;
+    statement
+        .query_map([], |row| row.get::<_, String>(1))
+        .and_then(Iterator::collect)
+}
+
+fn state_db_has_rollout_path(codex_dir: &std::path::Path) -> Result<bool, AgfError> {
+    let Some(path) = find_state_db(codex_dir)? else {
+        return Ok(false);
+    };
+    let conn = Connection::open_with_flags(path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+    Ok(table_columns(&conn, "threads")?.contains("rollout_path"))
+}
+
+fn is_interactive_source(
+    source: &str,
+    thread_source: Option<&str>,
+    agent_role: Option<&str>,
+) -> bool {
+    if matches!(thread_source, Some("subagent" | "exec")) || agent_role.is_some() {
+        return false;
     }
-
-    sessions
+    !matches!(source, "exec" | "subagent") && !source.contains("\"subagent\"")
 }
 
 /// Find the latest state_*.sqlite file in the codex directory.
-fn find_state_db(codex_dir: &std::path::Path) -> Option<std::path::PathBuf> {
-    let entries = std::fs::read_dir(codex_dir).ok()?;
-    entries
-        .filter_map(|e| e.ok())
-        .map(|e| e.path())
+fn find_state_db(codex_dir: &std::path::Path) -> std::io::Result<Option<std::path::PathBuf>> {
+    let entries = match std::fs::read_dir(codex_dir) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error),
+    };
+    let mut paths = Vec::new();
+    for entry in entries {
+        paths.push(entry?.path());
+    }
+    Ok(paths
+        .into_iter()
         .filter(|p| {
             p.file_name()
                 .and_then(|n| n.to_str())
@@ -258,7 +310,7 @@ fn find_state_db(codex_dir: &std::path::Path) -> Option<std::path::PathBuf> {
             state_db_index(a)
                 .cmp(&state_db_index(b))
                 .then_with(|| a.cmp(b))
-        })
+        }))
 }
 
 /// Numeric suffix of a `state_<n>.sqlite` filename, or `None` if the name
@@ -276,7 +328,7 @@ fn state_db_index(path: &std::path::Path) -> Option<u64> {
 fn scan_jsonl(
     codex_dir: &std::path::Path,
     summaries: &HashMap<String, Vec<String>>,
-) -> Vec<Session> {
+) -> Result<Vec<Session>, AgfError> {
     use serde::Deserialize;
 
     #[derive(Deserialize)]
@@ -303,19 +355,17 @@ fn scan_jsonl(
     let mut sessions = Vec::new();
 
     if !sessions_dir.exists() {
-        return sessions;
+        return Ok(sessions);
     }
 
-    for entry in WalkDir::new(&sessions_dir)
-        .into_iter()
-        .filter_map(|e| e.ok())
-    {
+    for entry in WalkDir::new(&sessions_dir) {
+        let entry = entry.map_err(std::io::Error::other)?;
         let path = entry.path();
         if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
             continue;
         }
 
-        let Some(first_line) = read_first_line(path) else {
+        let Some(first_line) = read_first_line_result(path)? else {
             continue;
         };
 
@@ -343,12 +393,27 @@ fn scan_jsonl(
 
         let project_name = project_name_from_path(&cwd);
 
-        let timestamp = payload
+        let header_timestamp = payload
             .timestamp
             .as_deref()
             .and_then(|ts| chrono::DateTime::parse_from_rfc3339(ts).ok())
             .map(|dt| dt.timestamp_millis())
             .unwrap_or(0);
+        // Legacy rollout headers contain creation time. The rollout mtime is
+        // the durable last-activity fallback and keeps legacy sessions aligned
+        // with the SQLite scanner's updated_at semantics.
+        let mtime = path
+            .metadata()
+            .ok()
+            .and_then(|metadata| metadata.modified().ok())
+            .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
+            .and_then(|duration| i64::try_from(duration.as_millis()).ok())
+            .unwrap_or(0);
+        // Keep the raw durable candidate until the common scan boundary. A
+        // near-future mtime must make the snapshot non-cacheable; clamping it
+        // here to the creation header would permanently hide the later-valid
+        // activity time behind an unchanged source fingerprint.
+        let timestamp = header_timestamp.max(mtime);
 
         let git_branch = payload.git.and_then(|g| g.branch);
         let session_summaries = summaries.get(&session_id).cloned().unwrap_or_default();
@@ -363,10 +428,11 @@ fn scan_jsonl(
             git_branch,
             worktree: None,
             recap: None,
+            interactive: true,
         });
     }
 
-    sessions
+    Ok(sessions)
 }
 
 #[derive(serde::Deserialize)]
@@ -389,49 +455,58 @@ struct HistoryEntry {
 fn read_history_summaries(
     codex_dir: &std::path::Path,
     live_session_ids: Option<&HashSet<String>>,
-) -> HashMap<String, Vec<String>> {
+) -> Result<HashMap<String, Vec<String>>, AgfError> {
     let path = codex_dir.join("history.jsonl");
     let mut summaries: HashMap<String, Vec<(f64, String)>> = HashMap::new();
 
-    let Ok(file) = File::open(&path) else {
-        return HashMap::new();
-    };
+    if !path.exists() {
+        return Ok(HashMap::new());
+    }
 
-    for line in BufReader::new(file).lines() {
-        let Ok(line) = line else {
-            continue;
-        };
-        let line = line.trim();
-        if line.is_empty() {
-            continue;
+    let completed = for_each_bounded_line(&path, usize::MAX, HISTORY_LINE_BYTES, |line| {
+        if line.iter().all(u8::is_ascii_whitespace) {
+            return;
         }
-        let Ok(entry) = serde_json::from_str::<HistoryEntry>(line) else {
-            continue;
+        let Ok(entry) = serde_json::from_slice::<HistoryEntry>(line) else {
+            return;
         };
         let session_id = match entry.session_id {
             Some(id) if !id.is_empty() => id,
-            _ => continue,
+            _ => return,
         };
         if let Some(live) = live_session_ids
             && !live.contains(&session_id)
         {
-            continue;
+            return;
         }
         let ts = entry.ts.unwrap_or(0.0);
         let text = match entry.text {
             Some(t) if !t.is_empty() => t,
-            _ => continue,
+            _ => return,
         };
-        summaries.entry(session_id).or_default().push((ts, text));
+        let entries = summaries.entry(session_id).or_default();
+        if entries.len() < MAX_SUMMARIES {
+            entries.push((ts, text));
+        } else if let Some((oldest_index, _)) = entries
+            .iter()
+            .enumerate()
+            .min_by(|(_, a), (_, b)| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal))
+            && ts > entries[oldest_index].0
+        {
+            entries[oldest_index] = (ts, text);
+        }
+    });
+    if !completed {
+        return Err(std::io::Error::other(format!("could not read {}", path.display())).into());
     }
 
-    summaries
+    Ok(summaries
         .into_iter()
         .map(|(k, mut v)| {
             v.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
             (k, v.into_iter().map(|(_, s)| s).collect())
         })
-        .collect()
+        .collect())
 }
 
 #[cfg(test)]
@@ -480,73 +555,63 @@ mod tests {
     }
 
     #[test]
-    fn prune_orphan_threads_removes_only_target_ids() {
-        let dir = make_codex_dir("prune-target");
+    fn scan_sqlite_never_mutates_codex_state() {
+        let dir = make_codex_dir("read-only");
         let db = dir.join("state_5.sqlite");
-        seed_state_db(
-            &db,
-            &[
-                ("orphan-1", "/some/cwd"),
-                ("live-1", "/some/cwd"),
-                ("orphan-2", "/some/cwd"),
-            ],
-        );
+        seed_state_db(&db, &[("orphan", "/x"), ("live", "/x")]);
+        let live = HashSet::from(["live".to_string()]);
 
-        prune_orphan_threads(&dir, &["orphan-1".to_string(), "orphan-2".to_string()]);
+        let sessions = scan_sqlite(&dir, &HashMap::new(), Some(&live))
+            .unwrap()
+            .unwrap();
 
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].session_id, "live");
+        assert_eq!(count_threads(&db), 2, "a scan must not delete Codex rows");
+    }
+
+    #[test]
+    fn scan_sqlite_requires_a_real_rollout_when_schema_exposes_its_path() {
+        let dir = make_codex_dir("rollout-path");
+        let db = dir.join("state_5.sqlite");
+        let live_rollout = dir.join("live.jsonl");
+        fs::write(&live_rollout, b"{}\n").unwrap();
         let conn = Connection::open(&db).unwrap();
-        let remaining: Vec<String> = conn
-            .prepare("SELECT id FROM threads ORDER BY id")
-            .unwrap()
-            .query_map([], |r| r.get::<_, String>(0))
-            .unwrap()
-            .map(|r| r.unwrap())
-            .collect();
-        assert_eq!(remaining, vec!["live-1".to_string()]);
-    }
-
-    #[test]
-    fn prune_orphan_threads_walks_every_state_db() {
-        let dir = make_codex_dir("prune-walk");
-        let db4 = dir.join("state_4.sqlite");
-        let db5 = dir.join("state_5.sqlite");
-        seed_state_db(&db4, &[("orphan", "/x"), ("live", "/x")]);
-        seed_state_db(&db5, &[("orphan", "/x"), ("live", "/x")]);
-
-        prune_orphan_threads(&dir, &["orphan".to_string()]);
-
-        assert_eq!(count_threads(&db4), 1);
-        assert_eq!(count_threads(&db5), 1);
-    }
-
-    #[test]
-    fn prune_orphan_threads_ignores_non_state_files() {
-        let dir = make_codex_dir("prune-ignore");
-        let db = dir.join("state_5.sqlite");
-        seed_state_db(&db, &[("orphan", "/x")]);
-        // Sibling files that must not interfere with the walk
-        fs::write(dir.join("history.jsonl"), b"{}").unwrap();
-        fs::write(dir.join("auth.json"), b"{}").unwrap();
-
-        prune_orphan_threads(&dir, &["orphan".to_string()]);
-        assert_eq!(count_threads(&db), 0);
-    }
-
-    #[test]
-    fn prune_orphan_threads_tolerates_missing_threads_table() {
-        let dir = make_codex_dir("prune-noschema");
-        let bad = dir.join("state_3.sqlite");
-        // Db with no `threads` table — older Codex CLI schema.
-        let conn = Connection::open(&bad).unwrap();
-        conn.execute_batch("CREATE TABLE other (id TEXT);").unwrap();
+        conn.execute_batch(
+            "CREATE TABLE threads (
+                id TEXT PRIMARY KEY, cwd TEXT NOT NULL, title TEXT NOT NULL DEFAULT '',
+                updated_at INTEGER NOT NULL DEFAULT 0, archived INTEGER NOT NULL DEFAULT 0,
+                git_branch TEXT, first_user_message TEXT NOT NULL DEFAULT '', rollout_path TEXT
+            );",
+        )
+        .unwrap();
+        for (id, path) in [
+            ("live", live_rollout.to_string_lossy().into_owned()),
+            ("empty", String::new()),
+            (
+                "missing",
+                dir.join("missing.jsonl").to_string_lossy().into_owned(),
+            ),
+        ] {
+            conn.execute(
+                "INSERT INTO threads (id, cwd, rollout_path) VALUES (?1, '/tmp/p', ?2)",
+                rusqlite::params![id, path],
+            )
+            .unwrap();
+        }
         drop(conn);
 
-        let good = dir.join("state_5.sqlite");
-        seed_state_db(&good, &[("orphan", "/x")]);
+        let sessions = scan_sqlite(&dir, &HashMap::new(), None).unwrap().unwrap();
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].session_id, "live");
+    }
 
-        prune_orphan_threads(&dir, &["orphan".to_string()]);
-        // `bad` was silently skipped; `good` got pruned.
-        assert_eq!(count_threads(&good), 0);
+    #[test]
+    fn existing_broken_state_db_is_a_scan_error_not_an_empty_success() {
+        let dir = make_codex_dir("broken-state");
+        fs::write(dir.join("state_1.sqlite"), b"not a sqlite database").unwrap();
+
+        assert!(scan_sqlite(&dir, &HashMap::new(), None).is_err());
     }
 
     #[test]
@@ -576,6 +641,37 @@ mod tests {
         assert_eq!(live.len(), 1);
     }
 
+    #[test]
+    fn collect_live_session_ids_rejects_a_partial_or_malformed_tree() {
+        let dir = make_codex_dir("live-partial");
+        let day_dir = dir.join("sessions/2026/04/29");
+        fs::create_dir_all(&day_dir).unwrap();
+        fs::write(
+            day_dir.join("rollout-valid.jsonl"),
+            br#"{"type":"session_meta","payload":{"id":"session-abc"}}
+"#,
+        )
+        .unwrap();
+        fs::write(day_dir.join("rollout-broken.jsonl"), b"not-json\n").unwrap();
+
+        assert_eq!(collect_live_session_ids(&dir), None);
+    }
+
+    #[test]
+    fn codex_source_classification_matches_resume_semantics() {
+        assert!(is_interactive_source("cli", Some("user"), None));
+        assert!(is_interactive_source("vscode", None, None));
+        assert!(!is_interactive_source("exec", Some("user"), None));
+        assert!(!is_interactive_source(
+            r#"{"subagent":{"thread_spawn":{"depth":1}}}"#,
+            Some("subagent"),
+            Some("worker")
+        ));
+        // Older schemas have none of the classification columns. Preserve
+        // their historical top-level behavior instead of hiding everything.
+        assert!(is_interactive_source("", None, None));
+    }
+
     fn seed_history_jsonl(dir: &std::path::Path, entries: &[(&str, f64, &str)]) {
         let mut f = fs::File::create(dir.join("history.jsonl")).unwrap();
         for (sid, ts, text) in entries {
@@ -602,7 +698,7 @@ mod tests {
         let mut live = HashSet::new();
         live.insert("live-a".to_string());
 
-        let summaries = read_history_summaries(&dir, Some(&live));
+        let summaries = read_history_summaries(&dir, Some(&live)).unwrap();
 
         assert_eq!(summaries.len(), 1);
         // Newest-first order: 120.0 before 100.0.
@@ -623,7 +719,7 @@ mod tests {
         let dir = make_codex_dir("hist-no-filter");
         seed_history_jsonl(&dir, &[("a", 1.0, "kept-a"), ("b", 2.0, "kept-b")]);
 
-        let summaries = read_history_summaries(&dir, None);
+        let summaries = read_history_summaries(&dir, None).unwrap();
 
         assert_eq!(summaries.len(), 2);
         assert!(summaries.contains_key("a"));
@@ -652,7 +748,7 @@ mod state_db_tests {
             std::fs::write(dir.join(name), b"").unwrap();
         }
 
-        let found = find_state_db(&dir).unwrap();
+        let found = find_state_db(&dir).unwrap().unwrap();
 
         assert_eq!(found.file_name().unwrap(), "state_10.sqlite");
         let _ = std::fs::remove_dir_all(dir);
@@ -664,7 +760,7 @@ mod state_db_tests {
         std::fs::write(dir.join("state_backup.sqlite"), b"").unwrap();
         std::fs::write(dir.join("history.jsonl"), b"").unwrap();
 
-        let found = find_state_db(&dir).unwrap();
+        let found = find_state_db(&dir).unwrap().unwrap();
 
         assert_eq!(found.file_name().unwrap(), "state_backup.sqlite");
         let _ = std::fs::remove_dir_all(dir);
@@ -676,7 +772,7 @@ mod state_db_tests {
         std::fs::write(dir.join("state_backup.sqlite"), b"").unwrap();
         std::fs::write(dir.join("state_2.sqlite"), b"").unwrap();
 
-        let found = find_state_db(&dir).unwrap();
+        let found = find_state_db(&dir).unwrap().unwrap();
 
         assert_eq!(found.file_name().unwrap(), "state_2.sqlite");
         let _ = std::fs::remove_dir_all(dir);
@@ -686,7 +782,7 @@ mod state_db_tests {
     fn find_state_db_returns_none_without_any_state_file() {
         let dir = temp_dir("state-none");
         std::fs::write(dir.join("history.jsonl"), b"").unwrap();
-        assert!(find_state_db(&dir).is_none());
+        assert!(find_state_db(&dir).unwrap().is_none());
         let _ = std::fs::remove_dir_all(dir);
     }
 }

--- a/src/scanner/cursor_agent.rs
+++ b/src/scanner/cursor_agent.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use rusqlite::Connection;
@@ -6,7 +7,7 @@ use walkdir::WalkDir;
 use crate::error::AgfError;
 use crate::model::{Agent, Session};
 
-use super::{project_name_from_path, truncate};
+use super::{for_each_bounded_line, project_name_from_path, truncate};
 
 /// Max chars stored per session summary.
 const SUMMARY_MAX_CHARS: usize = 100;
@@ -22,6 +23,7 @@ const MAX_PARSE_BYTES: usize = 512 * 1024;
 /// almost always lands within the first few lines; the cap bounds work on
 /// pathological transcripts that pad with non-`role=user` rows.
 const MAX_PARSE_LINES: usize = 50;
+const MAX_LINE_BYTES: usize = 256 * 1024;
 
 pub fn scan() -> Result<Vec<Session>, AgfError> {
     scan_from(&crate::config::cursor_dir()?)
@@ -35,18 +37,18 @@ fn scan_from(cursor_dir: &Path) -> Result<Vec<Session>, AgfError> {
     }
 
     let chats_dir = cursor_dir.join("chats");
+    // Build once. The previous per-transcript read_dir(chats) lookup was
+    // O(session_count × workspace_count) and dominated cold scans for users
+    // with many Cursor workspaces.
+    let store_dbs = index_store_dbs(&chats_dir)?;
     let mut sessions = Vec::new();
 
     // Single walk covers both storage formats:
     //
     //   Legacy  (Cursor ≤ 2.4.7):  projects/<slug>/agent-transcripts/<uuid>.txt      (depth 3)
     //   Current (Composer 2 / 3+): projects/<slug>/agent-transcripts/<uuid>/<uuid>.jsonl (depth 4)
-    for entry in WalkDir::new(&projects_dir)
-        .min_depth(3)
-        .max_depth(4)
-        .into_iter()
-        .filter_map(|e| e.ok())
-    {
+    for entry in WalkDir::new(&projects_dir).min_depth(3).max_depth(4) {
+        let entry = entry.map_err(std::io::Error::other)?;
         let path = entry.path();
         if !path.is_file() {
             continue;
@@ -124,17 +126,16 @@ fn scan_from(cursor_dir: &Path) -> Result<Vec<Session>, AgfError> {
         // (Composer 2+) format we treat the absence of store.db as "orphaned"
         // and skip the session — otherwise agf would show sessions that
         // cursor-agent itself refuses to resume.
-        let store_db_path = if chats_dir.exists() {
-            find_store_db_path(&chats_dir, &session_id)
-        } else {
-            None
-        };
+        let store_db_path = store_dbs.get(&session_id);
 
         if ext == Some("jsonl") && store_db_path.is_none() {
             continue;
         }
 
-        let meta = store_db_path.as_deref().and_then(read_store_db);
+        let meta = match store_db_path {
+            Some(path) => read_store_db(path)?,
+            None => None,
+        };
 
         // Last-activity time: the transcript file is appended on every turn,
         // so its mtime tracks when the session was last used. Prefer it over
@@ -172,6 +173,7 @@ fn scan_from(cursor_dir: &Path) -> Result<Vec<Session>, AgfError> {
             git_branch: None,
             worktree: None,
             recap: None,
+            interactive: true,
         });
     }
 
@@ -187,34 +189,56 @@ struct StoreMeta {
 ///
 /// Presence of this file means cursor-agent considers the session resumable;
 /// the file is the source of truth for `/resume`.
-fn find_store_db_path(chats_dir: &Path, session_id: &str) -> Option<PathBuf> {
-    let read_dir = std::fs::read_dir(chats_dir).ok()?;
-    for workspace_entry in read_dir.filter_map(|e| e.ok()) {
-        let store_path = workspace_entry.path().join(session_id).join("store.db");
-        if store_path.exists() {
-            return Some(store_path);
+fn index_store_dbs(chats_dir: &Path) -> Result<HashMap<String, PathBuf>, AgfError> {
+    if !chats_dir.exists() {
+        return Ok(HashMap::new());
+    }
+    let mut stores = HashMap::new();
+    for entry in WalkDir::new(chats_dir).min_depth(3).max_depth(3) {
+        let entry = entry.map_err(std::io::Error::other)?;
+        if !entry.file_type().is_file() || entry.file_name() != "store.db" {
+            continue;
+        }
+        if let Some(id) = entry
+            .path()
+            .parent()
+            .and_then(Path::file_name)
+            .and_then(|name| name.to_str())
+        {
+            stores.insert(id.to_string(), entry.into_path());
         }
     }
-    None
+    Ok(stores)
 }
 
 /// Read the `meta` table from store.db, hex-decode the value, and parse as JSON.
-fn read_store_db(store_path: &Path) -> Option<StoreMeta> {
+fn read_store_db(store_path: &Path) -> Result<Option<StoreMeta>, AgfError> {
     let conn = Connection::open_with_flags(
         store_path,
         rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
-    )
-    .ok()?;
+    )?;
 
     // Cursor CLI stores session metadata as hex-encoded JSON in meta WHERE key='0'
-    let mut stmt = conn
-        .prepare("SELECT value FROM meta WHERE key = '0'")
-        .ok()?;
-    let hex_value: String = stmt.query_row([], |row| row.get(0)).ok()?;
+    let mut stmt = match conn.prepare("SELECT value FROM meta WHERE key = '0'") {
+        Ok(stmt) => stmt,
+        Err(error) if error.to_string().contains("no such table") => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
+    let hex_value: String = match stmt.query_row([], |row| row.get(0)) {
+        Ok(value) => value,
+        Err(rusqlite::Error::QueryReturnedNoRows) => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
 
-    let json_bytes = hex_decode(&hex_value)?;
-    let json_str = std::str::from_utf8(&json_bytes).ok()?;
-    let parsed: serde_json::Value = serde_json::from_str(json_str).ok()?;
+    let Some(json_bytes) = hex_decode(&hex_value) else {
+        return Ok(None);
+    };
+    let Ok(json_str) = std::str::from_utf8(&json_bytes) else {
+        return Ok(None);
+    };
+    let Ok(parsed) = serde_json::from_str::<serde_json::Value>(json_str) else {
+        return Ok(None);
+    };
 
     let name = parsed
         .get("name")
@@ -227,7 +251,7 @@ fn read_store_db(store_path: &Path) -> Option<StoreMeta> {
         .and_then(|v| v.as_i64())
         .unwrap_or(0);
 
-    Some(StoreMeta { name, created_at })
+    Ok(Some(StoreMeta { name, created_at }))
 }
 
 /// Decode a hex-encoded string to bytes.
@@ -251,75 +275,58 @@ fn hex_decode(hex: &str) -> Option<Vec<u8>> {
 /// User turns may contain a `<user_info>` system injection (always first) followed by
 /// the actual `<user_query>` prompt. We skip info blocks and strip the query tags.
 fn extract_first_prompt(jsonl_path: &Path) -> Option<String> {
-    use std::fs::File;
-    use std::io::{BufRead, BufReader};
-
-    let file = File::open(jsonl_path).ok()?;
-    let reader = BufReader::new(file);
-
-    let mut bytes_read = 0usize;
-    for (lines_seen, line_result) in reader.lines().enumerate() {
-        if lines_seen >= MAX_PARSE_LINES || bytes_read >= MAX_PARSE_BYTES {
-            break;
+    let mut found = None;
+    let mut lines_seen = 0usize;
+    for_each_bounded_line(jsonl_path, MAX_PARSE_BYTES, MAX_LINE_BYTES, |line| {
+        if found.is_some() || lines_seen >= MAX_PARSE_LINES {
+            return;
         }
-
-        // A single bad line (invalid UTF-8, transient IO error, malformed
-        // JSON, partial flush from a crashed session) must skip just that
-        // line — never disable extraction for the rest of the file. The
-        // previous `.ok()?` pattern silently defeated this fallback for any
-        // transcript whose first 50 lines had even one unparseable row.
-        let Ok(line) = line_result else {
-            continue;
-        };
-        bytes_read += line.len() + 1; // +1 approximates the stripped newline
-        let line = line.trim();
-        if line.is_empty() {
-            continue;
+        lines_seen += 1;
+        if let Ok(value) = serde_json::from_slice::<serde_json::Value>(line) {
+            found = prompt_from_cursor_value(&value);
         }
-        let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
-            continue;
-        };
-        if value.get("role").and_then(|v| v.as_str()) != Some("user") {
+    });
+    found
+}
+
+fn prompt_from_cursor_value(value: &serde_json::Value) -> Option<String> {
+    if value.get("role").and_then(|v| v.as_str()) != Some("user") {
+        return None;
+    }
+    let parts = value
+        .get("message")
+        .and_then(|m| m.get("content"))
+        .and_then(|c| c.as_array())?;
+
+    for part in parts {
+        if part.get("type").and_then(|t| t.as_str()) != Some("text") {
             continue;
         }
-        let Some(parts) = value
-            .get("message")
-            .and_then(|m| m.get("content"))
-            .and_then(|c| c.as_array())
-        else {
+        let Some(text) = part.get("text").and_then(|t| t.as_str()) else {
             continue;
         };
-
-        for part in parts {
-            if part.get("type").and_then(|t| t.as_str()) != Some("text") {
-                continue;
-            }
-            let Some(text) = part.get("text").and_then(|t| t.as_str()) else {
-                continue;
-            };
-            if text.trim_start().starts_with("<user_info>") {
-                continue;
-            }
-            // Strip the `<user_query>...</user_query>` wrapper if present.
-            // `str::find` returns the FIRST occurrence of each substring
-            // independently, so we must search for the closing tag AFTER
-            // the opening one — otherwise a text like
-            // `"</user_query>foo<user_query>...</user_query>"` (which can
-            // occur in a pasted log or AI-generated code sample) gives
-            // s > e and `text[s+12..e]` panics with `begin > end`.
-            let prompt = match text.find("<user_query>") {
-                Some(s) => {
-                    let after = s + "<user_query>".len();
-                    match text[after..].find("</user_query>") {
-                        Some(rel) => text[after..after + rel].trim(),
-                        None => text.trim(),
-                    }
+        if text.trim_start().starts_with("<user_info>") {
+            continue;
+        }
+        // Strip the `<user_query>...</user_query>` wrapper if present.
+        // `str::find` returns the FIRST occurrence of each substring
+        // independently, so we must search for the closing tag AFTER
+        // the opening one — otherwise a text like
+        // `"</user_query>foo<user_query>...</user_query>"` (which can
+        // occur in a pasted log or AI-generated code sample) gives
+        // s > e and `text[s+12..e]` panics with `begin > end`.
+        let prompt = match text.find("<user_query>") {
+            Some(s) => {
+                let after = s + "<user_query>".len();
+                match text[after..].find("</user_query>") {
+                    Some(rel) => text[after..after + rel].trim(),
+                    None => text.trim(),
                 }
-                None => text.trim(),
-            };
-            if !prompt.is_empty() {
-                return Some(truncate(prompt, SUMMARY_MAX_CHARS));
             }
+            None => text.trim(),
+        };
+        if !prompt.is_empty() {
+            return Some(truncate(prompt, SUMMARY_MAX_CHARS));
         }
     }
     None
@@ -329,6 +336,16 @@ fn extract_first_prompt(jsonl_path: &Path) -> Option<String> {
 /// e.g. "Users-subinium-Desktop-my-project" -> /Users/subinium/Desktop/my-project
 fn decode_dash_path(encoded: &str) -> Option<PathBuf> {
     let parts: Vec<&str> = encoded.split('-').collect();
+    #[cfg(windows)]
+    if let Some(drive) = parts.first()
+        && drive.len() == 1
+        && drive.as_bytes()[0].is_ascii_alphabetic()
+    {
+        let root = PathBuf::from(format!("{}:\\", drive.to_ascii_uppercase()));
+        if let Some(path) = solve(&parts, 1, &root) {
+            return Some(path);
+        }
+    }
     solve(&parts, 0, Path::new("/"))
 }
 

--- a/src/scanner/gemini.rs
+++ b/src/scanner/gemini.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::fs;
-use std::io::Read;
+use std::io::{self, Read};
 use std::path::Path;
 
 use sha2::{Digest, Sha256};
@@ -24,18 +24,17 @@ pub fn scan() -> Result<Vec<Session>, AgfError> {
         return Ok(Vec::new());
     }
 
-    let path_map = build_path_map(&gemini_dir);
+    let path_map = build_path_map(&gemini_dir)?;
 
     // Dedup by sessionId: keep the entry with the latest `lastUpdated`.
     // The same session can appear in both a hash dir (old) and a named dir
     // (new) when Gemini CLI migrates a project to projects.json.
     let mut by_id: HashMap<String, Session> = HashMap::new();
 
-    let Ok(entries) = fs::read_dir(&tmp_dir) else {
-        return Ok(Vec::new());
-    };
+    let entries = fs::read_dir(&tmp_dir)?;
 
-    for entry in entries.filter_map(|e| e.ok()) {
+    for entry in entries {
+        let entry = entry?;
         let dir_name = entry.file_name().to_string_lossy().to_string();
         let chats_dir = entry.path().join("chats");
 
@@ -49,17 +48,17 @@ pub fn scan() -> Result<Vec<Session>, AgfError> {
             continue;
         }
 
-        let Ok(chat_entries) = fs::read_dir(&chats_dir) else {
-            continue;
-        };
+        let chat_entries = fs::read_dir(&chats_dir)?;
 
-        for chat_entry in chat_entries.filter_map(|e| e.ok()) {
+        for chat_entry in chat_entries {
+            let chat_entry = chat_entry?;
             let fname = chat_entry.file_name().to_string_lossy().to_string();
             if !fname.starts_with("session-") || !fname.ends_with(".json") {
                 continue;
             }
 
-            if let Some(session) = parse_session(&chat_entry.path(), &project_path, &project_name) {
+            if let Some(session) = parse_session(&chat_entry.path(), &project_path, &project_name)?
+            {
                 let existing = by_id.get(&session.session_id);
                 if existing.is_none_or(|e| session.timestamp > e.timestamp) {
                     by_id.insert(session.session_id.clone(), session);
@@ -75,18 +74,17 @@ pub fn scan() -> Result<Vec<Session>, AgfError> {
 ///
 /// Named dirs (e.g. "github") come directly from `projects.json` values.
 /// Hash dirs (e.g. "e0dc5a91...") are matched by computing SHA256 of each known path.
-fn build_path_map(gemini_dir: &Path) -> HashMap<String, String> {
+fn build_path_map(gemini_dir: &Path) -> Result<HashMap<String, String>, AgfError> {
     let mut map = HashMap::new();
 
     let projects_file = gemini_dir.join("projects.json");
-    let Ok(content) = fs::read_to_string(projects_file) else {
-        return map;
-    };
-    let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) else {
-        return map;
-    };
+    if !projects_file.exists() {
+        return Ok(map);
+    }
+    let content = fs::read_to_string(projects_file)?;
+    let json = serde_json::from_str::<serde_json::Value>(&content)?;
     let Some(projects) = json.get("projects").and_then(|v| v.as_object()) else {
-        return map;
+        return Ok(map);
     };
 
     for (path, name) in projects {
@@ -98,7 +96,7 @@ fn build_path_map(gemini_dir: &Path) -> HashMap<String, String> {
         }
     }
 
-    map
+    Ok(map)
 }
 
 /// Resolve a project dir name to (project_path, project_name).
@@ -121,20 +119,35 @@ fn resolve_project(dir_name: &str, path_map: &HashMap<String, String>) -> (Strin
 ///
 /// For large files (> 64 KB) we read a capped slice and fall back to
 /// field extraction if the JSON is truncated.
-fn parse_session(path: &Path, project_path: &str, project_name: &str) -> Option<Session> {
+fn parse_session(
+    path: &Path,
+    project_path: &str,
+    project_name: &str,
+) -> Result<Option<Session>, AgfError> {
     let content = read_capped(path)?;
 
     // Try full JSON parse first (works for files ≤ 64 KB)
     if let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) {
-        let session_id = json.get("sessionId")?.as_str()?.to_string();
-        let timestamp_str = json
+        let Some(session_id) = json
+            .get("sessionId")
+            .and_then(|value| value.as_str())
+            .map(str::to_string)
+        else {
+            return Ok(None);
+        };
+        let Some(timestamp_str) = json
             .get("lastUpdated")
             .or_else(|| json.get("startTime"))
-            .and_then(|v| v.as_str())?;
-        let timestamp = parse_iso8601_ms(timestamp_str)?;
+            .and_then(|v| v.as_str())
+        else {
+            return Ok(None);
+        };
+        let Some(timestamp) = parse_iso8601_ms(timestamp_str) else {
+            return Ok(None);
+        };
         let summary = extract_summary(&json);
 
-        return Some(Session {
+        return Ok(Some(Session {
             agent: Agent::Gemini,
             session_id,
             project_name: project_name.to_string(),
@@ -144,19 +157,27 @@ fn parse_session(path: &Path, project_path: &str, project_name: &str) -> Option<
             git_branch: None,
             worktree: None,
             recap: None,
-        });
+            interactive: true,
+        }));
     }
 
     // Truncated file — extract key fields with string search.
     // sessionId and timestamps always appear in the first ~300 bytes.
     // The first user message is typically in the first few KB.
-    let session_id = extract_str_field(&content, "sessionId")?;
-    let timestamp_str = extract_str_field(&content, "lastUpdated")
-        .or_else(|| extract_str_field(&content, "startTime"))?;
-    let timestamp = parse_iso8601_ms(&timestamp_str)?;
+    let Some(session_id) = extract_str_field(&content, "sessionId") else {
+        return Ok(None);
+    };
+    let Some(timestamp_str) = extract_str_field(&content, "lastUpdated")
+        .or_else(|| extract_str_field(&content, "startTime"))
+    else {
+        return Ok(None);
+    };
+    let Some(timestamp) = parse_iso8601_ms(&timestamp_str) else {
+        return Ok(None);
+    };
     let summary = extract_summary_partial(&content);
 
-    Some(Session {
+    Ok(Some(Session {
         agent: Agent::Gemini,
         session_id,
         project_name: project_name.to_string(),
@@ -166,27 +187,28 @@ fn parse_session(path: &Path, project_path: &str, project_name: &str) -> Option<
         git_branch: None,
         worktree: None,
         recap: None,
-    })
+        interactive: true,
+    }))
 }
 
 /// Read up to MAX_FILE_BYTES from a file.
-fn read_capped(path: &Path) -> Option<String> {
-    let mut file = fs::File::open(path).ok()?;
-    let size = file.metadata().ok()?.len() as usize;
+fn read_capped(path: &Path) -> Result<String, io::Error> {
+    let mut file = fs::File::open(path)?;
+    let size = usize::try_from(file.metadata()?.len()).unwrap_or(usize::MAX);
 
     if size <= MAX_FILE_BYTES {
-        return fs::read_to_string(path).ok();
+        return fs::read_to_string(path);
     }
 
     let mut buf = vec![0u8; MAX_FILE_BYTES];
-    let n = file.read(&mut buf).ok()?;
+    let n = file.read(&mut buf)?;
     // Trim `n` to the last complete UTF-8 boundary so a mid-codepoint cut
     // doesn't produce replacement characters in the tail.
     let valid_len = std::str::from_utf8(&buf[..n])
         .map(|_| n)
         .unwrap_or_else(|e| e.valid_up_to());
     let text = String::from_utf8_lossy(&buf[..valid_len]);
-    Some(text.into_owned())
+    Ok(text.into_owned())
 }
 
 /// Extract the first user message text from a fully-parsed JSON value.

--- a/src/scanner/hermes.rs
+++ b/src/scanner/hermes.rs
@@ -92,7 +92,7 @@ pub fn scan() -> Result<Vec<Session>, AgfError> {
                 GROUP_CONCAT(child.title, '|||'), \
                 ( \
                     SELECT GROUP_CONCAT(content, '|||') FROM ( \
-                        SELECT content FROM messages \
+                        SELECT substr(content, 1, 4096) AS content FROM messages \
                         WHERE session_id = s.id AND role = 'user' AND content IS NOT NULL \
                         ORDER BY timestamp ASC LIMIT 4 \
                     ) \
@@ -108,96 +108,93 @@ pub fn scan() -> Result<Vec<Session>, AgfError> {
          ORDER BY ts_ms DESC",
     )?;
 
-    let sessions = stmt
-        .query_map([], |row| {
-            let id: String = row.get(0)?;
-            let title: Option<String> = row.get(1)?;
-            let source: String = row.get(2)?;
-            let model: Option<String> = row.get(3)?;
-            let message_count: i64 = row.get(4)?;
-            let timestamp: i64 = row.get(5)?;
-            let child_titles: Option<String> = row.get(6)?;
-            let user_msgs: Option<String> = row.get(7)?;
-            Ok((
-                id,
-                title,
-                source,
-                model,
-                message_count,
-                timestamp,
-                child_titles,
-                user_msgs,
-            ))
-        })?
-        .filter_map(|r| r.ok())
-        .map(
-            |(id, title, source, model, message_count, timestamp, child_titles, user_msgs)| {
-                // Build summaries: title first, then child session titles,
-                // then up to 4 user-message previews so the TUI detail pane
-                // shows how the conversation actually went, not just one
-                // line.
-                let mut summaries: Vec<String> = Vec::new();
-                if let Some(ref t) = title
-                    && !t.is_empty()
+    let rows = stmt.query_map([], |row| {
+        let id: String = row.get(0)?;
+        let title: Option<String> = row.get(1)?;
+        let source: String = row.get(2)?;
+        let model: Option<String> = row.get(3)?;
+        let message_count: i64 = row.get(4)?;
+        let timestamp: i64 = row.get(5)?;
+        let child_titles: Option<String> = row.get(6)?;
+        let user_msgs: Option<String> = row.get(7)?;
+        Ok((
+            id,
+            title,
+            source,
+            model,
+            message_count,
+            timestamp,
+            child_titles,
+            user_msgs,
+        ))
+    })?;
+    let mut sessions = Vec::new();
+    for row in rows {
+        let (id, title, source, model, message_count, timestamp, child_titles, user_msgs) = row?;
+        // Build summaries: title first, then child session titles,
+        // then up to 4 user-message previews so the TUI detail pane
+        // shows how the conversation actually went, not just one
+        // line.
+        let mut summaries: Vec<String> = Vec::new();
+        if let Some(ref t) = title
+            && !t.is_empty()
+        {
+            summaries.push(t.clone());
+        }
+        if let Some(ref children) = child_titles {
+            push_concat_titles(&mut summaries, children);
+        }
+        // Only surface user-message previews for ids that look like
+        // CLI/TUI sessions. dashboard:*/api-*/named ids get messages
+        // from external integrations (Notion webhooks, scheduled
+        // crons, dashboard callers), so their `role='user'` rows
+        // are not the user's own prompts and would mislead the
+        // TUI summary.
+        if is_user_cli_session(&id)
+            && let Some(ref blob) = user_msgs
+        {
+            let mut seen: std::collections::HashSet<String> = summaries.iter().cloned().collect();
+            for raw in blob.split("|||") {
+                if let Some(preview) = message_preview(raw)
+                    && seen.insert(preview.clone())
                 {
-                    summaries.push(t.clone());
+                    summaries.push(preview);
                 }
-                if let Some(ref children) = child_titles {
-                    push_concat_titles(&mut summaries, children);
-                }
-                // Only surface user-message previews for ids that look like
-                // CLI/TUI sessions. dashboard:*/api-*/named ids get messages
-                // from external integrations (Notion webhooks, scheduled
-                // crons, dashboard callers), so their `role='user'` rows
-                // are not the user's own prompts and would mislead the
-                // TUI summary.
-                if is_user_cli_session(&id)
-                    && let Some(ref blob) = user_msgs
-                {
-                    let mut seen: std::collections::HashSet<String> =
-                        summaries.iter().cloned().collect();
-                    for raw in blob.split("|||") {
-                        if let Some(preview) = message_preview(raw)
-                            && seen.insert(preview.clone())
-                        {
-                            summaries.push(preview);
-                        }
-                    }
-                }
+            }
+        }
 
-                // If we still have nothing, fall back to source + model info
-                // so the row is never blank.
-                if summaries.is_empty() {
-                    let mut fallback = format!("{source} session");
-                    if let Some(ref m) = model
-                        && !m.is_empty()
-                    {
-                        // Extract short model name (e.g. "claude-opus-4-6" from "anthropic/claude-opus-4-6")
-                        let short = m.rsplit('/').next().unwrap_or(m);
-                        fallback = format!("{fallback} ({short})");
-                    }
-                    if message_count > 0 {
-                        fallback = format!("{fallback} — {message_count} msgs");
-                    }
-                    summaries.push(fallback);
-                }
+        // If we still have nothing, fall back to source + model info
+        // so the row is never blank.
+        if summaries.is_empty() {
+            let mut fallback = format!("{source} session");
+            if let Some(ref m) = model
+                && !m.is_empty()
+            {
+                // Extract short model name (e.g. "claude-opus-4-6" from "anthropic/claude-opus-4-6")
+                let short = m.rsplit('/').next().unwrap_or(m);
+                fallback = format!("{fallback} ({short})");
+            }
+            if message_count > 0 {
+                fallback = format!("{fallback} — {message_count} msgs");
+            }
+            summaries.push(fallback);
+        }
 
-                Session {
-                    agent: Agent::Hermes,
-                    session_id: id,
-                    project_name: "hermes".to_string(),
-                    // Empty path → resume runs in the user's current cwd
-                    // (Hermes is cwd-independent). See shell::cd_and.
-                    project_path: String::new(),
-                    summaries,
-                    timestamp,
-                    git_branch: None,
-                    worktree: None,
-                    recap: None,
-                }
-            },
-        )
-        .collect();
+        sessions.push(Session {
+            agent: Agent::Hermes,
+            session_id: id,
+            project_name: "hermes".to_string(),
+            // Empty path → resume runs in the user's current cwd
+            // (Hermes is cwd-independent). See shell::cd_and.
+            project_path: String::new(),
+            summaries,
+            timestamp,
+            git_branch: None,
+            worktree: None,
+            recap: None,
+            interactive: true,
+        });
+    }
 
     Ok(sessions)
 }

--- a/src/scanner/kiro.rs
+++ b/src/scanner/kiro.rs
@@ -1,93 +1,475 @@
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
+
 use rusqlite::Connection;
+use serde_json::Value;
 
 use crate::error::AgfError;
 use crate::model::{Agent, Session};
 
-use super::{project_name_from_path, truncate};
+use super::{collapse_whitespace, for_each_bounded_line, project_name_from_path, truncate};
+
+const MAX_V3_METADATA_BYTES: u64 = 2 * 1024 * 1024;
+const MAX_V3_EVENT_LINE_BYTES: usize = 1024 * 1024;
 
 pub fn scan() -> Result<Vec<Session>, AgfError> {
-    let db_path = crate::config::kiro_data_dir()?.join("data.sqlite3");
-
-    if !db_path.exists() {
-        return Ok(Vec::new());
+    let mut by_id = HashMap::new();
+    for session in scan_v2(&crate::config::kiro_data_dir()?.join("data.sqlite3"))? {
+        by_id.insert(session.session_id.clone(), session);
     }
-
-    let conn = Connection::open_with_flags(
-        &db_path,
-        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
-    )?;
-
-    // Kiro stores conversations in conversations_v2 table
-    // key = project directory path, conversation_id = session UUID
-    // updated_at = Unix timestamp in milliseconds
-    let mut stmt = match conn.prepare(
-        "SELECT key, conversation_id, value, updated_at \
-         FROM conversations_v2 \
-         ORDER BY updated_at DESC",
-    ) {
-        Ok(s) => s,
-        Err(_) => return Ok(Vec::new()),
-    };
-
-    let sessions = stmt
-        .query_map([], |row| {
-            let directory: String = row.get(0)?;
-            let conversation_id: String = row.get(1)?;
-            let value: String = row.get(2)?;
-            let updated_at: i64 = row.get(3)?;
-            Ok((directory, conversation_id, value, updated_at))
-        })?
-        .filter_map(|r| r.ok())
-        .map(|(directory, conversation_id, value, updated_at)| {
-            let project_name = project_name_from_path(&directory);
-
-            let summaries = match extract_summary(&value) {
-                Some(s) => vec![s],
-                None => Vec::new(),
-            };
-
-            Session {
-                agent: Agent::Kiro,
-                session_id: conversation_id,
-                project_name,
-                project_path: directory,
-                summaries,
-                timestamp: updated_at,
-                git_branch: None,
-                worktree: None,
-                recap: None,
-            }
-        })
-        .collect();
-
-    Ok(sessions)
-}
-
-/// Extract the first user message from the conversation JSON as a summary.
-fn extract_summary(value: &str) -> Option<String> {
-    let parsed: serde_json::Value = serde_json::from_str(value).ok()?;
-    let messages = parsed.get("messages").and_then(|v| v.as_array())?;
-    for msg in messages {
-        let role = msg.get("role").and_then(|v| v.as_str()).unwrap_or("");
-        if role == "user" {
-            // Content can be a string or an array of content blocks
-            if let Some(content) = msg.get("content").and_then(|v| v.as_str()) {
-                let trimmed = content.trim();
-                if !trimmed.is_empty() {
-                    return Some(truncate(trimmed, 100));
-                }
-            }
-            if let Some(parts) = msg.get("content").and_then(|v| v.as_array()) {
-                for part in parts {
-                    if let Some(text) = part.get("text").and_then(|v| v.as_str()) {
-                        let trimmed = text.trim();
-                        if !trimmed.is_empty() {
-                            return Some(truncate(trimmed, 100));
-                        }
-                    }
-                }
+    for session in scan_v3(&crate::config::kiro_sessions_dir()?)? {
+        match by_id.get(&session.session_id) {
+            Some(existing) if existing.timestamp >= session.timestamp => {}
+            _ => {
+                by_id.insert(session.session_id.clone(), session);
             }
         }
     }
+    let mut sessions: Vec<_> = by_id.into_values().collect();
+    sessions.sort_by(|a, b| crate::model::compare_sessions(a, b, crate::model::SortMode::Time));
+    Ok(sessions)
+}
+
+fn scan_v2(db_path: &Path) -> Result<Vec<Session>, AgfError> {
+    if !db_path.exists() {
+        return Ok(Vec::new());
+    }
+    let conn = Connection::open_with_flags(
+        db_path,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )?;
+    let mut stmt = match conn.prepare(
+        // The prompt preview is near the head; never materialize an entire
+        // multi-megabyte conversation blob merely to render one summary.
+        "SELECT key, conversation_id, substr(value, 1, 262144), updated_at \
+         FROM conversations_v2 ORDER BY updated_at DESC",
+    ) {
+        Ok(statement) => statement,
+        Err(error) if error.to_string().contains("no such table") => return Ok(Vec::new()),
+        Err(error) => return Err(error.into()),
+    };
+    let rows = stmt.query_map([], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, String>(2)?,
+            row.get::<_, i64>(3)?,
+        ))
+    })?;
+    let mut sessions = Vec::new();
+    for row in rows {
+        let (directory, conversation_id, value, updated_at) = row?;
+        if directory.is_empty() || conversation_id.is_empty() {
+            continue;
+        }
+        sessions.push(Session {
+            agent: Agent::Kiro,
+            session_id: conversation_id,
+            project_name: project_name_from_path(&directory),
+            project_path: directory,
+            summaries: extract_summary(&value).into_iter().collect(),
+            timestamp: updated_at,
+            git_branch: None,
+            worktree: None,
+            recap: None,
+            interactive: true,
+        });
+    }
+    Ok(sessions)
+}
+
+fn scan_v3(dir: &Path) -> Result<Vec<Session>, AgfError> {
+    if !dir.exists() {
+        return Ok(Vec::new());
+    }
+    let mut sessions = Vec::new();
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if !entry.file_type()?.is_file()
+            || path.extension().and_then(|ext| ext.to_str()) != Some("json")
+        {
+            continue;
+        }
+        if let Some(session) = parse_v3_metadata(&path)? {
+            sessions.push(session);
+        }
+    }
+    Ok(sessions)
+}
+
+fn parse_v3_metadata(path: &Path) -> Result<Option<Session>, AgfError> {
+    let mut content = String::new();
+    File::open(path)?
+        .take(MAX_V3_METADATA_BYTES)
+        .read_to_string(&mut content)?;
+    let Ok(metadata) = serde_json::from_str::<Value>(&content) else {
+        return Ok(None);
+    };
+    let Some(stem) = path.file_stem().and_then(|stem| stem.to_str()) else {
+        return Ok(None);
+    };
+    let session_id = v3_session_id_from_metadata(&metadata, stem);
+    let Some(project_path) = first_string(
+        &metadata,
+        &["/cwd", "/workingDirectory", "/session/cwd", "/metadata/cwd"],
+    ) else {
+        return Ok(None);
+    };
+    let project_path = project_path.trim().to_string();
+    if session_id.is_empty() || project_path.is_empty() {
+        return Ok(None);
+    }
+
+    let event_path = path.with_extension("jsonl");
+    let event = scan_v3_events(&event_path)?;
+    let metadata_time = [
+        "/updated_at",
+        "/created_at",
+        "/updatedAt",
+        "/lastUpdated",
+        "/modifiedAt",
+        "/createdAt",
+    ]
+    .into_iter()
+    .filter_map(|pointer| parse_timestamp(metadata.pointer(pointer)))
+    .max()
+    .unwrap_or(0);
+    let file_time = path
+        .metadata()
+        .ok()
+        .and_then(|metadata| metadata.modified().ok())
+        .and_then(|time| time.duration_since(std::time::SystemTime::UNIX_EPOCH).ok())
+        .map(|duration| i64::try_from(duration.as_millis()).unwrap_or(i64::MAX))
+        .unwrap_or(0);
+    let title = first_string(
+        &metadata,
+        &["/title", "/name", "/session/title", "/metadata/title"],
+    )
+    .map(str::trim)
+    .filter(|title| !title.is_empty())
+    .map(|title| truncate(title, 100));
+    let mut summaries = Vec::new();
+    if let Some(title) = title {
+        summaries.push(title);
+    }
+    if let Some(summary) = event.summary
+        && summaries.first() != Some(&summary)
+    {
+        summaries.push(summary);
+    }
+
+    Ok(Some(Session {
+        agent: Agent::Kiro,
+        session_id,
+        project_name: project_name_from_path(&project_path),
+        project_path,
+        summaries,
+        // Preserve the durable raw value until the common scan boundary. If a
+        // near-future clock-skewed value is clamped there, the snapshot is kept
+        // out of the cache so it can become valid without a source rewrite.
+        timestamp: if event.last_activity != 0 {
+            event.last_activity
+        } else if metadata_time != 0 {
+            metadata_time
+        } else {
+            file_time
+        },
+        git_branch: first_string(&metadata, &["/gitBranch", "/git/branch"]).map(str::to_string),
+        worktree: None,
+        recap: None,
+        interactive: true,
+    }))
+}
+
+fn v3_session_id_from_metadata(metadata: &Value, stem: &str) -> String {
+    first_string(
+        metadata,
+        &[
+            "/session_id",
+            "/sessionId",
+            "/id",
+            "/session/id",
+            "/metadata/sessionId",
+        ],
+    )
+    .unwrap_or(stem)
+    .trim()
+    .to_string()
+}
+
+/// Read the authoritative v3 session id without assuming it matches the
+/// metadata filename. Kiro commonly stores generic stems such as
+/// `transcript.json`, while the resumable id lives inside the document.
+pub(crate) fn v3_session_id(path: &Path) -> Result<Option<String>, AgfError> {
+    let mut content = String::new();
+    File::open(path)?
+        .take(MAX_V3_METADATA_BYTES)
+        .read_to_string(&mut content)?;
+    let Ok(metadata) = serde_json::from_str::<Value>(&content) else {
+        return Ok(None);
+    };
+    let Some(stem) = path.file_stem().and_then(|stem| stem.to_str()) else {
+        return Ok(None);
+    };
+    let id = v3_session_id_from_metadata(&metadata, stem);
+    Ok((!id.is_empty()).then_some(id))
+}
+
+#[derive(Default)]
+struct V3EventInfo {
+    summary: Option<String>,
+    last_activity: i64,
+}
+
+fn scan_v3_events(path: &Path) -> Result<V3EventInfo, AgfError> {
+    let mut info = V3EventInfo::default();
+    if !path.exists() {
+        return Ok(info);
+    }
+    let read_ok = for_each_bounded_line(path, usize::MAX, MAX_V3_EVENT_LINE_BYTES, |line| {
+        let Ok(event) = serde_json::from_slice::<Value>(line) else {
+            return;
+        };
+        let role = match event.get("kind").and_then(Value::as_str) {
+            Some("Prompt") => Some("user"),
+            Some("AssistantMessage") => Some("assistant"),
+            _ => first_string(&event, &["/role", "/message/role", "/data/role"]),
+        };
+        if !matches!(role, Some("user" | "assistant")) {
+            return;
+        }
+        let event_time = [
+            "/data/meta/timestamp",
+            "/timestamp",
+            "/createdAt",
+            "/message/timestamp",
+        ]
+        .into_iter()
+        .filter_map(|pointer| parse_timestamp(event.pointer(pointer)))
+        .max()
+        .unwrap_or(0);
+        info.last_activity = info.last_activity.max(event_time);
+        if role == Some("user") && info.summary.is_none() {
+            let content = event
+                .pointer("/content")
+                .or_else(|| event.pointer("/message/content"))
+                .or_else(|| event.pointer("/data/content"));
+            info.summary = content_text(content)
+                .map(|text| collapse_whitespace(&text))
+                .filter(|text| !text.is_empty())
+                .map(|text| truncate(&text, 100));
+        }
+    });
+    if !read_ok {
+        return Err(std::io::Error::other(format!(
+            "failed to read Kiro v3 events {}",
+            path.display()
+        ))
+        .into());
+    }
+    Ok(info)
+}
+
+fn first_string<'a>(value: &'a Value, pointers: &[&str]) -> Option<&'a str> {
+    pointers
+        .iter()
+        .find_map(|pointer| value.pointer(pointer).and_then(Value::as_str))
+}
+
+fn parse_timestamp(value: Option<&Value>) -> Option<i64> {
+    match value? {
+        Value::Number(number) => number.as_i64().map(|timestamp| {
+            if timestamp < 10_000_000_000 {
+                timestamp.saturating_mul(1000)
+            } else {
+                timestamp
+            }
+        }),
+        Value::String(timestamp) => chrono::DateTime::parse_from_rfc3339(timestamp)
+            .ok()
+            .map(|timestamp| timestamp.timestamp_millis()),
+        _ => None,
+    }
+}
+
+fn content_text(content: Option<&Value>) -> Option<String> {
+    match content? {
+        Value::String(text) => Some(text.clone()),
+        Value::Array(blocks) => {
+            let text = blocks
+                .iter()
+                .filter_map(|block| {
+                    block.get("text").and_then(Value::as_str).or_else(|| {
+                        (block.get("kind").and_then(Value::as_str) == Some("text"))
+                            .then(|| block.get("data").and_then(Value::as_str))
+                            .flatten()
+                    })
+                })
+                .collect::<Vec<_>>()
+                .join(" ");
+            (!text.is_empty()).then_some(text)
+        }
+        _ => None,
+    }
+}
+
+fn extract_summary(value: &str) -> Option<String> {
+    let parsed: Value = serde_json::from_str(value).ok()?;
+    if let Some(prompt) = parsed
+        .get("history")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .find_map(|entry| {
+            first_string(
+                entry,
+                &[
+                    "/user/content/Prompt/prompt",
+                    "/user/content/prompt",
+                    "/user/Prompt/prompt",
+                ],
+            )
+        })
+    {
+        let normalized = collapse_whitespace(prompt);
+        if !normalized.is_empty() {
+            return Some(truncate(&normalized, 100));
+        }
+    }
+    let messages = parsed.get("messages").and_then(Value::as_array)?;
+    for message in messages {
+        if message.get("role").and_then(Value::as_str) != Some("user") {
+            continue;
+        }
+        let text = content_text(message.get("content"))?;
+        let normalized = collapse_whitespace(&text);
+        if !normalized.is_empty() {
+            return Some(truncate(&normalized, 100));
+        }
+    }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn v2_exact_ids_remain_distinct_in_one_cwd() {
+        let dir = std::env::temp_dir().join(format!("agf-kiro-v2-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let db = dir.join("data.sqlite3");
+        let conn = Connection::open(&db).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE conversations_v2 (key TEXT, conversation_id TEXT, value TEXT, updated_at INTEGER);",
+        )
+        .unwrap();
+        for (id, timestamp) in [
+            ("older", 1_785_542_401_000i64),
+            ("newer", 1_785_542_402_000),
+        ] {
+            conn.execute(
+                "INSERT INTO conversations_v2 VALUES (?1, ?2, ?3, ?4)",
+                ("/tmp/project", id, r#"{"messages":[]}"#, timestamp),
+            )
+            .unwrap();
+        }
+        drop(conn);
+
+        let sessions = scan_v2(&db).unwrap();
+        assert_eq!(sessions.len(), 2);
+        assert_ne!(sessions[0].session_id, sessions[1].session_id);
+    }
+
+    #[test]
+    fn extracts_real_v2_history_prompt_dialect() {
+        let value =
+            r#"{"history":[{"user":{"content":{"Prompt":{"prompt":"  real   v2 prompt  "}}}}]}"#;
+        assert_eq!(extract_summary(value).as_deref(), Some("real v2 prompt"));
+    }
+
+    #[test]
+    fn parses_v3_metadata_and_event_log() {
+        let dir = std::env::temp_dir().join(format!("agf-kiro-v3-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let metadata = dir.join("sess_abc.json");
+        std::fs::write(
+            &metadata,
+            r#"{"sessionId":"sess_abc","cwd":"/tmp/project","title":"Refactor","updatedAt":"2026-08-01T00:00:00Z"}"#,
+        )
+        .unwrap();
+        let mut events = File::create(dir.join("sess_abc.jsonl")).unwrap();
+        writeln!(
+            events,
+            r#"{{"role":"user","content":[{{"type":"text","text":"first prompt"}}],"timestamp":"2026-08-01T00:00:01Z"}}"#
+        )
+        .unwrap();
+
+        let session = parse_v3_metadata(&metadata).unwrap().unwrap();
+        assert_eq!(session.session_id, "sess_abc");
+        assert_eq!(session.project_path, "/tmp/project");
+        assert_eq!(session.summaries, ["Refactor", "first prompt"]);
+        assert_eq!(session.timestamp, 1_785_542_401_000);
+    }
+
+    #[test]
+    fn parses_real_v3_snake_case_replay_dialect() {
+        let dir = std::env::temp_dir().join(format!("agf-kiro-v3-real-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let metadata = dir.join("transcript.json");
+        std::fs::write(
+            &metadata,
+            r#"{"session_id":"real-id","created_at":1784126000,"updated_at":1784126037,"cwd":"/tmp/real-project","title":"Real replay"}"#,
+        )
+        .unwrap();
+        let mut events = File::create(dir.join("transcript.jsonl")).unwrap();
+        writeln!(
+            events,
+            r#"{{"version":"v1","kind":"Prompt","data":{{"content":[{{"kind":"text","data":"real first prompt"}}],"meta":{{"timestamp":1784126037}}}}}}"#
+        )
+        .unwrap();
+        writeln!(
+            events,
+            r#"{{"version":"v1","kind":"AssistantMessage","data":{{"content":[],"meta":{{"timestamp":1784126040}}}}}}"#
+        )
+        .unwrap();
+
+        let session = parse_v3_metadata(&metadata).unwrap().unwrap();
+        assert_eq!(session.session_id, "real-id");
+        assert_eq!(session.summaries, ["Real replay", "real first prompt"]);
+        assert_eq!(session.timestamp, 1_784_126_040_000);
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn durable_v3_updated_at_precedes_newer_file_mtime() {
+        use std::time::{Duration, SystemTime};
+
+        let dir = std::env::temp_dir().join(format!("agf-kiro-v3-mtime-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let metadata = dir.join("session.json");
+        std::fs::write(
+            &metadata,
+            r#"{"session_id":"id","updated_at":"2026-08-01T00:00:00Z","cwd":"/tmp/project"}"#,
+        )
+        .unwrap();
+        File::options()
+            .write(true)
+            .open(&metadata)
+            .unwrap()
+            .set_modified(SystemTime::UNIX_EPOCH + Duration::from_secs(1_786_320_000))
+            .unwrap();
+
+        let session = parse_v3_metadata(&metadata).unwrap().unwrap();
+        assert_eq!(session.timestamp, 1_785_542_400_000);
+        let _ = std::fs::remove_dir_all(dir);
+    }
 }

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -1,6 +1,7 @@
 use std::thread;
 
-use crate::model::Session;
+use crate::error::AgfError;
+use crate::model::{Agent, Session, compare_sessions, normalize_timestamp};
 
 pub mod claude;
 pub mod codex;
@@ -11,6 +12,7 @@ pub mod kiro;
 pub mod oh_my_pi;
 pub mod opencode;
 pub mod pi;
+pub mod prime_agent;
 pub mod yolop;
 
 /// Truncate a string to `max` chars, appending "..." if truncated.
@@ -25,23 +27,30 @@ pub(crate) fn truncate(s: &str, max: usize) -> String {
 
 /// Read only the first non-empty line of a file without loading the rest.
 pub(crate) fn read_first_line(path: &std::path::Path) -> Option<String> {
+    read_first_line_result(path).ok().flatten()
+}
+
+/// Fallible counterpart used by authoritative scanners, where a transient
+/// read error must not be mistaken for a malformed/absent record and cached
+/// as a successful partial scan.
+pub(crate) fn read_first_line_result(path: &std::path::Path) -> std::io::Result<Option<String>> {
     use std::fs::File;
     use std::io::{BufRead, BufReader, Read};
     /// Defensive cap matching the 512 KiB budgets used by cursor/pi scanners;
     /// a real first line is ~1 KB, and a truncated line just fails JSON
     /// parse upstream and is skipped.
     const MAX_FIRST_LINE_BYTES: u64 = 512 * 1024;
-    let file = File::open(path).ok()?;
+    let file = File::open(path)?;
     let mut reader = BufReader::new(file).take(MAX_FIRST_LINE_BYTES);
     let mut line = String::new();
     loop {
         line.clear();
-        let n = reader.read_line(&mut line).ok()?;
+        let n = reader.read_line(&mut line)?;
         if n == 0 {
-            return None;
+            return Ok(None);
         }
         if !line.trim().is_empty() {
-            return Some(line);
+            return Ok(Some(line));
         }
     }
 }
@@ -76,6 +85,96 @@ pub(crate) fn read_head_lines(
         }
     }
     lines
+}
+
+/// Stream complete lines while enforcing both a total byte budget and a hard
+/// per-line allocation ceiling. Oversized lines are discarded in chunks
+/// instead of being accumulated by `BufRead::read_line/read_until`.
+pub(crate) fn for_each_bounded_line(
+    path: &std::path::Path,
+    max_total_bytes: usize,
+    max_line_bytes: usize,
+    mut visit: impl FnMut(&[u8]),
+) -> bool {
+    for_each_bounded_line_with_overflow(
+        path,
+        max_total_bytes,
+        max_line_bytes,
+        |line, _tail, oversized| {
+            if !oversized {
+                visit(line);
+            }
+        },
+    )
+}
+
+/// Variant that reports an oversized row with its bounded prefix. Callers
+/// such as Prime can still recover envelope fields (type/role/timestamp)
+/// without allocating a multi-megabyte tool payload.
+pub(crate) fn for_each_bounded_line_with_overflow(
+    path: &std::path::Path,
+    max_total_bytes: usize,
+    max_line_bytes: usize,
+    mut visit: impl FnMut(&[u8], &[u8], bool),
+) -> bool {
+    use std::collections::VecDeque;
+    use std::fs::File;
+    use std::io::{BufRead, BufReader};
+
+    const MAX_TAIL_BYTES: usize = 64 * 1024;
+
+    let Ok(file) = File::open(path) else {
+        return false;
+    };
+    let mut reader = BufReader::new(file);
+    let mut total = 0usize;
+    let mut line = Vec::with_capacity(max_line_bytes.min(16 * 1024));
+    let mut tail = VecDeque::with_capacity(MAX_TAIL_BYTES);
+    let mut oversized = false;
+    while total < max_total_bytes {
+        let Ok(buffer) = reader.fill_buf() else {
+            return false;
+        };
+        if buffer.is_empty() {
+            if !line.is_empty() {
+                let tail_slice = tail.make_contiguous();
+                visit(&line, tail_slice, oversized);
+            }
+            return true;
+        }
+        let remaining = max_total_bytes - total;
+        let available = buffer.len().min(remaining);
+        let slice = &buffer[..available];
+        let (piece_len, ends_line) = match slice.iter().position(|byte| *byte == b'\n') {
+            Some(index) => (index + 1, true),
+            None => (slice.len(), false),
+        };
+        if !oversized {
+            let remaining_line = max_line_bytes.saturating_sub(line.len());
+            let copy_len = piece_len.min(remaining_line);
+            line.extend_from_slice(&slice[..copy_len]);
+            if copy_len < piece_len {
+                oversized = true;
+            }
+        }
+        if oversized {
+            tail.extend(slice[..piece_len].iter().copied());
+            let excess = tail.len().saturating_sub(MAX_TAIL_BYTES);
+            if excess > 0 {
+                tail.drain(..excess);
+            }
+        }
+        reader.consume(piece_len);
+        total += piece_len;
+        if ends_line {
+            let tail_slice = tail.make_contiguous();
+            visit(&line, tail_slice, oversized);
+            line.clear();
+            tail.clear();
+            oversized = false;
+        }
+    }
+    true
 }
 
 /// Char-safe slice: take first `max` chars (never panics on UTF-8 boundaries).
@@ -211,34 +310,65 @@ fn trim_partial_first_line(bytes: &[u8]) -> String {
     }
 }
 
-pub fn scan_all() -> Vec<Session> {
-    let handles = vec![
-        thread::spawn(|| claude::scan().unwrap_or_default()),
-        thread::spawn(|| codex::scan().unwrap_or_default()),
-        thread::spawn(|| opencode::scan().unwrap_or_default()),
-        thread::spawn(|| pi::scan().unwrap_or_default()),
-        thread::spawn(|| oh_my_pi::scan().unwrap_or_default()),
-        thread::spawn(|| kiro::scan().unwrap_or_default()),
-        thread::spawn(|| cursor_agent::scan().unwrap_or_default()),
-        thread::spawn(|| gemini::scan().unwrap_or_default()),
-        thread::spawn(|| hermes::scan().unwrap_or_default()),
-        thread::spawn(|| yolop::scan().unwrap_or_default()),
-    ];
-    let mut sessions: Vec<Session> = handles
-        .into_iter()
-        .flat_map(|h| match h.join() {
-            Ok(v) => v,
-            Err(_) => {
-                if std::env::var("AGF_DEBUG").is_ok() {
-                    eprintln!("[agf] scanner thread panicked");
-                }
-                Vec::new()
-            }
-        })
-        .collect();
+pub fn scan_agent(agent: Agent) -> Result<Vec<Session>, AgfError> {
+    match agent {
+        Agent::ClaudeCode => claude::scan(),
+        Agent::Codex => codex::scan(),
+        Agent::OpenCode => opencode::scan(),
+        Agent::Pi => pi::scan(),
+        Agent::OhMyPi => oh_my_pi::scan(),
+        Agent::Kiro => kiro::scan(),
+        Agent::CursorAgent => cursor_agent::scan(),
+        Agent::Gemini => gemini::scan(),
+        Agent::Hermes => hermes::scan(),
+        Agent::Yolop => yolop::scan(),
+        Agent::PrimeAgent => prime_agent::scan(),
+    }
+}
 
-    sessions.sort_by_key(|s| std::cmp::Reverse(s.timestamp));
-    sessions
+pub struct CompletedScan {
+    pub sessions: Vec<Session>,
+    /// Present only when sources were unchanged for the whole scan. The
+    /// sessions remain useful when an active agent appended concurrently, but
+    /// that snapshot must not be persisted as fresh cache state.
+    pub fingerprint: Option<crate::cache::SourceFingerprint>,
+}
+
+pub fn scan_agent_consistent(agent: Agent) -> Result<CompletedScan, String> {
+    let before = crate::cache::agent_fingerprint(agent);
+    let mut sessions = scan_agent(agent).map_err(|error| error.to_string())?;
+    let after = crate::cache::agent_fingerprint(agent);
+    let now = chrono::Utc::now().timestamp_millis();
+    let mut future_clamped = false;
+    for session in &mut sessions {
+        let raw_timestamp = session.timestamp;
+        session.timestamp = normalize_timestamp(raw_timestamp, 0);
+        // A timestamp just beyond the accepted skew window can become valid
+        // while the source remains byte-for-byte unchanged. Do not bless the
+        // clamped value as fresh cache state, or the raw durable timestamp is
+        // lost permanently and the session stays at the bottom.
+        future_clamped |= raw_timestamp > now && session.timestamp != raw_timestamp;
+    }
+    sessions.sort_by(|a, b| compare_sessions(a, b, crate::model::SortMode::Time));
+    Ok(CompletedScan {
+        sessions,
+        fingerprint: (before == after && !future_clamped).then_some(after),
+    })
+}
+
+pub fn scan_agents_detailed(agents: &[Agent]) -> Vec<(Agent, Result<CompletedScan, String>)> {
+    let handles: Vec<_> = agents
+        .iter()
+        .copied()
+        .map(|agent| (agent, thread::spawn(move || scan_agent_consistent(agent))))
+        .collect();
+    handles
+        .into_iter()
+        .map(|(agent, handle)| match handle.join() {
+            Ok(result) => (agent, result),
+            Err(_) => (agent, Err("scanner thread panicked".to_string())),
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -278,6 +408,42 @@ mod tests {
         assert_eq!(collapse_whitespace("one"), "one");
         // Unicode whitespace (ideographic space) collapses like split_whitespace.
         assert_eq!(collapse_whitespace("a\u{3000}b"), "a b");
+    }
+
+    #[test]
+    fn bounded_line_reader_discards_oversized_rows_and_recovers() {
+        let mut content = vec![b'x'; 1024];
+        content.extend_from_slice(b"\n{\"ok\":true}\n");
+        let path = write_tmp("agf-test-bounded-lines.jsonl", &content);
+        let mut lines = Vec::new();
+        assert!(for_each_bounded_line(&path, 2048, 128, |line| lines.push(line.to_vec())));
+        assert_eq!(lines, [b"{\"ok\":true}\n".to_vec()]);
+    }
+
+    #[test]
+    fn overflow_reader_retains_a_bounded_tail_for_late_envelope_fields() {
+        let mut content = br#"{"display":""#.to_vec();
+        content.extend(std::iter::repeat_n(b'x', 1024));
+        content.extend_from_slice(br#"","project":"/tmp/p","sessionId":"sid","timestamp":42}"#);
+        content.push(b'\n');
+        let path = write_tmp("agf-test-bounded-tail.jsonl", &content);
+        let mut observed = None;
+        assert!(for_each_bounded_line_with_overflow(
+            &path,
+            usize::MAX,
+            128,
+            |prefix, tail, oversized| {
+                observed = Some((prefix.to_vec(), tail.to_vec(), oversized));
+            }
+        ));
+        let (prefix, tail, oversized) = observed.expect("one row");
+        assert!(oversized);
+        assert_eq!(prefix.len(), 128);
+        assert!(
+            String::from_utf8(tail)
+                .unwrap()
+                .contains("\"sessionId\":\"sid\"")
+        );
     }
 
     #[test]

--- a/src/scanner/oh_my_pi.rs
+++ b/src/scanner/oh_my_pi.rs
@@ -6,7 +6,7 @@ pub fn scan() -> Result<Vec<Session>, AgfError> {
     // OMP stores task/subagent transcripts below each top-level session.
     // Its own global resume lookup only scans `*/*.jsonl`, so match that
     // boundary and don't surface nested files that `omp --resume` can't find.
-    Ok(super::pi::scan_from(&sessions_dir, Agent::OhMyPi, Some(2)))
+    super::pi::scan_from(&sessions_dir, Agent::OhMyPi, Some(2))
 }
 
 #[cfg(test)]
@@ -50,7 +50,7 @@ mod tests {
         )
         .unwrap();
 
-        let sessions = super::super::pi::scan_from(&root, Agent::OhMyPi, Some(2));
+        let sessions = super::super::pi::scan_from(&root, Agent::OhMyPi, Some(2)).unwrap();
         let _ = fs::remove_dir_all(&root);
 
         assert_eq!(sessions.len(), 1);

--- a/src/scanner/opencode.rs
+++ b/src/scanner/opencode.rs
@@ -30,41 +30,41 @@ pub fn scan() -> Result<Vec<Session>, AgfError> {
          ORDER BY s.time_updated DESC",
     )?;
 
-    let sessions = stmt
-        .query_map([], |row| {
-            let id: String = row.get(0)?;
-            let title: String = row.get(1)?;
-            let directory: String = row.get(2)?;
-            let time_updated: i64 = row.get(3)?;
-            let sub_titles: Option<String> = row.get(4)?;
-            Ok((id, title, directory, time_updated, sub_titles))
-        })?
-        .filter_map(|r| r.ok())
-        .map(|(id, title, directory, time_updated, sub_titles)| {
-            let project_name = project_name_from_path(&directory);
+    let rows = stmt.query_map([], |row| {
+        let id: String = row.get(0)?;
+        let title: String = row.get(1)?;
+        let directory: String = row.get(2)?;
+        let time_updated: i64 = row.get(3)?;
+        let sub_titles: Option<String> = row.get(4)?;
+        Ok((id, title, directory, time_updated, sub_titles))
+    })?;
+    let mut sessions = Vec::new();
+    for row in rows {
+        let (id, title, directory, time_updated, sub_titles) = row?;
+        let project_name = project_name_from_path(&directory);
 
-            // Parent title first, then deduplicated subagent titles.
-            let mut summaries: Vec<String> = Vec::new();
-            if !title.is_empty() {
-                summaries.push(title);
-            }
-            if let Some(ref blob) = sub_titles {
-                push_concat_titles(&mut summaries, blob);
-            }
+        // Parent title first, then deduplicated subagent titles.
+        let mut summaries: Vec<String> = Vec::new();
+        if !title.is_empty() {
+            summaries.push(title);
+        }
+        if let Some(ref blob) = sub_titles {
+            push_concat_titles(&mut summaries, blob);
+        }
 
-            Session {
-                agent: Agent::OpenCode,
-                session_id: id,
-                project_name,
-                project_path: directory,
-                summaries,
-                timestamp: time_updated,
-                git_branch: None,
-                worktree: None,
-                recap: None,
-            }
-        })
-        .collect();
+        sessions.push(Session {
+            agent: Agent::OpenCode,
+            session_id: id,
+            project_name,
+            project_path: directory,
+            summaries,
+            timestamp: time_updated,
+            git_branch: None,
+            worktree: None,
+            recap: None,
+            interactive: true,
+        });
+    }
 
     Ok(sessions)
 }

--- a/src/scanner/pi.rs
+++ b/src/scanner/pi.rs
@@ -1,13 +1,11 @@
 use serde::Deserialize;
 use serde_json::Value;
-use std::fs::File;
-use std::io::{BufRead, BufReader};
 use std::path::Path;
 use walkdir::WalkDir;
 
 use crate::error::AgfError;
 use crate::model::{Agent, Session};
-use crate::scanner::{first_line_truncated, project_name_from_path};
+use crate::scanner::{first_line_truncated, for_each_bounded_line, project_name_from_path};
 
 const SUMMARY_MAX_CHARS: usize = 120;
 
@@ -19,6 +17,7 @@ const SUMMARY_MAX_CHARS: usize = 120;
 /// is always read; this only bounds how many prompt summaries are collected
 /// from pathologically large sessions.
 const MAX_PARSE_BYTES: usize = 512 * 1024;
+const MAX_LINE_BYTES: usize = 256 * 1024;
 
 #[derive(Deserialize)]
 struct PiSessionHeader {
@@ -31,16 +30,16 @@ struct PiSessionHeader {
 
 pub fn scan() -> Result<Vec<Session>, AgfError> {
     let sessions_dir = crate::config::pi_sessions_dir()?;
-    Ok(scan_from(&sessions_dir, Agent::Pi, None))
+    scan_from(&sessions_dir, Agent::Pi, None)
 }
 
 pub(crate) fn scan_from(
     sessions_dir: &Path,
     agent: Agent,
     max_depth: Option<usize>,
-) -> Vec<Session> {
+) -> Result<Vec<Session>, AgfError> {
     if !sessions_dir.exists() {
-        return Vec::new();
+        return Ok(Vec::new());
     }
 
     let mut sessions = Vec::new();
@@ -49,13 +48,14 @@ pub(crate) fn scan_from(
         walker = walker.max_depth(depth);
     }
 
-    for entry in walker.into_iter().filter_map(|e| e.ok()) {
+    for entry in walker {
+        let entry = entry.map_err(std::io::Error::other)?;
         let path = entry.path();
         if !path.is_file() || path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
             continue;
         }
 
-        if let Some(session) = parse_session(path, agent) {
+        if let Some(session) = parse_session(path, agent)? {
             sessions.push(session);
         }
     }
@@ -64,58 +64,39 @@ pub(crate) fn scan_from(
     // so keep older sessions from the same project selectable.
     sessions.sort_by_key(|s| std::cmp::Reverse(s.timestamp));
 
-    sessions
+    Ok(sessions)
 }
 
-fn parse_session(path: &Path, agent: Agent) -> Option<Session> {
-    let file = File::open(path).ok()?;
-    let reader = BufReader::new(file);
+fn parse_session(path: &Path, agent: Agent) -> Result<Option<Session>, AgfError> {
     let mut header = None;
     let mut summaries = Vec::new();
-    let mut bytes_read = 0usize;
-
-    for line_result in reader.lines() {
-        // A single bad line (invalid UTF-8, transient IO error) must skip just
-        // that line — never abort the rest of the file. `map_while(Result::ok)`
-        // stops at the first `Err`, which silently truncates summaries (or
-        // drops the entire session if the bad line is line 1, since the header
-        // is not yet captured). Same bug class as the cursor `.ok()?` fix in
-        // v0.11.3 (`extract_first_prompt_skips_invalid_utf8_lines`).
-        let Ok(line) = line_result else {
-            continue;
-        };
-        // +1 approximates the newline stripped by `lines()`; we only need a
-        // rough byte budget, not an exact count.
-        bytes_read += line.len() + 1;
-
-        let line = line.trim();
-        if !line.is_empty()
-            && let Ok(value) = serde_json::from_str::<Value>(line)
-        {
+    let read_ok = for_each_bounded_line(path, MAX_PARSE_BYTES, MAX_LINE_BYTES, |line| {
+        if let Ok(value) = serde_json::from_slice::<Value>(line) {
             if header.is_none() && value.get("type").and_then(Value::as_str) == Some("session") {
-                // Re-parse from the raw line rather than `from_value(clone)`:
-                // the header record carries the whole session preamble, and
-                // cloning it just to reshape it is a pure copy.
-                header = serde_json::from_str::<PiSessionHeader>(line).ok();
+                header = serde_json::from_slice::<PiSessionHeader>(line).ok();
             }
 
             if let Some(summary) = extract_user_summary(&value) {
                 summaries.push(summary);
             }
         }
-
-        if bytes_read >= MAX_PARSE_BYTES {
-            break;
-        }
+    });
+    if !read_ok {
+        return Err(
+            std::io::Error::other(format!("failed to read pi session {}", path.display())).into(),
+        );
     }
 
-    let header = header?;
+    let Some(header) = header else {
+        return Ok(None);
+    };
     if header.entry_type.as_deref() != Some("session") {
-        return None;
+        return Ok(None);
     }
 
-    let session_id = header.id?;
-    let cwd = header.cwd?;
+    let (Some(session_id), Some(cwd)) = (header.id, header.cwd) else {
+        return Ok(None);
+    };
     // pi's session-header timestamp is the CREATION time and never advances as
     // the session is used. The transcript file is appended on every turn, so
     // its mtime tracks last activity — take the max of the two so a
@@ -136,7 +117,7 @@ fn parse_session(path: &Path, agent: Agent) -> Option<Session> {
 
     let project_name = project_name_from_path(&cwd);
 
-    Some(Session {
+    Ok(Some(Session {
         agent,
         session_id,
         project_name,
@@ -146,7 +127,8 @@ fn parse_session(path: &Path, agent: Agent) -> Option<Session> {
         git_branch: None,
         worktree: None,
         recap: None,
-    })
+        interactive: true,
+    }))
 }
 
 fn extract_user_summary(value: &Value) -> Option<String> {
@@ -214,7 +196,9 @@ mod tests {
         let session = parse_session(&path, Agent::Pi);
         let _ = fs::remove_file(&path);
 
-        let session = session.expect("session header should parse");
+        let session = session
+            .expect("session file should be readable")
+            .expect("session header should parse");
         assert_eq!(session.session_id, "session-with-summary");
         assert_eq!(session.summaries, vec!["发布pip版本", "再发一个版本"]);
     }
@@ -240,7 +224,9 @@ mod tests {
         let session = parse_session(&path, Agent::Pi);
         let _ = fs::remove_file(&path);
 
-        let session = session.expect("header on line 1 should parse within the budget");
+        let session = session
+            .expect("session file should be readable")
+            .expect("header on line 1 should parse within the budget");
         assert_eq!(session.session_id, "big");
         // The 512 KiB budget stops collection before all 400 prompts are read.
         assert!(
@@ -282,7 +268,9 @@ mod tests {
         let session = parse_session(&path, Agent::Pi);
         let _ = fs::remove_file(&path);
 
-        let session = session.expect("session should surface despite invalid UTF-8 on line 1");
+        let session = session
+            .expect("session file should be readable")
+            .expect("session should surface despite invalid UTF-8 on line 1");
         assert_eq!(session.session_id, "recovered");
         assert_eq!(session.summaries, vec!["after garbage"]);
     }

--- a/src/scanner/prime_agent.rs
+++ b/src/scanner/prime_agent.rs
@@ -1,0 +1,372 @@
+use std::path::Path;
+
+use serde_json::Value;
+
+use crate::error::AgfError;
+use crate::model::{Agent, Session};
+use crate::scanner::{
+    collapse_whitespace, for_each_bounded_line_with_overflow, project_name_from_path, truncate,
+};
+
+const MAX_LINE_BYTES: usize = 2 * 1024 * 1024;
+
+pub fn scan() -> Result<Vec<Session>, AgfError> {
+    scan_from(&crate::config::prime_sessions_dir()?)
+}
+
+fn scan_from(dir: &Path) -> Result<Vec<Session>, AgfError> {
+    if !dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut sessions = Vec::new();
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if !entry.file_type()?.is_file()
+            || path.extension().and_then(|ext| ext.to_str()) != Some("jsonl")
+        {
+            continue;
+        }
+        if let Some(session) = parse_session(&path)? {
+            sessions.push(session);
+        }
+    }
+    sessions.sort_by(|a, b| crate::model::compare_sessions(a, b, crate::model::SortMode::Time));
+    Ok(sessions)
+}
+
+fn parse_session(path: &Path) -> Result<Option<Session>, AgfError> {
+    let metadata = path.metadata()?;
+    let mtime = metadata
+        .modified()
+        .ok()
+        .and_then(|time| time.duration_since(std::time::SystemTime::UNIX_EPOCH).ok())
+        .map(|duration| i64::try_from(duration.as_millis()).unwrap_or(i64::MAX))
+        .unwrap_or(0);
+    let mut session_id = None;
+    let mut cwd = None;
+    let mut header_timestamp = 0;
+    let mut last_activity = 0;
+    let mut summaries = Vec::new();
+    let mut name = None;
+    let mut git_branch = None;
+    let mut message_count = 0u64;
+    let mut status = None;
+    let mut first_valid_seen = false;
+    let mut invalid_header = false;
+
+    // Prime's durable activity/name/status can be appended arbitrarily late in
+    // a long transcript. Stream to EOF while retaining the per-line allocation
+    // ceiling; a total-byte cap would silently sort active long sessions as old.
+    let read_ok = for_each_bounded_line_with_overflow(
+        path,
+        usize::MAX,
+        MAX_LINE_BYTES,
+        |line, _, oversized| {
+            if invalid_header {
+                return;
+            }
+            if oversized {
+                let entry_type = json_string_from_prefix(line, "type");
+                if !first_valid_seen {
+                    first_valid_seen = true;
+                    if entry_type.as_deref() != Some("session") {
+                        invalid_header = true;
+                        return;
+                    }
+                }
+                if entry_type.as_deref() == Some("message") {
+                    message_count = message_count.saturating_add(1);
+                    let role = json_string_from_prefix(line, "role");
+                    if matches!(role.as_deref(), Some("user" | "assistant"))
+                        && let Some(timestamp) = json_string_from_prefix(line, "timestamp")
+                            .and_then(|timestamp| {
+                                chrono::DateTime::parse_from_rfc3339(&timestamp).ok()
+                            })
+                            .map(|timestamp| timestamp.timestamp_millis())
+                    {
+                        last_activity = last_activity.max(timestamp);
+                    }
+                    if role.as_deref() == Some("user") && summaries.len() < 10 {
+                        let preview = json_string_from_prefix(line, "text")
+                            .or_else(|| json_string_from_prefix(line, "content"));
+                        let preview = preview
+                            .map(|preview| truncate(&collapse_whitespace(&preview), 200))
+                            .filter(|preview| !preview.is_empty())
+                            .unwrap_or_else(|| "(large message)".to_string());
+                        summaries.push(preview);
+                    }
+                }
+                return;
+            }
+            let Ok(value) = serde_json::from_slice::<Value>(line) else {
+                return;
+            };
+            let entry_type = value.get("type").and_then(Value::as_str);
+            let is_first = !first_valid_seen;
+            if is_first {
+                first_valid_seen = true;
+                if entry_type != Some("session") {
+                    invalid_header = true;
+                    return;
+                }
+            }
+            match entry_type {
+                Some("session") if is_first => {
+                    let id = value.get("id").and_then(Value::as_str).map(str::trim);
+                    let project = value.get("cwd").and_then(Value::as_str).map(str::trim);
+                    if let (Some(id), Some(project)) = (id, project)
+                        && !id.is_empty()
+                        && !project.is_empty()
+                    {
+                        session_id = Some(id.to_string());
+                        cwd = Some(project.to_string());
+                        header_timestamp = iso_timestamp(&value);
+                        git_branch = value
+                            .pointer("/git/branch")
+                            .and_then(Value::as_str)
+                            .map(str::to_string);
+                    }
+                }
+                Some("message") => {
+                    message_count = message_count.saturating_add(1);
+                    let Some(message) = value.get("message") else {
+                        return;
+                    };
+                    let role = message.get("role").and_then(Value::as_str);
+                    if matches!(role, Some("user" | "assistant")) {
+                        let message_time = message
+                            .get("timestamp")
+                            .and_then(Value::as_i64)
+                            .unwrap_or_else(|| iso_timestamp(&value));
+                        last_activity = last_activity.max(message_time);
+                    }
+                    if role == Some("user")
+                        && summaries.len() < 10
+                        && let Some(text) = content_text(message.get("content"))
+                    {
+                        summaries.push(truncate(&collapse_whitespace(&text), 200));
+                    }
+                }
+                Some("session_info") => {
+                    name = value
+                        .get("name")
+                        .and_then(Value::as_str)
+                        .map(str::trim)
+                        .filter(|name| !name.is_empty())
+                        .map(str::to_string);
+                }
+                Some("git_state") => {
+                    if let Some(branch) = value.pointer("/git/branch").and_then(Value::as_str) {
+                        git_branch = Some(branch.to_string());
+                    }
+                }
+                Some("agent_status") => {
+                    let basis = value
+                        .pointer("/status/basedOnMessageCount")
+                        .and_then(Value::as_u64);
+                    let summary = value
+                        .pointer("/status/summary")
+                        .and_then(Value::as_str)
+                        .map(str::trim)
+                        .filter(|summary| !summary.is_empty())
+                        .map(str::to_string);
+                    if let (Some(basis), Some(summary)) = (basis, summary) {
+                        status = Some((basis, summary));
+                    }
+                }
+                _ => {}
+            }
+        },
+    );
+    if !read_ok {
+        return Err(std::io::Error::other(format!(
+            "failed to read Prime Agent session {}",
+            path.display()
+        ))
+        .into());
+    }
+
+    let (Some(session_id), Some(project_path)) = (session_id, cwd) else {
+        return Ok(None);
+    };
+    if let Some(name) = name {
+        summaries.insert(0, name);
+    }
+    let recap = status
+        .filter(|(basis, _)| *basis == message_count)
+        .map(|(_, summary)| format!("recap: {summary}"));
+
+    Ok(Some(Session {
+        agent: Agent::PrimeAgent,
+        session_id,
+        project_name: project_name_from_path(&project_path),
+        project_path,
+        summaries,
+        timestamp: if last_activity != 0 {
+            last_activity
+        } else if header_timestamp != 0 {
+            header_timestamp
+        } else {
+            mtime
+        },
+        git_branch,
+        worktree: None,
+        recap,
+        interactive: true,
+    }))
+}
+
+fn json_string_from_prefix(prefix: &[u8], field: &str) -> Option<String> {
+    let text = std::str::from_utf8(prefix).ok()?;
+    let key = format!("\"{field}\"");
+    let mut search_from = 0usize;
+    while let Some(relative) = text.get(search_from..)?.find(&key) {
+        let after_key = search_from + relative + key.len();
+        let mut rest = text.get(after_key..)?.trim_start();
+        if !rest.starts_with(':') {
+            search_from = after_key;
+            continue;
+        }
+        rest = rest.get(1..)?.trim_start();
+        let encoded = rest.strip_prefix('"')?;
+        let mut escaped = false;
+        for (index, ch) in encoded.char_indices() {
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == '"' {
+                return serde_json::from_str::<String>(&rest[..=index + 1]).ok();
+            }
+        }
+        return None;
+    }
+    None
+}
+
+fn iso_timestamp(value: &Value) -> i64 {
+    value
+        .get("timestamp")
+        .and_then(Value::as_str)
+        .and_then(|timestamp| chrono::DateTime::parse_from_rfc3339(timestamp).ok())
+        .map(|timestamp| timestamp.timestamp_millis())
+        .unwrap_or(0)
+}
+
+fn content_text(content: Option<&Value>) -> Option<String> {
+    match content? {
+        Value::String(text) => Some(text.clone()),
+        Value::Array(blocks) => {
+            let mut output = String::new();
+            for text in blocks.iter().filter_map(|block| {
+                (block.get("type").and_then(Value::as_str) == Some("text"))
+                    .then(|| block.get("text").and_then(Value::as_str))
+                    .flatten()
+            }) {
+                if !output.is_empty() {
+                    output.push(' ');
+                }
+                output.push_str(text);
+            }
+            (!output.is_empty()).then_some(output)
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::File;
+    use std::io::Write;
+
+    fn fixture(name: &str, lines: &[&str]) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!("agf-prime-{name}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("different-file-stem.jsonl");
+        let mut file = File::create(&path).unwrap();
+        for line in lines {
+            writeln!(file, "{line}").unwrap();
+        }
+        path
+    }
+
+    #[test]
+    fn parses_v3_activity_name_git_and_current_recap() {
+        let path = fixture(
+            "v3",
+            &[
+                r#"{"type":"session","version":3,"id":"prime-id","timestamp":"2026-08-01T00:00:00Z","cwd":"/tmp/project","git":{"branch":"old"}}"#,
+                r#"{"type":"message","id":"a","parentId":null,"timestamp":"2026-08-01T00:00:01Z","message":{"role":"user","content":"first prompt","timestamp":1785542401000}}"#,
+                r#"{"type":"message","id":"b","parentId":"a","timestamp":"2026-08-01T00:00:02Z","message":{"role":"assistant","content":[{"type":"text","text":"ok"}],"timestamp":1785542402000}}"#,
+                r#"{"type":"session_info","id":"c","parentId":"b","timestamp":"2026-08-01T00:00:03Z","name":"Named session"}"#,
+                r#"{"type":"git_state","id":"d","parentId":"c","timestamp":"2026-08-01T00:00:04Z","git":{"branch":"feature"}}"#,
+                r#"{"type":"agent_status","id":"e","parentId":"d","timestamp":"2026-08-01T00:00:05Z","status":{"summary":"finished","basedOnMessageCount":2}}"#,
+            ],
+        );
+
+        let session = parse_session(&path).unwrap().unwrap();
+        assert_eq!(session.session_id, "prime-id");
+        assert_eq!(session.summaries, ["Named session", "first prompt"]);
+        assert_eq!(session.git_branch.as_deref(), Some("feature"));
+        assert_eq!(session.recap.as_deref(), Some("recap: finished"));
+        assert_eq!(session.timestamp, 1_785_542_402_000);
+    }
+
+    #[test]
+    fn bookkeeping_does_not_bump_activity_and_stale_recap_is_hidden() {
+        let path = fixture(
+            "activity",
+            &[
+                r#"{"type":"session","version":3,"id":"prime-id","timestamp":"2026-08-01T00:00:00Z","cwd":"/tmp/project"}"#,
+                r#"{"type":"message","id":"a","parentId":null,"timestamp":"2026-08-01T00:00:01Z","message":{"role":"user","content":"prompt","timestamp":1785542401000}}"#,
+                r#"{"type":"git_state","id":"b","parentId":"a","timestamp":"2026-08-15T00:00:00Z","git":{"branch":"main"}}"#,
+                r#"{"type":"agent_status","id":"c","parentId":"b","timestamp":"2026-08-15T00:00:01Z","status":{"summary":"stale","basedOnMessageCount":0}}"#,
+            ],
+        );
+
+        let session = parse_session(&path).unwrap().unwrap();
+        assert_eq!(session.timestamp, 1_785_542_401_000);
+        assert_eq!(session.recap, None);
+    }
+
+    #[test]
+    fn oversized_message_preserves_count_role_and_activity_from_prefix() {
+        let huge = "x".repeat(MAX_LINE_BYTES + 1024);
+        let message = format!(
+            r#"{{"type":"message","timestamp":"2026-08-01T00:00:05Z","message":{{"role":"user","content":"{huge}"}}}}"#
+        );
+        let path = fixture(
+            "oversized",
+            &[
+                r#"{"type":"session","version":3,"id":"prime-big","timestamp":"2026-08-01T00:00:00Z","cwd":"/tmp/project"}"#,
+                &message,
+                r#"{"type":"agent_status","status":{"basedOnMessageCount":1,"summary":"current"}}"#,
+            ],
+        );
+
+        let session = parse_session(&path).unwrap().unwrap();
+        assert_eq!(session.timestamp, 1_785_542_405_000);
+        assert_eq!(session.recap.as_deref(), Some("recap: current"));
+        assert_eq!(session.summaries, ["(large message)"]);
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    #[test]
+    fn rejects_a_late_header_after_a_valid_non_session_record() {
+        let path = fixture(
+            "late-header",
+            &[
+                "not json",
+                r#"{"type":"message","timestamp":"2026-08-01T00:00:01Z","message":{"role":"user","content":"prompt"}}"#,
+                r#"{"type":"session","version":3,"id":"prime-late","timestamp":"2026-08-01T00:00:00Z","cwd":"/tmp/project"}"#,
+            ],
+        );
+
+        assert!(parse_session(&path).unwrap().is_none());
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
+}

--- a/src/scanner/yolop.rs
+++ b/src/scanner/yolop.rs
@@ -11,16 +11,6 @@ const SUMMARY_MAX_CHARS: usize = 120;
 const EVENT_HEAD_BYTES: u64 = 512 * 1024;
 const EVENT_TAIL_BYTES: u64 = 64 * 1024;
 
-/// How far ahead of "now" a session timestamp may claim to be before we stop
-/// believing it.
-///
-/// Every candidate is self-reported (`updated_at`, event `ts`) or comes from a
-/// filesystem whose clock we don't control, so a corrupt file or a skewed clock
-/// can name an arbitrary future instant — which would pin that session to the
-/// top of the time sort permanently. One day absorbs ordinary timezone/NTP
-/// skew while still rejecting the "year 2087" case.
-const MAX_FUTURE_SKEW_MS: i64 = 24 * 60 * 60 * 1000;
-
 pub fn scan() -> Result<Vec<Session>, AgfError> {
     scan_from(&crate::config::yolop_sessions_dir()?)
 }
@@ -31,7 +21,8 @@ fn scan_from(sessions_dir: &Path) -> Result<Vec<Session>, AgfError> {
     }
 
     let mut sessions = Vec::new();
-    for entry in std::fs::read_dir(sessions_dir)?.flatten() {
+    for entry in std::fs::read_dir(sessions_dir)? {
+        let entry = entry?;
         let dir = entry.path();
         if !dir.is_dir() {
             continue;
@@ -42,7 +33,7 @@ fn scan_from(sessions_dir: &Path) -> Result<Vec<Session>, AgfError> {
         if !valid_session_id(&session_id) {
             continue;
         }
-        if let Some(session) = parse_session(&dir, session_id) {
+        if let Some(session) = parse_session(&dir, session_id)? {
             sessions.push(session);
         }
     }
@@ -61,18 +52,20 @@ pub(crate) fn valid_session_id(id: &str) -> bool {
         .is_some_and(|suffix| suffix.len() == 32 && suffix.bytes().all(|b| b.is_ascii_hexdigit()))
 }
 
-fn parse_session(dir: &Path, session_id: String) -> Option<Session> {
+fn parse_session(dir: &Path, session_id: String) -> Result<Option<Session>, AgfError> {
     let log_path = dir.join("events.jsonl");
     if !log_path.is_file() {
-        return None;
+        return Ok(None);
     }
-    let workspace: Value =
-        serde_json::from_slice(&std::fs::read(dir.join("workspace.json")).ok()?).ok()?;
+    let workspace: Value = serde_json::from_slice(&std::fs::read(dir.join("workspace.json"))?)?;
     let project_path = workspace
         .get("active_root")
         .and_then(Value::as_str)
-        .or_else(|| workspace.get("workspace_root").and_then(Value::as_str))?
-        .to_string();
+        .or_else(|| workspace.get("workspace_root").and_then(Value::as_str));
+    let Some(project_path) = project_path else {
+        return Ok(None);
+    };
+    let project_path = project_path.to_string();
     let mut project_name = workspace
         .get("canonical_repo_root")
         .and_then(Value::as_str)
@@ -156,16 +149,20 @@ fn parse_session(dir: &Path, session_id: String) -> Option<Session> {
 
     // Explicit metadata is useful for idle sessions, while the log mtime and
     // event timestamps keep active sessions fresh between metadata writes.
-    let timestamp = newest_plausible(
-        [
-            metadata_timestamp,
-            modified_ms(&log_path),
-            latest_ts.unwrap_or(0),
-        ],
-        chrono::Utc::now().timestamp_millis(),
-    );
+    // Preserve the raw durable maximum until the common scan boundary. That
+    // layer both clamps implausible future values and prevents their fallback
+    // from being cached as fresh, allowing a small clock skew to become valid
+    // later even when the source file itself does not change.
+    let timestamp = [
+        metadata_timestamp,
+        modified_ms(&log_path),
+        latest_ts.unwrap_or(0),
+    ]
+    .into_iter()
+    .max()
+    .unwrap_or(0);
 
-    Some(Session {
+    Ok(Some(Session {
         agent: Agent::Yolop,
         session_id,
         project_name,
@@ -175,20 +172,8 @@ fn parse_session(dir: &Path, session_id: String) -> Option<Session> {
         git_branch,
         worktree,
         recap: None,
-    })
-}
-
-/// Newest candidate that isn't implausibly far in the future (see
-/// [`MAX_FUTURE_SKEW_MS`]). Falls back to `now` when every candidate is
-/// rejected, so such a session sorts as "just used" and then ages normally
-/// instead of staying pinned above everything forever.
-fn newest_plausible(candidates: [i64; 3], now: i64) -> i64 {
-    let ceiling = now.saturating_add(MAX_FUTURE_SKEW_MS);
-    candidates
-        .into_iter()
-        .filter(|&ts| ts <= ceiling)
-        .max()
-        .unwrap_or(now)
+        interactive: true,
+    }))
 }
 
 fn parse_timestamp(timestamp: &str) -> Option<i64> {
@@ -324,7 +309,9 @@ mod tests {
         let root = temp_root("parse");
         let dir = write_session(&root);
 
-        let session = parse_session(&dir, SESSION_ID.to_string()).unwrap();
+        let session = parse_session(&dir, SESSION_ID.to_string())
+            .unwrap()
+            .unwrap();
 
         assert_eq!(session.agent, Agent::Yolop);
         assert_eq!(session.project_name, "example");
@@ -382,7 +369,9 @@ mod tests {
         .unwrap();
         backdate(&dir.join("events.jsonl"), 1_700_000_000);
 
-        let session = parse_session(&dir, SESSION_ID.to_string()).unwrap();
+        let session = parse_session(&dir, SESSION_ID.to_string())
+            .unwrap()
+            .unwrap();
 
         assert_eq!(session.project_name, "yolop");
         assert_eq!(
@@ -409,7 +398,7 @@ mod tests {
     /// Regression: an `updated_at` far in the future used to win the `max()`
     /// outright and pin the session above every real session forever.
     #[test]
-    fn implausible_future_metadata_does_not_pin_the_session_to_the_top() {
+    fn implausible_future_metadata_is_preserved_for_common_normalization() {
         let root = temp_root("future-metadata");
         let dir = root.join(SESSION_ID);
         fs::create_dir_all(&dir).unwrap();
@@ -421,24 +410,14 @@ mod tests {
         fs::write(dir.join("events.jsonl"), b"").unwrap();
         backdate(&dir.join("events.jsonl"), 1_700_000_000);
 
-        let session = parse_session(&dir, SESSION_ID.to_string()).unwrap();
+        let session = parse_session(&dir, SESSION_ID.to_string())
+            .unwrap()
+            .unwrap();
 
-        // The bogus value is discarded; the real log mtime is used instead.
-        assert_eq!(session.timestamp, 1_700_000_000_000);
+        // The scanner boundary owns plausibility and cacheability. Keeping the
+        // raw value here lets it detect that normalization occurred.
+        assert_eq!(session.timestamp, rfc3339_ms("2087-01-01T00:00:00Z"));
         fs::remove_dir_all(root).unwrap();
-    }
-
-    #[test]
-    fn newest_plausible_falls_back_to_now_when_every_candidate_is_bogus() {
-        let now = 1_800_000_000_000;
-        let future = now + MAX_FUTURE_SKEW_MS * 10;
-        assert_eq!(newest_plausible([future, future, future], now), now);
-        // Inside the skew window the value is still trusted.
-        assert_eq!(
-            newest_plausible([now + 1000, 0, 0], now),
-            now + 1000,
-            "small skew must not be discarded"
-        );
     }
 
     /// An unreadable event log must degrade the entry, not remove it: the
@@ -462,7 +441,9 @@ mod tests {
         )
         .unwrap();
 
-        let session = parse_session(&dir, SESSION_ID.to_string()).unwrap();
+        let session = parse_session(&dir, SESSION_ID.to_string())
+            .unwrap()
+            .unwrap();
 
         assert_eq!(session.project_name, "example");
         assert_eq!(session.summaries, ["Still here"]);
@@ -491,7 +472,9 @@ mod tests {
         )
         .unwrap();
 
-        let session = parse_session(&dir, SESSION_ID.to_string()).unwrap();
+        let session = parse_session(&dir, SESSION_ID.to_string())
+            .unwrap()
+            .unwrap();
 
         assert_eq!(
             session.summaries,
@@ -552,7 +535,9 @@ mod tests {
         )
         .unwrap();
 
-        let session = parse_session(&dir, SESSION_ID.to_string()).unwrap();
+        let session = parse_session(&dir, SESSION_ID.to_string())
+            .unwrap()
+            .unwrap();
 
         assert_eq!(session.summaries, ["valid prompt"]);
         fs::remove_dir_all(root).unwrap();

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -18,6 +18,8 @@ pub struct Settings {
     pub pinned_sessions: Vec<String>, // session IDs pinned to top of list
     #[serde(default)]
     pub show_recap: bool, // show Claude Code recap (away_summary) instead of last prompt
+    #[serde(default)]
+    pub include_non_interactive: bool, // include Codex subagents/exec sessions
 }
 
 fn default_summary_search_count() -> usize {
@@ -38,6 +40,7 @@ impl Default for Settings {
             editor: None,
             pinned_sessions: Vec::new(),
             show_recap: false,
+            include_non_interactive: false,
         }
     }
 }

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -105,9 +105,12 @@ impl CommandShell {
     /// Used by the delivery path to warn when shell integration is missing
     /// (a bare `cd` printed to stdout doesn't persist in the parent shell).
     pub fn is_cd_only(&self, cmd: &str) -> bool {
+        let command = cmd.trim_start();
         match self {
-            Self::Posix => !cmd.contains(" && "),
-            Self::PowerShell => !cmd.contains("; if ($?) {"),
+            Self::Posix => command.starts_with("cd ") && !command.contains(" && "),
+            Self::PowerShell => {
+                command.starts_with("Set-Location ") && !command.contains("; if ($?) {")
+            }
         }
     }
 
@@ -127,24 +130,32 @@ impl CommandShell {
 }
 
 /// Detect user's shell and append the init line to the appropriate rc file.
-pub fn setup() -> anyhow::Result<()> {
+pub fn setup(shell_override: Option<&str>) -> anyhow::Result<()> {
     let shell_path = std::env::var("SHELL").unwrap_or_default();
-    let shell_name = shell_path.rsplit('/').next().unwrap_or("");
+    let detected = shell_path.rsplit('/').next().unwrap_or("");
+    let shell_name = shell_override.unwrap_or(detected).to_ascii_lowercase();
 
-    let (rc_file, init_line) = match shell_name {
+    let (rc_file, init_line, reload) = match shell_name.as_str() {
         "zsh" => (
             dirs::home_dir().unwrap_or_default().join(".zshrc"),
             r#"eval "$(agf init zsh)""#.to_string(),
+            "source".to_string(),
         ),
         "bash" => {
             let home = dirs::home_dir().unwrap_or_default();
-            // Prefer .bashrc, fall back to .bash_profile on macOS
-            let rc = if home.join(".bashrc").exists() {
-                home.join(".bashrc")
-            } else {
+            // Login Bash reads .bash_profile on macOS. Linux interactive Bash
+            // reads .bashrc; create it instead of overwriting an unrelated
+            // .profile.
+            let rc = if cfg!(target_os = "macos") {
                 home.join(".bash_profile")
+            } else {
+                home.join(".bashrc")
             };
-            (rc, r#"eval "$(agf init bash)""#.to_string())
+            (
+                rc,
+                r#"eval "$(agf init bash)""#.to_string(),
+                "source".to_string(),
+            )
         }
         "fish" => (
             dirs::config_dir()
@@ -152,11 +163,23 @@ pub fn setup() -> anyhow::Result<()> {
                 .join("fish")
                 .join("config.fish"),
             "agf init fish | source".to_string(),
+            "source".to_string(),
+        ),
+        "powershell" => (
+            powershell_profile_path(Some("powershell")),
+            "agf init powershell | Out-String | Invoke-Expression".to_string(),
+            ".".to_string(),
+        ),
+        "pwsh" => (
+            powershell_profile_path(Some("pwsh")),
+            "agf init powershell | Out-String | Invoke-Expression".to_string(),
+            ".".to_string(),
         ),
         // No POSIX SHELL and we're on Windows — default to PowerShell.
         _ if shell_name.is_empty() && cfg!(windows) => (
-            powershell_profile_path(),
+            powershell_profile_path(None),
             "agf init powershell | Out-String | Invoke-Expression".to_string(),
+            ".".to_string(),
         ),
         _ => {
             eprintln!("Unsupported shell: {shell_name}");
@@ -174,7 +197,10 @@ pub fn setup() -> anyhow::Result<()> {
         let content = fs::read_to_string(&rc_file)?;
         if content.contains("# agf - AI Agent Session Finder") {
             eprintln!("Already configured in {}", rc_file.display());
-            eprintln!("Restart your shell or run: source {}", rc_file.display());
+            eprintln!(
+                "Restart your shell or run: {reload} '{}'",
+                rc_file.display()
+            );
             return Ok(());
         }
     }
@@ -200,7 +226,10 @@ pub fn setup() -> anyhow::Result<()> {
     crate::fsx::write_atomic(&rc_file, content.as_bytes())?;
 
     eprintln!("Added to {}", rc_file.display());
-    eprintln!("Restart your shell or run: source {}", rc_file.display());
+    eprintln!(
+        "Restart your shell or run: {reload} '{}'",
+        rc_file.display()
+    );
     Ok(())
 }
 
@@ -212,17 +241,19 @@ pub fn setup() -> anyhow::Result<()> {
 /// to the PS 7 path (modern default, created on demand).
 ///
 /// On non-Windows, PowerShell 7 uses `~/.config/powershell/profile.ps1`.
-fn powershell_profile_path() -> PathBuf {
+fn powershell_profile_path(preferred_shell: Option<&str>) -> PathBuf {
     if cfg!(windows) {
         let docs = dirs::document_dir()
             .unwrap_or_else(|| dirs::home_dir().unwrap_or_default().join("Documents"));
         let ps5 = docs.join("WindowsPowerShell");
         // Prefer PS 7 (`PowerShell`); fall back to PS 5.1 only when its dir
         // exists and PS 7's does not. Created on demand by setup().
-        let dir = if ps5.exists() && !docs.join("PowerShell").exists() {
-            ps5
-        } else {
-            docs.join("PowerShell")
+        let ps7 = docs.join("PowerShell");
+        let dir = match preferred_shell {
+            Some("powershell") => ps5,
+            Some("pwsh") => ps7,
+            _ if ps5.exists() && !ps7.exists() => ps5,
+            _ => ps7,
         };
         dir.join("profile.ps1")
     } else {
@@ -239,9 +270,7 @@ pub fn shell_init(shell: &str) -> String {
         "bash" => BASH_WRAPPER.to_string(),
         "fish" => FISH_WRAPPER.to_string(),
         "powershell" | "pwsh" => POWERSHELL_WRAPPER.to_string(),
-        other => {
-            format!("echo \"Unsupported shell: {other}. Use zsh, bash, fish, or powershell.\"")
-        }
+        _ => "echo 'Unsupported shell. Use zsh, bash, fish, or powershell.'".to_string(),
     }
 }
 
@@ -255,9 +284,11 @@ const ZSH_WRAPPER: &str = r#"function agf() {
         result="$(cat "$tmpfile")"
         if [ -n "$result" ]; then
             eval "$result"
+            ret=$?
         fi
     fi
     rm -f "$tmpfile"
+    return $ret
 }"#;
 
 const BASH_WRAPPER: &str = r#"function agf() {
@@ -270,9 +301,11 @@ const BASH_WRAPPER: &str = r#"function agf() {
         result="$(cat "$tmpfile")"
         if [ -n "$result" ]; then
             eval "$result"
+            ret=$?
         fi
     fi
     rm -f "$tmpfile"
+    return $ret
 }"#;
 
 const FISH_WRAPPER: &str = r#"function agf
@@ -283,9 +316,11 @@ const FISH_WRAPPER: &str = r#"function agf
         set -l result (cat $tmpfile)
         if test -n "$result"
             eval $result
+            set ret $status
         end
     end
     rm -f $tmpfile
+    return $ret
 end"#;
 
 // PowerShell wrapper. Compatible with Windows PowerShell 5.1 and PowerShell 7+.
@@ -309,6 +344,10 @@ const POWERSHELL_WRAPPER: &str = r#"function agf {
         return
     }
     $__agfTmp = [System.IO.Path]::GetTempFileName()
+    $__agfHadCmdFile = Test-Path Env:AGF_CMD_FILE
+    $__agfOldCmdFile = $env:AGF_CMD_FILE
+    $__agfHadShell = Test-Path Env:AGF_SHELL
+    $__agfOldShell = $env:AGF_SHELL
     try {
         $env:AGF_CMD_FILE = $__agfTmp
         $env:AGF_SHELL = 'powershell'
@@ -318,13 +357,26 @@ const POWERSHELL_WRAPPER: &str = r#"function agf {
             $__agfResult = Get-Content -Raw -LiteralPath $__agfTmp -Encoding UTF8
             if ($__agfResult) {
                 Invoke-Expression $__agfResult
+                $__agfInvokeOk = $?
+                $__agfNativeExit = $LASTEXITCODE
+                if ($__agfInvokeOk -or $__agfNativeExit -ne 0) {
+                    $__agfExit = $__agfNativeExit
+                } else {
+                    $__agfExit = 1
+                }
             }
         }
     }
     finally {
         Remove-Item -Force -LiteralPath $__agfTmp -ErrorAction SilentlyContinue
-        Remove-Item -Path Env:AGF_CMD_FILE -ErrorAction SilentlyContinue
-        Remove-Item -Path Env:AGF_SHELL -ErrorAction SilentlyContinue
+        if ($__agfHadCmdFile) { $env:AGF_CMD_FILE = $__agfOldCmdFile }
+        else { Remove-Item -Path Env:AGF_CMD_FILE -ErrorAction SilentlyContinue }
+        if ($__agfHadShell) { $env:AGF_SHELL = $__agfOldShell }
+        else { Remove-Item -Path Env:AGF_SHELL -ErrorAction SilentlyContinue }
+    }
+    $global:LASTEXITCODE = $__agfExit
+    if ($__agfExit -ne 0) {
+        Write-Error "agf command failed with exit code $__agfExit"
     }
 }"#;
 
@@ -361,10 +413,12 @@ mod tests {
         let posix = CommandShell::Posix;
         assert!(posix.is_cd_only("cd '/tmp'"));
         assert!(!posix.is_cd_only("cd '/tmp' && claude"));
+        assert!(!posix.is_cd_only("hermes --resume 'session-id'"));
 
         let pwsh = CommandShell::PowerShell;
         assert!(pwsh.is_cd_only("Set-Location '/tmp'"));
         assert!(!pwsh.is_cd_only("Set-Location '/tmp'; if ($?) { claude }"));
+        assert!(!pwsh.is_cd_only("hermes --resume 'session-id'"));
     }
 
     #[test]

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::io::{self, IsTerminal, Write};
+use std::io::{self, Write};
 
 use crate::model::{Agent, Session};
 use crate::text;
@@ -19,7 +19,7 @@ struct Ansi {
 impl Ansi {
     fn new() -> Self {
         Self {
-            enabled: io::stdout().is_terminal(),
+            enabled: text::color_enabled(),
         }
     }
     fn rgb(&self, r: u8, g: u8, b: u8, text: &str) -> String {
@@ -117,7 +117,7 @@ fn print_text(sessions: &[Session]) {
     let mut by_project: HashMap<String, (usize, Option<Agent>)> = HashMap::new();
     for s in sessions {
         let entry = by_project
-            .entry(s.project_name.clone())
+            .entry(text::sanitize_terminal(&s.project_name))
             .or_insert((0, None));
         entry.0 += 1;
         // Keep first-seen agent (project color)
@@ -160,42 +160,29 @@ fn print_text(sessions: &[Session]) {
 
     // Activity timeline
     let now = chrono::Utc::now().timestamp_millis();
-    let day_ms: i64 = 86_400_000;
-    let week_ms: i64 = 7 * day_ms;
-    let month_ms: i64 = 30 * day_ms;
-
-    let mut today = 0usize;
-    let mut this_week = 0usize;
-    let mut this_month = 0usize;
-    let mut older = 0usize;
-
-    for s in sessions {
-        let age = now - s.timestamp;
-        if age < day_ms {
-            today += 1;
-        } else if age < week_ms {
-            this_week += 1;
-        } else if age < month_ms {
-            this_month += 1;
-        } else {
-            older += 1;
-        }
-    }
+    let activity = activity_counts(sessions, now);
 
     let _ = writeln!(out);
     let _ = writeln!(out, "  {}", a.bold("Activity"));
     let _ = writeln!(out);
 
-    let max_time = [today, this_week, this_month, older]
-        .into_iter()
-        .max()
-        .unwrap_or(1);
+    let max_time = [
+        activity.today,
+        activity.week,
+        activity.month,
+        activity.older,
+        activity.future,
+    ]
+    .into_iter()
+    .max()
+    .unwrap_or(1);
 
     let time_items = [
-        ("Last 24h", today, (52, 211, 153)),      // green
-        ("Last 7d", this_week, (139, 92, 246)),   // violet
-        ("Last 30d", this_month, (59, 130, 246)), // blue
-        ("Older", older, (107, 114, 128)),        // gray
+        ("Last 24h", activity.today, (52, 211, 153)),
+        ("Last 7d", activity.week, (139, 92, 246)),
+        ("Last 30d", activity.month, (59, 130, 246)),
+        ("Older", activity.older, (107, 114, 128)),
+        ("Future/invalid", activity.future, (239, 68, 68)),
     ];
     for (label, count, (r, g, b)) in &time_items {
         let filled = (count * bar_width).checked_div(max_time).unwrap_or(0);
@@ -224,40 +211,94 @@ fn print_json(sessions: &[Session]) {
     }
 
     let now = chrono::Utc::now().timestamp_millis();
-    let day_ms: i64 = 86_400_000;
-    let week_ms: i64 = 7 * day_ms;
-    let month_ms: i64 = 30 * day_ms;
-
-    let mut today = 0usize;
-    let mut this_week = 0usize;
-    let mut this_month = 0usize;
-    let mut older = 0usize;
-
-    for s in sessions {
-        let age = now - s.timestamp;
-        if age < day_ms {
-            today += 1;
-        } else if age < week_ms {
-            this_week += 1;
-        } else if age < month_ms {
-            this_month += 1;
-        } else {
-            older += 1;
-        }
-    }
+    let activity = activity_counts(sessions, now);
 
     let json = serde_json::json!({
         "total": sessions.len(),
         "by_agent": by_agent,
         "by_project": by_project,
         "activity": {
-            "today": today,
-            "this_week": this_week,
-            "this_month": this_month,
-            "older": older,
+            "today": activity.today,
+            "this_week": activity.week,
+            "this_month": activity.month,
+            "older": activity.older,
+            "future_or_invalid": activity.future,
         }
     });
     if let Ok(s) = serde_json::to_string_pretty(&json) {
-        println!("{s}");
+        let mut out = io::stdout().lock();
+        let _ = writeln!(out, "{s}");
+    }
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct ActivityCounts {
+    today: usize,
+    week: usize,
+    month: usize,
+    older: usize,
+    future: usize,
+}
+
+fn activity_counts(sessions: &[Session], now: i64) -> ActivityCounts {
+    const DAY: i64 = 86_400_000;
+    const MIN_VALID: i64 = 946_684_800_000;
+    let mut counts = ActivityCounts::default();
+    for session in sessions {
+        if session.timestamp < MIN_VALID || session.timestamp > now.saturating_add(5 * 60_000) {
+            counts.future += 1;
+            continue;
+        }
+        let age = now.saturating_sub(session.timestamp);
+        if age <= DAY {
+            counts.today += 1;
+        }
+        if age <= 7 * DAY {
+            counts.week += 1;
+        }
+        if age <= 30 * DAY {
+            counts.month += 1;
+        } else {
+            counts.older += 1;
+        }
+    }
+    counts
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn activity_windows_are_cumulative_and_future_is_separate() {
+        let now = 1_800_000_000_000i64;
+        let make = |timestamp: i64| Session {
+            agent: Agent::Codex,
+            session_id: timestamp.to_string(),
+            project_name: "project".into(),
+            project_path: "/tmp/project".into(),
+            summaries: Vec::new(),
+            timestamp,
+            git_branch: None,
+            worktree: None,
+            recap: None,
+            interactive: true,
+        };
+        let sessions = [
+            make(now),
+            make(now - 2 * 86_400_000),
+            make(now - 10 * 86_400_000),
+            make(now + 10 * 60_000),
+        ];
+        assert_eq!(
+            activity_counts(&sessions, now),
+            ActivityCounts {
+                today: 1,
+                week: 2,
+                month: 3,
+                older: 0,
+                future: 1
+            }
+        );
     }
 }

--- a/src/text.rs
+++ b/src/text.rs
@@ -6,7 +6,67 @@
 //! every column to the right of a CJK cell, so all column work goes through
 //! these helpers instead of `format!` padding.
 
-use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+use unicode_segmentation::UnicodeSegmentation;
+use unicode_width::UnicodeWidthStr;
+
+/// Remove terminal control sequences from untrusted session metadata.
+///
+/// Project names, branches, and paths originate in agent logs and repositories.
+/// Emitting ESC/C0/C1 bytes verbatim lets a crafted name rewrite the terminal,
+/// set a title, or copy data through OSC 52.  Single-line renderers do not need
+/// any control characters, so whitespace controls become spaces and all other
+/// controls are dropped.
+pub fn sanitize_terminal(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        if matches!(ch, '\n' | '\r' | '\t') {
+            out.push(' ');
+        } else if ch == '\u{1b}' || ch.is_control() || is_bidi_formatting(ch) {
+            continue;
+        } else {
+            out.push(ch);
+        }
+    }
+    collapse_spaces(&out)
+}
+
+fn is_bidi_formatting(ch: char) -> bool {
+    matches!(
+        ch,
+        '\u{061c}'
+            | '\u{200e}'
+            | '\u{200f}'
+            | '\u{202a}'..='\u{202e}'
+            | '\u{2066}'..='\u{2069}'
+    )
+}
+
+fn collapse_spaces(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut previous_space = false;
+    for ch in s.chars() {
+        if ch.is_whitespace() {
+            if !previous_space && !out.is_empty() {
+                out.push(' ');
+            }
+            previous_space = true;
+        } else {
+            out.push(ch);
+            previous_space = false;
+        }
+    }
+    if out.ends_with(' ') {
+        out.pop();
+    }
+    out
+}
+
+pub fn color_enabled() -> bool {
+    use std::io::IsTerminal;
+    std::io::stdout().is_terminal()
+        && std::env::var_os("NO_COLOR").is_none()
+        && std::env::var("TERM").ok().as_deref() != Some("dumb")
+}
 
 /// Display width of `s` in terminal columns.
 pub fn width(s: &str) -> usize {
@@ -24,12 +84,7 @@ pub fn truncate(s: &str, max_width: usize) -> String {
 /// Used for free-form session summaries rendered inside a single TUI row,
 /// where a raw `\n` would break the layout.
 pub fn truncate_flat(s: &str, max_width: usize) -> String {
-    if s.contains(['\n', '\r', '\t']) {
-        let flattened = s.split_whitespace().collect::<Vec<_>>().join(" ");
-        truncate_with(&flattened, max_width, "...")
-    } else {
-        truncate_with(s, max_width, "...")
-    }
+    truncate_with(&sanitize_terminal(s), max_width, "...")
 }
 
 /// Pad `s` with trailing spaces to `to_width` columns. Wider input is returned
@@ -49,7 +104,7 @@ pub fn pad(s: &str, to_width: usize) -> String {
 /// long, space-padded if too short. This is the CJK-safe replacement for
 /// `format!("{:<column_width$}", truncate(s, column_width))`.
 pub fn fit(s: &str, column_width: usize) -> String {
-    pad(&truncate(s, column_width), column_width)
+    pad(&truncate(&sanitize_terminal(s), column_width), column_width)
 }
 
 /// Shared truncation core. The ellipsis is *included* in the budget, so the
@@ -70,15 +125,13 @@ fn truncate_with(s: &str, max_width: usize, ellipsis: &str) -> String {
 
     let mut out = String::with_capacity(s.len().min(budget.saturating_mul(4)) + ellipsis.len());
     let mut used = 0;
-    for ch in s.chars() {
-        // Zero-width and control chars report `None`; treat them as 0 columns
-        // so they ride along without consuming budget.
-        let ch_width = ch.width().unwrap_or(0);
-        if used + ch_width > budget {
+    for grapheme in s.graphemes(true) {
+        let grapheme_width = width(grapheme);
+        if used + grapheme_width > budget {
             break;
         }
-        used += ch_width;
-        out.push(ch);
+        used += grapheme_width;
+        out.push_str(grapheme);
     }
     if marked {
         out.push_str(ellipsis);
@@ -116,6 +169,13 @@ mod tests {
     }
 
     #[test]
+    fn truncate_never_splits_an_emoji_grapheme() {
+        let out = truncate("👩‍🔬xyz", 4);
+        assert_eq!(out, "👩‍🔬x…");
+        assert!(!out.ends_with('\u{200d}'));
+    }
+
+    #[test]
     fn truncate_keeps_short_input_verbatim() {
         assert_eq!(truncate("agf", 10), "agf");
         assert_eq!(truncate("프로젝트", 8), "프로젝트");
@@ -144,5 +204,13 @@ mod tests {
     fn zero_width_budget_yields_empty_string() {
         assert_eq!(truncate("anything", 0), "");
         assert_eq!(fit("anything", 0), "");
+    }
+
+    #[test]
+    fn sanitize_terminal_strips_escape_and_control_bytes() {
+        let hostile = "safe\x1b]52;c;secret\x07\nnext\tpart\u{0085}\u{202e}spoof\u{2066}end";
+        let clean = sanitize_terminal(hostile);
+        assert_eq!(clean, "safe]52;c;secret next partspoofend");
+        assert!(!clean.chars().any(char::is_control));
     }
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -7,7 +7,7 @@ use crate::action;
 use crate::cache::ScanResult;
 use crate::config::installed_agents;
 use crate::fuzzy::FuzzyMatcher;
-use crate::model::{Action, Agent, Session, SortMode};
+use crate::model::{Action, Agent, Session, SessionIdentity, SortMode, compare_sessions};
 use crate::text::{self, truncate_flat as truncate_str};
 
 /// Width of the agent-name column, shared by the row builder and the layout
@@ -25,6 +25,7 @@ const SEPARATOR: slt::Color = slt::Color::Rgb(64, 64, 64);
 const RED: slt::Color = slt::Color::Rgb(239, 68, 68);
 const GREEN_400: slt::Color = slt::Color::Rgb(52, 211, 153);
 const CYAN: slt::Color = slt::Color::Rgb(34, 211, 238);
+const BROWSE_FIRST_SESSION_ROW: usize = 3;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Mode {
@@ -44,7 +45,13 @@ pub enum Mode {
 pub struct ProjectGroup {
     pub project_path: String,
     pub project_name: String,
-    pub sessions: Vec<usize>, // indices into App.sessions
+    pub sessions: Vec<SessionIdentity>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum GroupSelection {
+    Header(String),
+    Session(SessionIdentity),
 }
 
 #[derive(Debug, Clone)]
@@ -56,6 +63,7 @@ pub struct NewSessionOption {
 
 pub struct App {
     pub sessions: Vec<Session>,
+    session_index: HashMap<SessionIdentity, usize>,
     pub filtered_indices: Vec<usize>,
     pub match_positions: Vec<Vec<u32>>,
     pub selected: usize,
@@ -65,6 +73,14 @@ pub struct App {
     pub action_index: usize,
     pub agent_index: usize,
     pub delete_index: usize,
+    /// Identity captured when a single-session confirmation opens. Background
+    /// refreshes can replace/reorder the session Vec while the dialog is
+    /// visible, so a numeric cursor is not a safe deletion target.
+    pending_delete: Option<SessionIdentity>,
+    /// Session whose action/preview flow is open. Unlike the browse cursor,
+    /// this identity cannot drift to a neighbor when a streaming scan removes
+    /// or reorders rows.
+    active_session: Option<SessionIdentity>,
     pub new_session_options: Vec<NewSessionOption>,
     pub mode_index: usize,
     pub mode_options: Vec<(&'static str, &'static str)>,
@@ -83,7 +99,7 @@ pub struct App {
     /// accepts `&str`) instead of allocating a key per row per frame, and so
     /// the delete pass gets its per-agent batches for free.
     pub selected_set: HashMap<Agent, HashSet<String>>,
-    pub summary_offsets: HashMap<String, usize>,
+    pub summary_offsets: HashMap<Agent, HashMap<String, usize>>,
     pub summary_search_count: usize,
     pub include_summaries: bool,
     pub show_recap: bool,
@@ -112,6 +128,15 @@ pub struct App {
     /// Agents whose background scan is still running. Drives the
     /// "Refreshing N agents…" footer indicator.
     pub scanning_agents: HashSet<Agent>,
+    /// Failed/panicked workers are no longer shown as scanning, but their
+    /// previous cache entries must be preserved on exit.
+    pub failed_agents: HashSet<Agent>,
+    /// Source snapshot paired with each successfully ingested worker result.
+    /// Cache writes must use this snapshot, never a later unrelated mtime.
+    pub scan_fingerprints: HashMap<Agent, crate::cache::SourceFingerprint>,
+    /// Successful deletes made after workers started. Late results from those
+    /// workers are filtered so they cannot resurrect a deleted row.
+    deleted_tombstones: HashMap<Agent, HashSet<String>>,
     fuzzy: FuzzyMatcher,
 }
 
@@ -148,6 +173,11 @@ impl App {
             });
         }
 
+        let session_index = sessions
+            .iter()
+            .enumerate()
+            .map(|(index, session)| (session.identity(), index))
+            .collect();
         let filtered_indices: Vec<usize> = (0..sessions.len()).collect();
         let match_positions: Vec<Vec<u32>> = vec![Vec::new(); sessions.len()];
         let query = initial_query.unwrap_or_default();
@@ -162,6 +192,7 @@ impl App {
         let show_recap = settings.show_recap;
         let mut app = Self {
             sessions,
+            session_index,
             filtered_indices,
             match_positions,
             selected: 0,
@@ -171,6 +202,8 @@ impl App {
             action_index: 0,
             agent_index: 0,
             delete_index: 1,
+            pending_delete: None,
+            active_session: None,
             new_session_options,
             mode_index: 0,
             mode_options: Vec::new(),
@@ -197,6 +230,9 @@ impl App {
             name_col_width_cache: None,
             scan_rx,
             scanning_agents,
+            failed_agents: HashSet::new(),
+            scan_fingerprints: HashMap::new(),
+            deleted_tombstones: HashMap::new(),
             fuzzy: FuzzyMatcher::new(),
         };
         if !app.query.is_empty() {
@@ -215,22 +251,8 @@ impl App {
     }
 
     fn apply_sort_preserving(&mut self, pivot: Option<(Agent, String)>) {
-        match self.sort_mode {
-            SortMode::Time => self
-                .sessions
-                .sort_by_key(|s| std::cmp::Reverse(s.timestamp)),
-            SortMode::Name => self.sessions.sort_by(|a, b| {
-                a.project_name
-                    .to_lowercase()
-                    .cmp(&b.project_name.to_lowercase())
-            }),
-            SortMode::Agent => self.sessions.sort_by(|a, b| {
-                a.agent
-                    .to_string()
-                    .cmp(&b.agent.to_string())
-                    .then(b.timestamp.cmp(&a.timestamp))
-            }),
-        }
+        self.sessions
+            .sort_by(|a, b| compare_sessions(a, b, self.sort_mode));
 
         // Boost: pinned first; everything else keeps the primary sort order
         // (stable sort preserves it within rank). The previous cwd-match
@@ -241,7 +263,8 @@ impl App {
         // Pinning is still honored because it's an explicit user action.
         let pinned = &self.pinned_sessions;
         self.sessions
-            .sort_by_key(|s| !pinned.contains(&s.session_id));
+            .sort_by_key(|session| !is_pinned_in(pinned, session));
+        self.rebuild_session_index();
 
         // Sessions reordered → cached column width no longer valid.
         self.name_col_width_cache = None;
@@ -265,7 +288,10 @@ impl App {
             .sessions
             .iter()
             .enumerate()
-            .filter(|(_, s)| self.agent_filter.is_none_or(|agent| s.agent == agent))
+            .filter(|(_, session)| {
+                (self.settings.include_non_interactive || session.interactive)
+                    && self.agent_filter.is_none_or(|agent| session.agent == agent)
+            })
             .map(|(i, _)| i)
             .collect();
 
@@ -287,6 +313,11 @@ impl App {
             self.match_positions = results.into_iter().map(|r| r.positions).collect();
         }
 
+        if let Some(max) = self.settings.max_sessions {
+            self.filtered_indices.truncate(max);
+            self.match_positions.truncate(max);
+        }
+
         if self.filtered_indices.is_empty() {
             self.selected = 0;
         } else if self.selected >= self.filtered_indices.len() {
@@ -297,7 +328,7 @@ impl App {
         let name_col_width = self
             .filtered_indices
             .iter()
-            .map(|&i| UnicodeWidthStr::width(self.sessions[i].project_name.as_str()))
+            .map(|&i| text::width(&text::sanitize_terminal(&self.sessions[i].project_name)))
             .max()
             .unwrap_or(0)
             .min(30); // cap at 30 chars to leave room for summary
@@ -310,6 +341,21 @@ impl App {
         self.filtered_indices
             .get(self.selected)
             .and_then(|&i| self.sessions.get(i))
+    }
+
+    fn capture_active_session(&mut self) -> bool {
+        self.active_session = self.selected_session().map(Session::identity);
+        self.active_session.is_some()
+    }
+
+    fn action_session(&self) -> Option<&Session> {
+        self.active_session
+            .as_ref()
+            .and_then(|identity| self.session_by_identity(identity))
+    }
+
+    fn is_pinned(&self, session: &Session) -> bool {
+        is_pinned_in(&self.pinned_sessions, session)
     }
 
     /// Total number of sessions checked for bulk delete.
@@ -355,8 +401,14 @@ impl App {
         if count <= 1 {
             return;
         }
-        let id = session.session_id.clone();
-        let offset = self.summary_offsets.entry(id).or_insert(0);
+        let agent = session.agent;
+        let session_id = session.session_id.clone();
+        let offset = self
+            .summary_offsets
+            .entry(agent)
+            .or_default()
+            .entry(session_id)
+            .or_insert(0);
         *offset = if forward {
             (*offset + 1) % count
         } else if *offset == 0 {
@@ -401,11 +453,13 @@ impl App {
     }
 
     pub fn build_groups(&mut self) {
-        let mut map: std::collections::BTreeMap<String, Vec<usize>> =
+        let mut map: std::collections::BTreeMap<String, Vec<SessionIdentity>> =
             std::collections::BTreeMap::new();
         for &idx in &self.filtered_indices {
             let s = &self.sessions[idx];
-            map.entry(s.project_path.clone()).or_default().push(idx);
+            map.entry(s.project_path.clone())
+                .or_default()
+                .push(s.identity());
         }
         self.groups = map
             .into_iter()
@@ -417,7 +471,7 @@ impl App {
                     .to_string();
                 ProjectGroup {
                     project_path: path,
-                    project_name: name,
+                    project_name: text::sanitize_terminal(&name),
                     sessions,
                 }
             })
@@ -426,21 +480,87 @@ impl App {
         // each group's sessions, not `.first()` — `.first()` is only the newest
         // when the list is in Time sort; in Name/Agent sort it is not, which
         // ordered the groups incorrectly.
+        let session_index = &self.session_index;
+        let all_sessions = &self.sessions;
         self.groups.sort_by(|a, b| {
             let a_ts = a
                 .sessions
                 .iter()
-                .map(|&i| self.sessions[i].timestamp)
+                .filter_map(|identity| session_index.get(identity))
+                .filter_map(|index| all_sessions.get(*index))
+                .map(|session| session.timestamp)
                 .max()
                 .unwrap_or(0);
             let b_ts = b
                 .sessions
                 .iter()
-                .map(|&i| self.sessions[i].timestamp)
+                .filter_map(|identity| session_index.get(identity))
+                .filter_map(|index| all_sessions.get(*index))
+                .map(|session| session.timestamp)
                 .max()
                 .unwrap_or(0);
             b_ts.cmp(&a_ts)
         });
+    }
+
+    fn rebuild_session_index(&mut self) {
+        self.session_index = self
+            .sessions
+            .iter()
+            .enumerate()
+            .map(|(index, session)| (session.identity(), index))
+            .collect();
+    }
+
+    fn session_by_identity(&self, identity: &SessionIdentity) -> Option<&Session> {
+        self.session_index
+            .get(identity)
+            .and_then(|index| self.sessions.get(*index))
+    }
+
+    fn filtered_position_for_identity(&self, identity: &SessionIdentity) -> Option<usize> {
+        let index = *self.session_index.get(identity)?;
+        self.filtered_indices
+            .iter()
+            .position(|candidate| *candidate == index)
+    }
+
+    fn grouped_selection_identity(&self) -> Option<GroupSelection> {
+        let (group_index, child) = self.grouped_row_at(self.grouped_selected)?;
+        let group = self.groups.get(group_index)?;
+        Some(match child {
+            None => GroupSelection::Header(group.project_path.clone()),
+            Some(child_index) => GroupSelection::Session(group.sessions.get(child_index)?.clone()),
+        })
+    }
+
+    fn restore_grouped_selection(&mut self, selection: Option<GroupSelection>) {
+        let Some(selection) = selection else {
+            self.grouped_selected = self
+                .grouped_selected
+                .min(self.grouped_row_count().saturating_sub(1));
+            return;
+        };
+        let mut row = 0;
+        for group in &self.groups {
+            if selection == GroupSelection::Header(group.project_path.clone()) {
+                self.grouped_selected = row;
+                return;
+            }
+            row += 1;
+            if self.group_expanded.contains(&group.project_path) {
+                for identity in &group.sessions {
+                    if selection == GroupSelection::Session(identity.clone()) {
+                        self.grouped_selected = row;
+                        return;
+                    }
+                    row += 1;
+                }
+            }
+        }
+        self.grouped_selected = self
+            .grouped_selected
+            .min(self.grouped_row_count().saturating_sub(1));
     }
 
     /// Count total visible rows in grouped view (headers + expanded children)
@@ -537,14 +657,33 @@ impl App {
             self.selected_session()
                 .map(|s| (s.agent, s.session_id.clone()))
         };
-        let mut received_any = false;
+        let grouped_pivot = (self.mode == Mode::GroupedBrowse)
+            .then(|| self.grouped_selection_identity())
+            .flatten();
+        let mut merged_any = false;
         let mut channel_open = true;
         loop {
             match rx.try_recv() {
                 Ok(result) => {
-                    self.merge_agent_sessions(result.agent, result.sessions);
                     self.scanning_agents.remove(&result.agent);
-                    received_any = true;
+                    match result.sessions {
+                        Ok(scan) => {
+                            self.failed_agents.remove(&result.agent);
+                            if let Some(fingerprint) = scan.fingerprint {
+                                self.scan_fingerprints.insert(result.agent, fingerprint);
+                            } else {
+                                self.scan_fingerprints.remove(&result.agent);
+                            }
+                            self.merge_agent_sessions(result.agent, scan.sessions);
+                            merged_any = true;
+                        }
+                        Err(error) => {
+                            self.failed_agents.insert(result.agent);
+                            if std::env::var("AGF_DEBUG").is_ok() {
+                                eprintln!("[agf] {} refresh failed: {error}", result.agent);
+                            }
+                        }
+                    }
                 }
                 Err(std::sync::mpsc::TryRecvError::Empty) => break,
                 Err(std::sync::mpsc::TryRecvError::Disconnected) => {
@@ -556,11 +695,17 @@ impl App {
         if channel_open {
             // More results may arrive — keep polling next frame.
             self.scan_rx = Some(rx);
+        } else if !self.scanning_agents.is_empty() {
+            self.failed_agents.extend(self.scanning_agents.drain());
         }
-        if received_any {
+        if merged_any {
             // Re-apply current sort + filter so new sessions land in the
             // correct order and the cached column width is recomputed.
             self.apply_sort_preserving(pivot);
+            if self.mode == Mode::GroupedBrowse {
+                self.build_groups();
+                self.restore_grouped_selection(grouped_pivot);
+            }
         }
     }
 
@@ -568,17 +713,23 @@ impl App {
     /// responsible for re-sorting / re-filtering.
     fn merge_agent_sessions(&mut self, agent: Agent, new_sessions: Vec<Session>) {
         self.sessions.retain(|s| s.agent != agent);
-        self.sessions.extend(new_sessions);
-        if let Some(max) = self.settings.max_sessions {
-            // Keep most-recent first so truncation drops the tail.
-            self.sessions
-                .sort_by_key(|s| std::cmp::Reverse(s.timestamp));
-            self.sessions.truncate(max);
-        }
-        // Recount *after* truncating. Counting the incoming batch instead left
-        // the agent badge claiming sessions that `max_sessions` had just
-        // dropped off the end of the list.
+        let tombstones = self.deleted_tombstones.get(&agent);
+        self.sessions
+            .extend(new_sessions.into_iter().filter(|session| {
+                !tombstones.is_some_and(|ids| ids.contains(session.session_id.as_str()))
+            }));
         self.recount_agents();
+    }
+
+    pub fn cache_skip_agents(&self) -> HashSet<Agent> {
+        self.scanning_agents
+            .union(&self.failed_agents)
+            .copied()
+            .collect()
+    }
+
+    pub fn cache_invalidate_agents(&self) -> HashSet<Agent> {
+        self.deleted_tombstones.keys().copied().collect()
     }
 
     pub fn run(&mut self) -> anyhow::Result<Option<String>> {
@@ -613,6 +764,16 @@ type StyledChunk = (String, slt::Style);
 fn agent_color(agent: Agent) -> slt::Color {
     let (r, g, b) = agent.color();
     slt::Color::Rgb(r, g, b)
+}
+
+fn is_pinned_in(pins: &[String], session: &Session) -> bool {
+    pins.iter().any(|saved| {
+        saved == &session.session_id
+            || saved
+                .strip_prefix(session.agent.slug())
+                .and_then(|rest| rest.strip_prefix(':'))
+                == Some(session.session_id.as_str())
+    })
 }
 
 fn ui_browse(ui: &mut slt::Context, app: &mut App) {
@@ -694,11 +855,11 @@ fn ui_browse(ui: &mut slt::Context, app: &mut App) {
         app.selected += 1;
         app.adjust_scroll();
     }
-    if enter && app.selected_session().is_some() {
+    if enter && app.capture_active_session() {
         app.action_index = 0;
         app.mode = Mode::ActionSelect;
     }
-    if (right || ctrl_right) && app.selected_session().is_some() {
+    if (right || ctrl_right) && app.capture_active_session() {
         app.mode = Mode::Preview;
     }
     if ctrl_sort {
@@ -741,17 +902,16 @@ fn ui_browse(ui: &mut slt::Context, app: &mut App) {
         app.adjust_scroll();
     }
 
-    // Mouse: click on session row (search=1 + separator=1, list starts at y=2)
-    if let Some((_x, y)) = ui.mouse_down() {
-        let y = y as usize;
-        if y >= 2 {
-            let clicked_vi = app.scroll_offset + (y - 2);
-            if clicked_vi < app.filtered_indices.len() {
-                app.selected = clicked_vi;
-                app.adjust_scroll();
-                app.action_index = 0;
-                app.mode = Mode::ActionSelect;
-            }
+    // Mouse: the blank top row, search row, and separator occupy y=0..=2.
+    if let Some((_x, y)) = ui.mouse_down()
+        && let Some(clicked_vi) =
+            browse_click_index(y as usize, app.scroll_offset, app.filtered_indices.len())
+    {
+        app.selected = clicked_vi;
+        app.adjust_scroll();
+        app.action_index = 0;
+        if app.capture_active_session() {
+            app.mode = Mode::ActionSelect;
         }
     }
 
@@ -779,7 +939,7 @@ fn ui_browse(ui: &mut slt::Context, app: &mut App) {
             };
         });
 
-        ui.separator_colored(SEPARATOR);
+        let _ = ui.separator_colored(SEPARATOR);
 
         // Session list (rows have "> " or "  " prefix built-in)
         let _ = ui.container().grow(1).pr(1).col(|ui| {
@@ -817,7 +977,7 @@ fn ui_browse(ui: &mut slt::Context, app: &mut App) {
         });
 
         // Separator between content and statusbar
-        ui.separator_colored(SEPARATOR);
+        let _ = ui.separator_colored(SEPARATOR);
 
         render_footer(
             ui,
@@ -858,6 +1018,12 @@ fn ui_browse(ui: &mut slt::Context, app: &mut App) {
     }
 }
 
+fn browse_click_index(y: usize, scroll_offset: usize, session_count: usize) -> Option<usize> {
+    let row = y.checked_sub(BROWSE_FIRST_SESSION_ROW)?;
+    let index = scroll_offset.checked_add(row)?;
+    (index < session_count).then_some(index)
+}
+
 fn ui_grouped_browse(ui: &mut slt::Context, app: &mut App) {
     let esc = ui.consume_key_code(slt::KeyCode::Esc);
     let enter = ui.consume_key_code(slt::KeyCode::Enter);
@@ -894,10 +1060,12 @@ fn ui_grouped_browse(ui: &mut slt::Context, app: &mut App) {
         return;
     }
     if ctrl_right && let Some((gi, Some(ci))) = app.grouped_row_at(app.grouped_selected) {
-        let session_idx = app.groups[gi].sessions[ci];
-        if let Some(vi) = app.filtered_indices.iter().position(|&i| i == session_idx) {
+        let identity = app.groups[gi].sessions[ci].clone();
+        if let Some(vi) = app.filtered_position_for_identity(&identity) {
             app.selected = vi;
-            app.mode = Mode::Preview;
+            if app.capture_active_session() {
+                app.mode = Mode::Preview;
+            }
             return;
         }
     }
@@ -924,12 +1092,13 @@ fn ui_grouped_browse(ui: &mut slt::Context, app: &mut App) {
                 }
             }
             Some(ci) => {
-                let session_idx = app.groups[gi].sessions[ci];
-                // Find this session in filtered_indices to set app.selected
-                if let Some(vi) = app.filtered_indices.iter().position(|&i| i == session_idx) {
+                let identity = app.groups[gi].sessions[ci].clone();
+                if let Some(vi) = app.filtered_position_for_identity(&identity) {
                     app.selected = vi;
                     app.action_index = 0;
-                    app.mode = Mode::ActionSelect;
+                    if app.capture_active_session() {
+                        app.mode = Mode::ActionSelect;
+                    }
                 }
             }
         }
@@ -961,7 +1130,7 @@ fn ui_grouped_browse(ui: &mut slt::Context, app: &mut App) {
             ))
             .fg(GRAY_500);
         });
-        ui.separator_colored(SEPARATOR);
+        let _ = ui.separator_colored(SEPARATOR);
 
         let _ = ui.container().grow(1).pr(1).col(|ui| {
             if app.groups.is_empty() {
@@ -981,15 +1150,18 @@ fn ui_grouped_browse(ui: &mut slt::Context, app: &mut App) {
                 // Get most recent timestamp for the group
                 let latest_time = group
                     .sessions
-                    .first()
-                    .map(|&i| app.sessions[i].time_display())
+                    .iter()
+                    .filter_map(|identity| app.session_by_identity(identity))
+                    .max_by_key(|session| session.timestamp)
+                    .map(Session::time_display)
                     .unwrap_or_default();
                 // Agents in this group
                 let mut agent_set: Vec<Agent> = Vec::new();
-                for &idx in &group.sessions {
-                    let a = app.sessions[idx].agent;
-                    if !agent_set.contains(&a) {
-                        agent_set.push(a);
+                for identity in &group.sessions {
+                    if let Some(session) = app.session_by_identity(identity)
+                        && !agent_set.contains(&session.agent)
+                    {
+                        agent_set.push(session.agent);
                     }
                 }
 
@@ -1003,10 +1175,14 @@ fn ui_grouped_browse(ui: &mut slt::Context, app: &mut App) {
                     };
                     let arrow = if expanded { "\u{25be}" } else { "\u{25b8}" };
                     let display_path = if let Some(home) = dirs::home_dir() {
-                        if let Some(rest) =
-                            group.project_path.strip_prefix(home.to_str().unwrap_or(""))
+                        if let Ok(rest) =
+                            std::path::Path::new(&group.project_path).strip_prefix(&home)
                         {
-                            format!("~{rest}")
+                            if rest.as_os_str().is_empty() {
+                                "~".to_string()
+                            } else {
+                                format!("~/{}", rest.to_string_lossy())
+                            }
                         } else {
                             group.project_path.clone()
                         }
@@ -1032,7 +1208,10 @@ fn ui_grouped_browse(ui: &mut slt::Context, app: &mut App) {
                             );
                         }
                         ui.styled("  ".to_string(), slt::Style::new().bg(bg));
-                        ui.styled(display_path, slt::Style::new().fg(GRAY_500).bg(bg));
+                        ui.styled(
+                            text::sanitize_terminal(&display_path),
+                            slt::Style::new().fg(GRAY_500).bg(bg),
+                        );
                         ui.spacer();
                         ui.styled(
                             format!("  {latest_time} "),
@@ -1044,9 +1223,12 @@ fn ui_grouped_browse(ui: &mut slt::Context, app: &mut App) {
 
                 // Child rows (if expanded)
                 if expanded {
-                    for (ci, &session_idx) in group.sessions.iter().enumerate() {
+                    for (ci, identity) in group.sessions.iter().enumerate() {
                         if row_idx >= app.grouped_scroll && row_idx < end {
-                            let s = &app.sessions[session_idx];
+                            let Some(s) = app.session_by_identity(identity) else {
+                                row_idx += 1;
+                                continue;
+                            };
                             let is_selected = row_idx == app.grouped_selected;
                             let bg = if is_selected {
                                 HIGHLIGHT_BG
@@ -1055,12 +1237,15 @@ fn ui_grouped_browse(ui: &mut slt::Context, app: &mut App) {
                             };
                             let is_last = ci == group.sessions.len() - 1;
                             let tree_char = if is_last { "  └─ " } else { "  ├─ " };
-                            let is_pinned = app.pinned_sessions.contains(&s.session_id);
+                            let is_pinned = app.is_pinned(s);
                             let pin_str = if is_pinned { "*" } else { " " };
 
                             // Calculate available space for summary
                             let fixed_width = 5 + 1 + 12 + 2 + 16; // tree + pin + agent + gap + time
-                            let git_width = s.git_branch.as_ref().map_or(0, |b| b.len() + 2);
+                            let git_width = s
+                                .git_branch
+                                .as_ref()
+                                .map_or(0, |b| text::width(&text::sanitize_terminal(b)) + 2);
                             let summary_max =
                                 total_width.saturating_sub(fixed_width + git_width + 2);
 
@@ -1112,7 +1297,7 @@ fn ui_grouped_browse(ui: &mut slt::Context, app: &mut App) {
                                 ui.spacer();
                                 if let Some(branch) = &s.git_branch {
                                     ui.styled(
-                                        branch.to_string(),
+                                        text::sanitize_terminal(branch),
                                         slt::Style::new().fg(GREEN_400).bg(bg),
                                     );
                                 }
@@ -1128,7 +1313,7 @@ fn ui_grouped_browse(ui: &mut slt::Context, app: &mut App) {
             }
         });
 
-        ui.separator_colored(SEPARATOR);
+        let _ = ui.separator_colored(SEPARATOR);
         render_footer(
             ui,
             &[
@@ -1146,6 +1331,7 @@ fn ui_action_select(ui: &mut slt::Context, app: &mut App, result: &mut Option<St
     let action_count = actions.len();
 
     if ui.key_code(slt::KeyCode::Esc) {
+        app.active_session = None;
         app.mode = Mode::Browse;
     }
 
@@ -1174,7 +1360,7 @@ fn ui_action_select(ui: &mut slt::Context, app: &mut App, result: &mut Option<St
             // picker instead of dispatching Resume directly. Other actions
             // dispatch immediately.
             if actions[app.action_index] == Action::Resume {
-                if let Some(session) = app.selected_session() {
+                if let Some(session) = app.action_session() {
                     app.resume_mode_options = session.agent.resume_mode_options().to_vec();
                     app.resume_mode_index = 0;
                     app.mode = Mode::ResumeSelect;
@@ -1192,7 +1378,7 @@ fn ui_action_select(ui: &mut slt::Context, app: &mut App, result: &mut Option<St
             let clicked = y - 4;
             app.action_index = clicked;
             if actions[app.action_index] == Action::Resume {
-                if let Some(session) = app.selected_session() {
+                if let Some(session) = app.action_session() {
                     app.resume_mode_options = session.agent.resume_mode_options().to_vec();
                     app.resume_mode_index = 0;
                     app.mode = Mode::ResumeSelect;
@@ -1206,7 +1392,7 @@ fn ui_action_select(ui: &mut slt::Context, app: &mut App, result: &mut Option<St
     if ui.key_code(slt::KeyCode::Enter) {
         // Resume → go to mode picker; others → dispatch directly
         if actions[app.action_index] == Action::Resume {
-            if let Some(session) = app.selected_session() {
+            if let Some(session) = app.action_session() {
                 app.resume_mode_options = session.agent.resume_mode_options().to_vec();
                 app.resume_mode_index = 0;
                 app.mode = Mode::ResumeSelect;
@@ -1216,29 +1402,32 @@ fn ui_action_select(ui: &mut slt::Context, app: &mut App, result: &mut Option<St
         }
     }
 
-    let Some(session) = app.selected_session() else {
+    let Some(session) = app.action_session() else {
+        app.active_session = None;
         app.mode = Mode::Browse;
         return;
     };
 
     let _ = ui.col(|ui| {
-        ui.separator_colored(SEPARATOR);
+        let _ = ui.separator_colored(SEPARATOR);
         ui.line(|ui| {
             ui.text(format!(" {} ", session.agent))
                 .fg(agent_color(session.agent))
                 .bold();
             ui.text("| ").fg(SEPARATOR);
-            ui.text(&session.project_name).fg(BRIGHT_WHITE).bold();
+            ui.text(text::sanitize_terminal(&session.project_name))
+                .fg(BRIGHT_WHITE)
+                .bold();
             ui.text(" | ").fg(SEPARATOR);
             ui.text(session.display_path()).fg(GRAY_500);
             if let Some(branch) = &session.git_branch {
                 ui.text(" | ").fg(SEPARATOR);
-                ui.text(branch).fg(GREEN_400);
+                ui.text(text::sanitize_terminal(branch)).fg(GREEN_400);
             }
             ui.text(" | ").fg(SEPARATOR);
             ui.text(session.time_display()).fg(VIOLET);
         });
-        ui.separator_colored(SEPARATOR);
+        let _ = ui.separator_colored(SEPARATOR);
         ui.text("");
 
         let _ = ui.container().grow(1).col(|ui| {
@@ -1253,8 +1442,8 @@ fn ui_action_select(ui: &mut slt::Context, app: &mut App, result: &mut Option<St
                 let indicator = format!(" {}) ", i + 1);
                 let label = if *act == Action::Pin {
                     let is_pinned = app
-                        .selected_session()
-                        .is_some_and(|s| app.pinned_sessions.contains(&s.session_id));
+                        .action_session()
+                        .is_some_and(|session| app.is_pinned(session));
                     if is_pinned {
                         "Unpin Session".to_string()
                     } else {
@@ -1275,7 +1464,7 @@ fn ui_action_select(ui: &mut slt::Context, app: &mut App, result: &mut Option<St
                 } else {
                     base_style
                 };
-                let preview = action::action_preview(session, *act);
+                let preview = truncate_str(&action::action_preview(session, *act), total_width);
                 let mut preview_text = format!("    {preview}");
                 let used = UnicodeWidthStr::width(indicator.as_str())
                     + UnicodeWidthStr::width(label.as_str())
@@ -1313,7 +1502,7 @@ fn ui_action_select(ui: &mut slt::Context, app: &mut App, result: &mut Option<St
         });
 
         ui.text("");
-        ui.separator_colored(SEPARATOR);
+        let _ = ui.separator_colored(SEPARATOR);
         render_footer(
             ui,
             &[("Tab/jk", "nav"), ("Enter", "select"), ("Esc", "back")],
@@ -1329,6 +1518,7 @@ fn dispatch_action(
 ) {
     match selected_action {
         Action::Back => {
+            app.active_session = None;
             app.mode = Mode::Browse;
         }
         Action::NewSession => {
@@ -1337,23 +1527,32 @@ fn dispatch_action(
         }
         Action::Delete => {
             app.delete_index = 1;
-            app.mode = Mode::DeleteConfirm;
+            app.pending_delete = app.active_session.clone();
+            if app.pending_delete.is_some() {
+                app.mode = Mode::DeleteConfirm;
+            }
         }
         Action::Pin => {
-            if let Some(session) = app.selected_session() {
-                let id = session.session_id.clone();
-                if let Some(pos) = app.pinned_sessions.iter().position(|s| s == &id) {
+            if let Some(session) = app.action_session() {
+                let key = session.settings_key();
+                let legacy_id = session.session_id.clone();
+                if let Some(pos) = app
+                    .pinned_sessions
+                    .iter()
+                    .position(|saved| saved == &key || saved == &legacy_id)
+                {
                     app.pinned_sessions.remove(pos);
                 } else {
-                    app.pinned_sessions.push(id);
+                    app.pinned_sessions.push(key);
                 }
                 app.save_settings();
                 app.apply_sort();
             }
+            app.active_session = None;
             app.mode = Mode::Browse;
         }
         _ => {
-            if let Some(session) = app.selected_session().cloned()
+            if let Some(session) = app.action_session().cloned()
                 && let Some(cmd) = action::generate_command(&session, selected_action, None)
             {
                 result.replace(cmd);
@@ -1404,19 +1603,20 @@ fn ui_agent_select(ui: &mut slt::Context, app: &mut App, result: &mut Option<Str
         }
     }
 
-    let Some(session) = app.selected_session() else {
+    let Some(session) = app.action_session() else {
+        app.active_session = None;
         app.mode = Mode::Browse;
         return;
     };
 
     let _ = ui.col(|ui| {
-        ui.separator_colored(SEPARATOR);
+        let _ = ui.separator_colored(SEPARATOR);
         ui.line(|ui| {
             ui.text(" New session in ").fg(BRIGHT_WHITE);
             ui.text(session.display_path()).fg(GRAY_500);
             ui.text("  (enter -> permission mode)").fg(GRAY_500);
         });
-        ui.separator_colored(SEPARATOR);
+        let _ = ui.separator_colored(SEPARATOR);
         ui.text("");
 
         let _ = ui.container().grow(1).col(|ui| {
@@ -1429,7 +1629,7 @@ fn ui_agent_select(ui: &mut slt::Context, app: &mut App, result: &mut Option<Str
                     slt::Color::Reset
                 };
                 let indicator = format!(" {}) ", i + 1);
-                let preview = if let Some(s) = app.selected_session() {
+                let preview = if let Some(s) = app.action_session() {
                     let shell = crate::shell::CommandShell::from_env();
                     action::preview_cd_and(&shell, s, opt.agent.new_session_cmd())
                 } else {
@@ -1457,7 +1657,7 @@ fn ui_agent_select(ui: &mut slt::Context, app: &mut App, result: &mut Option<Str
         });
 
         ui.text("");
-        ui.separator_colored(SEPARATOR);
+        let _ = ui.separator_colored(SEPARATOR);
         render_footer(
             ui,
             &[
@@ -1500,7 +1700,7 @@ fn permission_options_for(agent: Agent) -> Vec<(&'static str, &'static str)> {
 
 fn dispatch_agent_option(ui: &mut slt::Context, app: &mut App, result: &mut Option<String>) {
     if let Some(opt) = app.new_session_options.get(app.agent_index)
-        && let Some(session) = app.selected_session().cloned()
+        && let Some(session) = app.action_session().cloned()
     {
         let cmd = action::new_session_with_flags(&session, opt.agent, opt.command_suffix);
         result.replace(cmd);
@@ -1544,7 +1744,8 @@ fn ui_permission_select(ui: &mut slt::Context, app: &mut App, result: &mut Optio
         dispatch_mode_option(ui, app, result);
     }
 
-    if app.selected_session().is_none() {
+    if app.action_session().is_none() {
+        app.active_session = None;
         app.mode = Mode::Browse;
         return;
     }
@@ -1555,12 +1756,12 @@ fn ui_permission_select(ui: &mut slt::Context, app: &mut App, result: &mut Optio
         .map_or("agent", |o| o.label.as_str());
 
     let _ = ui.col(|ui| {
-        ui.separator_colored(SEPARATOR);
+        let _ = ui.separator_colored(SEPARATOR);
         ui.line(|ui| {
             ui.text(" Select mode for ").fg(BRIGHT_WHITE);
             ui.text(agent_label).fg(YELLOW).bold();
         });
-        ui.separator_colored(SEPARATOR);
+        let _ = ui.separator_colored(SEPARATOR);
         ui.text("");
 
         let _ = ui.container().grow(1).col(|ui| {
@@ -1600,7 +1801,7 @@ fn ui_permission_select(ui: &mut slt::Context, app: &mut App, result: &mut Optio
         });
 
         ui.text("");
-        ui.separator_colored(SEPARATOR);
+        let _ = ui.separator_colored(SEPARATOR);
         render_footer(
             ui,
             &[("1-9", "select"), ("Enter", "confirm"), ("Esc", "back")],
@@ -1611,7 +1812,7 @@ fn ui_permission_select(ui: &mut slt::Context, app: &mut App, result: &mut Optio
 fn dispatch_mode_option(ui: &mut slt::Context, app: &mut App, result: &mut Option<String>) {
     if let Some((_, flags)) = app.mode_options.get(app.mode_index)
         && let Some(opt) = app.new_session_options.get(app.agent_index)
-        && let Some(session) = app.selected_session().cloned()
+        && let Some(session) = app.action_session().cloned()
     {
         let cmd = action::new_session_with_flags(&session, opt.agent, flags);
         result.replace(cmd);
@@ -1655,20 +1856,21 @@ fn ui_resume_select(ui: &mut slt::Context, app: &mut App, result: &mut Option<St
         dispatch_resume_mode(ui, app, result);
     }
 
-    let Some(session) = app.selected_session() else {
+    let Some(session) = app.action_session() else {
+        app.active_session = None;
         app.mode = Mode::Browse;
         return;
     };
 
     let _ = ui.col(|ui| {
-        ui.separator_colored(SEPARATOR);
+        let _ = ui.separator_colored(SEPARATOR);
         ui.line(|ui| {
             ui.text(" Resume mode for ").fg(BRIGHT_WHITE);
             ui.text(format!("{}", session.agent))
                 .fg(agent_color(session.agent))
                 .bold();
         });
-        ui.separator_colored(SEPARATOR);
+        let _ = ui.separator_colored(SEPARATOR);
         ui.text("");
 
         let _ = ui.container().grow(1).col(|ui| {
@@ -1708,7 +1910,7 @@ fn ui_resume_select(ui: &mut slt::Context, app: &mut App, result: &mut Option<St
         });
 
         ui.text("");
-        ui.separator_colored(SEPARATOR);
+        let _ = ui.separator_colored(SEPARATOR);
         render_footer(
             ui,
             &[("1-9", "select"), ("Enter", "confirm"), ("Esc", "back")],
@@ -1718,7 +1920,7 @@ fn ui_resume_select(ui: &mut slt::Context, app: &mut App, result: &mut Option<St
 
 fn dispatch_resume_mode(ui: &mut slt::Context, app: &mut App, result: &mut Option<String>) {
     if let Some((_, flags)) = app.resume_mode_options.get(app.resume_mode_index)
-        && let Some(session) = app.selected_session().cloned()
+        && let Some(session) = app.action_session().cloned()
     {
         let cmd = action::resume_with_flags(&session, flags);
         result.replace(cmd);
@@ -1768,6 +1970,7 @@ fn ui_bulk_delete(ui: &mut slt::Context, app: &mut App) {
 
     if ui.key_code(slt::KeyCode::Enter) && !app.selected_set.is_empty() {
         app.delete_index = 1;
+        app.pending_delete = None;
         app.mode = Mode::DeleteConfirm;
     }
 
@@ -1807,6 +2010,7 @@ fn ui_delete_confirm(ui: &mut slt::Context, app: &mut App) {
     let is_bulk = !app.selected_set.is_empty();
 
     if ui.key_code(slt::KeyCode::Esc) {
+        app.pending_delete = None;
         if is_bulk {
             app.mode = Mode::BulkDelete;
         } else {
@@ -1856,26 +2060,43 @@ fn ui_delete_confirm(ui: &mut slt::Context, app: &mut App) {
                 // Only agents whose pass succeeded come back, so a failed
                 // delete leaves its rows visible.
                 let deleted = crate::delete::delete_selection(&targets);
+                for (agent, ids) in &deleted {
+                    app.deleted_tombstones
+                        .entry(*agent)
+                        .or_default()
+                        .extend(ids.iter().cloned());
+                }
                 app.sessions.retain(|s| {
                     !deleted
                         .get(&s.agent)
                         .is_some_and(|ids| ids.contains(s.session_id.as_str()))
                 });
                 app.recount_agents();
+                app.rebuild_session_index();
                 app.update_filter();
-            } else if let Some(idx) = app.filtered_indices.get(app.selected).copied() {
+            } else if let Some(identity) = app.pending_delete.take()
+                && let Some(idx) = app.session_index.get(&identity).copied()
+            {
                 // Only drop the row from the UI when the on-disk delete
                 // actually succeeded; a failed delete stays visible.
                 if crate::delete::delete_session(&app.sessions[idx]).is_ok() {
+                    app.deleted_tombstones
+                        .entry(identity.agent)
+                        .or_default()
+                        .insert(identity.session_id.clone());
                     app.sessions.remove(idx);
                     app.recount_agents();
+                    app.rebuild_session_index();
                 }
                 app.update_filter();
             }
+            app.active_session = None;
             app.mode = Mode::Browse;
         } else if is_bulk {
             app.mode = Mode::BulkDelete;
         } else {
+            app.pending_delete = None;
+            app.active_session = None;
             app.mode = Mode::Browse;
         }
     }
@@ -1888,14 +2109,18 @@ fn ui_delete_confirm(ui: &mut slt::Context, app: &mut App) {
 }
 
 fn render_single_delete_confirm(ui: &mut slt::Context, app: &App) {
-    let Some(session) = app.selected_session() else {
+    let Some(session) = app
+        .pending_delete
+        .as_ref()
+        .and_then(|identity| app.session_by_identity(identity))
+    else {
         return;
     };
 
     let _ = ui.col(|ui| {
-        ui.separator_colored(SEPARATOR);
+        let _ = ui.separator_colored(SEPARATOR);
         ui.text(" Delete session?").fg(RED).bold();
-        ui.separator_colored(SEPARATOR);
+        let _ = ui.separator_colored(SEPARATOR);
         ui.text("");
 
         ui.line(|ui| {
@@ -1903,9 +2128,11 @@ fn render_single_delete_confirm(ui: &mut slt::Context, app: &App) {
                 .fg(agent_color(session.agent))
                 .bold();
             ui.text("| ").fg(SEPARATOR);
-            ui.text(&session.project_name).fg(BRIGHT_WHITE);
+            ui.text(text::sanitize_terminal(&session.project_name))
+                .fg(BRIGHT_WHITE);
             ui.text(" | ").fg(SEPARATOR);
-            ui.text(&session.session_id).fg(GRAY_500);
+            ui.text(text::sanitize_terminal(&session.session_id))
+                .fg(GRAY_500);
         });
         ui.text(format!("  {}", session.display_path()))
             .fg(GRAY_500);
@@ -1946,7 +2173,7 @@ fn render_single_delete_confirm(ui: &mut slt::Context, app: &App) {
             });
         }
 
-        ui.separator_colored(SEPARATOR);
+        let _ = ui.separator_colored(SEPARATOR);
     });
 }
 
@@ -1958,15 +2185,15 @@ fn render_bulk_delete_confirm(ui: &mut slt::Context, app: &App) {
         .sessions
         .iter()
         .filter(|s| app.is_checked(s))
-        .map(|s| s.project_name.clone())
+        .map(|s| text::sanitize_terminal(&s.project_name))
         .collect();
     let count = names.len();
     names.sort();
 
     let _ = ui.col(|ui| {
-        ui.separator_colored(SEPARATOR);
+        let _ = ui.separator_colored(SEPARATOR);
         ui.text(format!(" Delete {count} sessions?")).fg(RED).bold();
-        ui.separator_colored(SEPARATOR);
+        let _ = ui.separator_colored(SEPARATOR);
         ui.text("");
 
         for (i, name) in names.iter().enumerate() {
@@ -2009,7 +2236,7 @@ fn render_bulk_delete_confirm(ui: &mut slt::Context, app: &App) {
             });
         }
 
-        ui.separator_colored(SEPARATOR);
+        let _ = ui.separator_colored(SEPARATOR);
     });
 }
 
@@ -2021,6 +2248,7 @@ fn ui_preview(ui: &mut slt::Context, app: &mut App) {
         || ui.key_code(slt::KeyCode::Left)
         || ui.key_mod('h', slt::KeyModifiers::CONTROL)
     {
+        app.active_session = None;
         app.mode = Mode::Browse;
         return;
     }
@@ -2041,21 +2269,24 @@ fn ui_preview(ui: &mut slt::Context, app: &mut App) {
     if up && app.selected > 0 {
         app.selected -= 1;
         app.adjust_scroll();
+        app.capture_active_session();
     }
     if down && !app.filtered_indices.is_empty() && app.selected < app.filtered_indices.len() - 1 {
         app.selected += 1;
         app.adjust_scroll();
+        app.capture_active_session();
     }
 
-    let Some(session) = app.selected_session() else {
+    let Some(session) = app.action_session() else {
+        app.active_session = None;
         app.mode = Mode::Browse;
         return;
     };
 
     let _ = ui.col(|ui| {
-        ui.separator_colored(SEPARATOR);
+        let _ = ui.separator_colored(SEPARATOR);
         ui.text(" Session Detail").fg(BRIGHT_WHITE).bold();
-        ui.separator_colored(SEPARATOR);
+        let _ = ui.separator_colored(SEPARATOR);
         ui.text("");
 
         ui.line(|ui| {
@@ -2066,7 +2297,9 @@ fn ui_preview(ui: &mut slt::Context, app: &mut App) {
         });
         ui.line(|ui| {
             ui.text("  Project:  ").fg(GRAY_500);
-            ui.text(&session.project_name).fg(BRIGHT_WHITE).bold();
+            ui.text(text::sanitize_terminal(&session.project_name))
+                .fg(BRIGHT_WHITE)
+                .bold();
         });
         ui.line(|ui| {
             ui.text("  Path:     ").fg(GRAY_500);
@@ -2074,7 +2307,8 @@ fn ui_preview(ui: &mut slt::Context, app: &mut App) {
         });
         ui.line(|ui| {
             ui.text("  Session:  ").fg(GRAY_500);
-            ui.text(&session.session_id).fg(GRAY_400);
+            ui.text(text::sanitize_terminal(&session.session_id))
+                .fg(GRAY_400);
         });
         ui.line(|ui| {
             ui.text("  Time:     ").fg(GRAY_500);
@@ -2084,13 +2318,13 @@ fn ui_preview(ui: &mut slt::Context, app: &mut App) {
         if let Some(branch) = &session.git_branch {
             ui.line(|ui| {
                 ui.text("  Branch:   ").fg(GRAY_500);
-                ui.text(branch).fg(GREEN_400);
+                ui.text(text::sanitize_terminal(branch)).fg(GREEN_400);
             });
         }
         if let Some(wt) = &session.worktree {
             ui.line(|ui| {
                 ui.text("  Worktree: ").fg(GRAY_500);
-                ui.text(wt).fg(CYAN);
+                ui.text(text::sanitize_terminal(wt)).fg(CYAN);
             });
         }
 
@@ -2121,7 +2355,7 @@ fn ui_preview(ui: &mut slt::Context, app: &mut App) {
         }
 
         ui.text("");
-        ui.separator_colored(SEPARATOR);
+        let _ = ui.separator_colored(SEPARATOR);
         render_footer(
             ui,
             &[("↑↓", "cycle"), ("Enter", "actions"), ("Esc/←", "back")],
@@ -2169,11 +2403,13 @@ fn ui_help(ui: &mut slt::Context, app: &mut App) {
     if app.help_selected == 1 && (ui.key('+') || ui.key('=')) {
         app.summary_search_count = app.summary_search_count.saturating_add(1).min(50);
         app.save_settings();
+        app.update_filter();
     }
 
     if app.help_selected == 1 && ui.key('-') {
         app.summary_search_count = app.summary_search_count.saturating_sub(1).max(1);
         app.save_settings();
+        app.update_filter();
     }
 
     if app.help_selected == 2
@@ -2199,7 +2435,7 @@ fn ui_help(ui: &mut slt::Context, app: &mut App) {
         let _ = ui.container().pl(2).pr(1).col(|ui| {
             ui.text("Help & Settings").fg(BRIGHT_WHITE).bold();
         });
-        ui.separator_colored(SEPARATOR);
+        let _ = ui.separator_colored(SEPARATOR);
 
         let _ = ui.container().pl(2).pr(1).grow(1).col(|ui| {
             ui.text("").dim();
@@ -2320,7 +2556,7 @@ fn ui_help(ui: &mut slt::Context, app: &mut App) {
             ui.text(format!("  {config_path_str}")).fg(GRAY_500);
         });
 
-        ui.separator_colored(SEPARATOR);
+        let _ = ui.separator_colored(SEPARATOR);
         render_footer(
             ui,
             &[
@@ -2414,7 +2650,7 @@ fn render_session_list(ui: &mut slt::Context, app: &App, bulk_mode: bool) {
                 render_chunks(ui, chunks);
             });
         } else {
-            let is_pinned = app.pinned_sessions.contains(&session.session_id);
+            let is_pinned = app.is_pinned(session);
             let indicator = match (is_selected, is_pinned) {
                 (true, true) => ">*",
                 (true, false) => "> ",
@@ -2424,7 +2660,8 @@ fn render_session_list(ui: &mut slt::Context, app: &App, bulk_mode: bool) {
             let match_positions = app.match_positions.get(vi).map(Vec::as_slice);
             let summary_offset = app
                 .summary_offsets
-                .get(&session.session_id)
+                .get(&session.agent)
+                .and_then(|offsets| offsets.get(session.session_id.as_str()))
                 .copied()
                 .unwrap_or(0);
             let summary_text = if app.show_recap && summary_offset == 0 {
@@ -2472,7 +2709,12 @@ fn render_session_list_compact(ui: &mut slt::Context, app: &App) {
         } else {
             slt::Color::Reset
         };
-        let indicator = if is_selected { "> " } else { "  " };
+        let indicator = match (is_selected, app.is_pinned(session)) {
+            (true, true) => ">*",
+            (true, false) => "> ",
+            (false, true) => " *",
+            (false, false) => "  ",
+        };
 
         let _ = ui.row(|ui| {
             ui.styled(
@@ -2535,9 +2777,12 @@ fn build_session_row(
     let right_display_width = time_width + right_margin;
 
     let git_info_str = if let Some(wt) = &session.worktree {
-        Some(format!("  {wt}"))
+        Some(format!("  {}", text::sanitize_terminal(wt)))
     } else {
-        session.git_branch.as_ref().map(|b| format!("  {b}"))
+        session
+            .git_branch
+            .as_ref()
+            .map(|b| format!("  {}", text::sanitize_terminal(b)))
     };
     let git_info_width = git_info_str.as_deref().map_or(0, UnicodeWidthStr::width);
 
@@ -2546,12 +2791,13 @@ fn build_session_row(
     let max_proj =
         total_width.saturating_sub(fixed_left + right_display_width + git_info_width + 4);
     let col_width = name_col_width.min(max_proj);
+    let project_name = text::sanitize_terminal(&session.project_name);
     let proj_display = if col_width == 0 {
         String::new()
-    } else if text::width(&session.project_name) > col_width {
-        truncate_str(&session.project_name, col_width)
+    } else if text::width(&project_name) > col_width {
+        truncate_str(&project_name, col_width)
     } else {
-        text::pad(&session.project_name, col_width)
+        text::pad(&project_name, col_width)
     };
 
     if let Some(positions) = match_positions {
@@ -2676,6 +2922,7 @@ mod scroll_margin_tests {
                 git_branch: None,
                 worktree: None,
                 recap: None,
+                interactive: true,
             })
             .collect();
         App::new(
@@ -2742,6 +2989,14 @@ mod streaming_selection_tests {
             git_branch: None,
             worktree: None,
             recap: None,
+            interactive: true,
+        }
+    }
+
+    fn completed(sessions: Vec<Session>) -> crate::scanner::CompletedScan {
+        crate::scanner::CompletedScan {
+            sessions,
+            fingerprint: Some(crate::cache::SourceFingerprint::default()),
         }
     }
 
@@ -2774,7 +3029,7 @@ mod streaming_selection_tests {
 
         tx.send(ScanResult {
             agent: Agent::OpenCode,
-            sessions: vec![session(Agent::OpenCode, "opencode", 10)],
+            sessions: Ok(completed(vec![session(Agent::OpenCode, "opencode", 10)])),
         })
         .unwrap();
         app.ingest_scan_results();
@@ -2782,7 +3037,7 @@ mod streaming_selection_tests {
 
         tx.send(ScanResult {
             agent: Agent::ClaudeCode,
-            sessions: vec![session(Agent::ClaudeCode, "claude", 20)],
+            sessions: Ok(completed(vec![session(Agent::ClaudeCode, "claude", 20)])),
         })
         .unwrap();
         app.ingest_scan_results();
@@ -2807,7 +3062,7 @@ mod streaming_selection_tests {
 
         tx.send(ScanResult {
             agent: Agent::ClaudeCode,
-            sessions: vec![session(Agent::ClaudeCode, "claude", 30)],
+            sessions: Ok(completed(vec![session(Agent::ClaudeCode, "claude", 30)])),
         })
         .unwrap();
         app.ingest_scan_results();
@@ -2816,6 +3071,120 @@ mod streaming_selection_tests {
             app.selected_session().unwrap().session_id,
             "chosen-opencode"
         );
+    }
+
+    #[test]
+    fn failed_stream_preserves_stale_rows_and_marks_agent_failed() {
+        let (tx, rx) = mpsc::channel();
+        let mut app = make_app(
+            vec![session(Agent::Codex, "cached", 10)],
+            rx,
+            HashSet::from([Agent::Codex]),
+        );
+        tx.send(ScanResult {
+            agent: Agent::Codex,
+            sessions: Err("database is locked".into()),
+        })
+        .unwrap();
+        app.ingest_scan_results();
+        assert_eq!(app.sessions.len(), 1);
+        assert_eq!(app.sessions[0].session_id, "cached");
+        assert!(app.failed_agents.contains(&Agent::Codex));
+        assert!(!app.scanning_agents.contains(&Agent::Codex));
+    }
+
+    #[test]
+    fn action_target_never_drifts_when_refresh_removes_it() {
+        let (tx, rx) = mpsc::channel();
+        let mut app = make_app(
+            vec![
+                session(Agent::Codex, "chosen", 20),
+                session(Agent::Codex, "neighbor", 10),
+            ],
+            rx,
+            HashSet::from([Agent::Codex]),
+        );
+        app.apply_sort();
+        assert!(app.capture_active_session());
+        app.mode = Mode::ActionSelect;
+
+        tx.send(ScanResult {
+            agent: Agent::Codex,
+            sessions: Ok(completed(vec![session(Agent::Codex, "neighbor", 30)])),
+        })
+        .unwrap();
+        app.ingest_scan_results();
+
+        assert!(app.action_session().is_none());
+        assert_eq!(app.selected_session().unwrap().session_id, "neighbor");
+    }
+
+    #[test]
+    fn late_scan_cannot_resurrect_a_deleted_identity() {
+        let (tx, rx) = mpsc::channel();
+        let mut app = make_app(Vec::new(), rx, HashSet::from([Agent::Codex]));
+        app.deleted_tombstones
+            .entry(Agent::Codex)
+            .or_default()
+            .insert("deleted".to_string());
+        tx.send(ScanResult {
+            agent: Agent::Codex,
+            sessions: Ok(completed(vec![
+                session(Agent::Codex, "deleted", 30),
+                session(Agent::Codex, "keep", 20),
+            ])),
+        })
+        .unwrap();
+
+        app.ingest_scan_results();
+
+        assert!(
+            !app.sessions
+                .iter()
+                .any(|session| session.session_id == "deleted")
+        );
+        assert!(
+            app.sessions
+                .iter()
+                .any(|session| session.session_id == "keep")
+        );
+    }
+
+    #[test]
+    fn grouped_streaming_rebuilds_identity_rows_without_stale_indices() {
+        let (tx, rx) = mpsc::channel();
+        let mut chosen = session(Agent::OpenCode, "chosen", 10);
+        chosen.project_path = "/tmp/chosen".into();
+        chosen.project_name = "chosen".into();
+        let mut app = make_app(vec![chosen], rx, HashSet::from([Agent::ClaudeCode]));
+        app.mode = Mode::GroupedBrowse;
+        app.build_groups();
+        app.group_expanded.insert("/tmp/chosen".into());
+        app.grouped_selected = 1;
+
+        let mut incoming = session(Agent::ClaudeCode, "new", 20);
+        incoming.project_path = "/tmp/new".into();
+        incoming.project_name = "new".into();
+        tx.send(ScanResult {
+            agent: Agent::ClaudeCode,
+            sessions: Ok(completed(vec![incoming])),
+        })
+        .unwrap();
+        app.ingest_scan_results();
+
+        assert_eq!(
+            app.grouped_selection_identity(),
+            Some(GroupSelection::Session(SessionIdentity {
+                agent: Agent::OpenCode,
+                session_id: "chosen".into(),
+            }))
+        );
+        assert!(app.groups.iter().all(|group| {
+            group
+                .sessions
+                .iter()
+                .all(|identity| app.session_by_identity(identity).is_some())
+        }));
     }
 }
 
@@ -2834,6 +3203,7 @@ mod bulk_selection_tests {
             git_branch: None,
             worktree: None,
             recap: None,
+            interactive: true,
         }
     }
 
@@ -2894,11 +3264,10 @@ mod bulk_selection_tests {
         assert_eq!(app.selection_count(), 3);
     }
 
-    /// Regression: the incoming batch's length was recorded as the agent count
-    /// *before* `max_sessions` truncation, so the agent badge advertised
-    /// sessions that had just been dropped off the end of the list.
+    /// `max_sessions` is a presentation limit. It must not truncate the source
+    /// vector that is later persisted to cache.
     #[test]
-    fn merge_recounts_agents_after_max_sessions_truncation() {
+    fn max_sessions_limits_visible_rows_without_dropping_cache_rows() {
         let settings = crate::settings::Settings {
             max_sessions: Some(2),
             ..crate::settings::Settings::default()
@@ -2913,10 +3282,11 @@ mod bulk_selection_tests {
                 session(Agent::ClaudeCode, "claude-3", 70),
             ],
         );
+        app.apply_sort();
 
-        // Truncated to 2: codex-new (100) + claude-1 (90).
-        assert_eq!(app.sessions.len(), 2);
-        assert_eq!(app.agent_counts.get(&Agent::ClaudeCode), Some(&1));
+        assert_eq!(app.sessions.len(), 4);
+        assert_eq!(app.filtered_indices.len(), 2);
+        assert_eq!(app.agent_counts.get(&Agent::ClaudeCode), Some(&3));
         assert_eq!(app.agent_counts.get(&Agent::Codex), Some(&1));
         assert_eq!(
             app.agent_counts.values().sum::<usize>(),

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -1,3 +1,4 @@
+use std::io::IsTerminal;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, mpsc};
 use std::time::{Duration, Instant};
@@ -14,33 +15,87 @@ struct WatchState {
     scroll_offset: usize,
 }
 
-pub fn run_watch(interval_secs: u64) -> anyhow::Result<()> {
-    let sessions = scanner::scan_all();
-    let running_agents = detect_running_agents();
+type ScanBatch = Vec<(Agent, Result<crate::scanner::CompletedScan, String>)>;
+
+/// Replace only agents whose scanner completed successfully. A transient
+/// permission/SQLite error must not erase stale-but-useful rows in watch mode.
+fn merge_scan_batch(sessions: &mut Vec<Session>, batch: ScanBatch, include_non_interactive: bool) {
+    for (agent, result) in batch {
+        match result {
+            Ok(scan) => {
+                let mut new_sessions = scan.sessions;
+                if !include_non_interactive {
+                    new_sessions.retain(|session| session.interactive);
+                }
+                sessions.retain(|session| session.agent != agent);
+                sessions.extend(new_sessions);
+            }
+            Err(error) => {
+                if std::env::var("AGF_DEBUG").is_ok() {
+                    eprintln!("[agf] {agent} watch refresh failed: {error}");
+                }
+            }
+        }
+    }
+    sessions.sort_by(|a, b| crate::model::compare_sessions(a, b, crate::model::SortMode::Time));
+}
+
+pub fn run_watch(interval_secs: u64, include_non_interactive: bool) -> anyhow::Result<()> {
+    if !std::io::stdin().is_terminal() || !std::io::stdout().is_terminal() {
+        return Err(anyhow::anyhow!(
+            "watch requires terminal stdin and stdout; use `agf list` for pipelines"
+        ));
+    }
+    // Paint stale cache immediately; filesystem/SQLite scans and process
+    // probes run off the render thread even on the first frame.
+    let include_non_interactive =
+        include_non_interactive || crate::settings::Settings::load().include_non_interactive;
+    let (mut sessions, _) = crate::cache::load_cache();
+    if !include_non_interactive {
+        sessions.retain(|session| session.interactive);
+    }
 
     let mut state = WatchState {
         sessions,
-        running_agents,
+        running_agents: Vec::new(),
         last_refresh: Instant::now(),
         selected: 0,
         scroll_offset: 0,
     };
 
-    let (tx, rx) = mpsc::channel::<(Vec<Session>, Vec<Agent>)>();
-    let refreshing = Arc::new(AtomicBool::new(false));
+    let (tx, rx) = mpsc::channel::<(ScanBatch, Vec<Agent>)>();
+    let refreshing = Arc::new(AtomicBool::new(true));
+    {
+        let tx = tx.clone();
+        let refreshing = Arc::clone(&refreshing);
+        std::thread::spawn(move || {
+            let sessions = scanner::scan_agents_detailed(&crate::config::installed_agents());
+            let running = detect_running_agents();
+            let _ = tx.send((sessions, running));
+            refreshing.store(false, Ordering::SeqCst);
+        });
+    }
 
     slt::run_with(
         slt::RunConfig::default().title("agf watch").mouse(true),
         |ui: &mut slt::Context| {
             // Check for background refresh results
             if let Ok((new_sessions, new_running)) = rx.try_recv() {
-                state.sessions = new_sessions;
+                let selected_identity = state.sessions.get(state.selected).map(Session::identity);
+                merge_scan_batch(&mut state.sessions, new_sessions, include_non_interactive);
                 state.running_agents = new_running;
                 // Clamp the cursor: a refresh can shrink the list (sessions
                 // deleted elsewhere), and a stale `selected` past the end
                 // would push the scroll offset past the list and blank the
                 // viewport until the user pressed Up repeatedly.
-                state.selected = state.selected.min(state.sessions.len().saturating_sub(1));
+                state.selected = selected_identity
+                    .and_then(|identity| {
+                        state
+                            .sessions
+                            .iter()
+                            .position(|session| session.identity() == identity)
+                    })
+                    .unwrap_or_else(|| state.selected.min(state.sessions.len().saturating_sub(1)));
                 state.last_refresh = Instant::now();
             }
 
@@ -52,7 +107,8 @@ pub fn run_watch(interval_secs: u64) -> anyhow::Result<()> {
                 let tx = tx.clone();
                 let r = Arc::clone(&refreshing);
                 std::thread::spawn(move || {
-                    let sessions = scanner::scan_all();
+                    let sessions =
+                        scanner::scan_agents_detailed(&crate::config::installed_agents());
                     let running = detect_running_agents();
                     let _ = tx.send((sessions, running));
                     r.store(false, Ordering::SeqCst);
@@ -112,7 +168,7 @@ pub fn run_watch(interval_secs: u64) -> anyhow::Result<()> {
                     ui.text(format!("  {elapsed}s ago"))
                         .fg(slt::Color::Rgb(107, 114, 128));
                 });
-                ui.separator_colored(slt::Color::Rgb(64, 64, 64));
+                let _ = ui.separator_colored(slt::Color::Rgb(64, 64, 64));
 
                 let _ = ui.container().grow(1).pr(1).col(|ui| {
                     if state.sessions.is_empty() {
@@ -149,12 +205,12 @@ pub fn run_watch(interval_secs: u64) -> anyhow::Result<()> {
                                 slt::Style::new().fg(agent_color).bold().bg(bg),
                             );
                             ui.styled(
-                                text::fit(&s.project_name, 20),
+                                text::fit(&text::sanitize_terminal(&s.project_name), 20),
                                 slt::Style::new().fg(slt::Color::Rgb(229, 229, 229)).bg(bg),
                             );
                             if let Some(branch) = &s.git_branch {
                                 ui.styled(
-                                    format!("  {branch}"),
+                                    format!("  {}", text::sanitize_terminal(branch)),
                                     slt::Style::new().fg(slt::Color::Rgb(52, 211, 153)).bg(bg),
                                 );
                             }
@@ -166,7 +222,7 @@ pub fn run_watch(interval_secs: u64) -> anyhow::Result<()> {
                     }
                 });
 
-                ui.separator_colored(slt::Color::Rgb(64, 64, 64));
+                let _ = ui.separator_colored(slt::Color::Rgb(64, 64, 64));
                 let _ = ui.container().pr(1).row(|ui| {
                     ui.spacer();
                     let _ = ui.help_colored(
@@ -189,19 +245,80 @@ pub fn run_watch(interval_secs: u64) -> anyhow::Result<()> {
 /// required: the child's stdout must be captured, or it would paint over the
 /// TUI. Note this runs on the refresh worker thread, not the render path.
 fn detect_running_agents() -> Vec<Agent> {
-    let mut running = Vec::new();
-    for agent in crate::config::installed_agents() {
-        match std::process::Command::new("pgrep")
-            .args(["-x", agent.cli_name()])
-            .output()
-        {
-            Ok(output) if output.status.success() => running.push(agent),
-            // Ran, found nothing.
-            Ok(_) => {}
-            // `pgrep` itself is missing (Windows, minimal containers). Retrying
-            // it once per agent, every refresh tick, only burns process spawns.
-            Err(_) => break,
+    #[cfg(windows)]
+    return Vec::new();
+
+    #[cfg(not(windows))]
+    {
+        static PGREP_AVAILABLE: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+        if !*PGREP_AVAILABLE.get_or_init(|| {
+            std::process::Command::new("pgrep")
+                .arg("--version")
+                .output()
+                .is_ok()
+        }) {
+            return Vec::new();
+        }
+        let mut running = Vec::new();
+        for agent in crate::config::installed_agents() {
+            match std::process::Command::new("pgrep")
+                .args(["-x", agent.cli_name()])
+                .output()
+            {
+                Ok(output) if output.status.success() => running.push(agent),
+                // Ran, found nothing.
+                Ok(_) => {}
+                // `pgrep` itself is missing (Windows, minimal containers). Retrying
+                // it once per agent, every refresh tick, only burns process spawns.
+                Err(_) => break,
+            }
+        }
+        running
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn session(agent: Agent, id: &str, timestamp: i64) -> Session {
+        Session {
+            agent,
+            session_id: id.to_string(),
+            project_name: "project".to_string(),
+            project_path: "/tmp/project".to_string(),
+            summaries: Vec::new(),
+            timestamp,
+            git_branch: None,
+            worktree: None,
+            recap: None,
+            interactive: true,
         }
     }
-    running
+
+    #[test]
+    fn failed_watch_scan_preserves_stale_agent_rows() {
+        let mut sessions = vec![
+            session(Agent::ClaudeCode, "stale", 1),
+            session(Agent::Codex, "old", 2),
+        ];
+        merge_scan_batch(
+            &mut sessions,
+            vec![
+                (Agent::ClaudeCode, Err("locked".to_string())),
+                (
+                    Agent::Codex,
+                    Ok(crate::scanner::CompletedScan {
+                        sessions: vec![session(Agent::Codex, "fresh", 3)],
+                        fingerprint: Some(crate::cache::SourceFingerprint::default()),
+                    }),
+                ),
+            ],
+            false,
+        );
+
+        assert!(sessions.iter().any(|session| session.session_id == "stale"));
+        assert!(!sessions.iter().any(|session| session.session_id == "old"));
+        assert!(sessions.iter().any(|session| session.session_id == "fresh"));
+    }
 }


### PR DESCRIPTION
## Summary

Prepare AGF 0.14.0 as a correctness, performance, terminal-safety, and agent-coverage release.

- add Prime Agent discovery and exact resume support using the v0.7.2 session contract
- add real Kiro v3 metadata/event parsing and exact `--resume-id` behavior
- make Codex discovery read-only and hide non-interactive/subagent threads by default
- replace index-based TUI actions with stable `(agent, session_id)` identities
- harden cache freshness, stale-while-revalidate, cross-process writes, deletion truth, and terminal output
- upgrade SuperLightTUI to 0.22.3 and add Linux ARM64, MSRV, RustSec, and Windows gates

## Correctness and safety

- deterministic total ordering with one common timestamp-normalization boundary
- source fingerprints include nanosecond metadata, entry digests, SQLite WAL files, configurable roots, and all scanner inputs
- failed/partial scans preserve stale rows and are not persisted as authoritative empty results
- action/resume/delete targets remain stable while background scans reorder or remove sessions
- exact, bounded deletion with path guards and fail-closed Prime Agent deletion
- stdin/stdout TTY contracts, wrapper exit status preservation, ANSI/control/bidi sanitization, and symlink-safe atomic setup writes

## Performance

- CLI reuses validated per-agent cache and pushes agent filters into scan planning
- Codex uses `threads.rollout_path` instead of opening thousands of rollout files on current schemas
- Cursor indexes store databases once; JSONL readers have bounded per-line allocation; SQLite previews are bounded in SQL
- measured on the audited local store: forced Codex scan 0.10–0.12s at about 22.7MB RSS, versus the 0.13 baseline of 2.54s cold and 0.82–0.99s warm

## Verification

Exact frozen source passed:

- `cargo fmt --all -- --check`
- `cargo check --all-targets --all-features --locked`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- 163/163 debug tests and 163/163 release tests
- Rust 1.88 MSRV check
- `cargo audit` with 0 vulnerabilities across 146 dependencies
- release build and `cargo package` recompile
- CLI JSON/CSV ordering, Codex modes, non-TTY behavior, zsh/bash status preservation, `NO_COLOR`, and direct PTY TUI teardown

## Release follow-up

The Homebrew formula intentionally remains unchanged in this PR because v0.14.0 archive checksums do not exist before the tag workflow runs. After the five release assets are published, a follow-up PR will update the formula to 0.14.0 with four Unix checksums and Linux ARM CPU routing.

Closes #61
Closes #62
Closes #63
Closes #64
Closes #65
Closes #66
Closes #67
Closes #68
Closes #69
Closes #70
Closes #71
Closes #72
Closes #73
Closes #74
Partially addresses #75
Partially addresses #76