### PR TITLE
chore: update Homebrew formula for v0.14.0

### DIFF
--- a/homebrew/agf.rb
+++ b/homebrew/agf.rb
@@ -1,22 +1,27 @@
 class Agf < Formula
   desc "AI Agent Session Finder TUI — find, resume, and manage AI coding agent sessions"
   homepage "https://github.com/subinium/agf"
-  version "0.13.0"
+  version "0.14.0"
   license "MIT"
 
   on_macos do
     if Hardware::CPU.arm?
       url "https://github.com/subinium/agf/releases/download/v#{version}/agf-aarch64-apple-darwin.tar.gz"
-      sha256 "61e4377dc4164fbb1009e467d1cfe1219d32bfa382a99c1b7f6c955576a78ba2"
+      sha256 "0623218e27e508654c037343d46a043ee1e8e22ae1255426932f2d19d11ed49a"
     else
       url "https://github.com/subinium/agf/releases/download/v#{version}/agf-x86_64-apple-darwin.tar.gz"
-      sha256 "9bdb2ad5c3ca46150f743ae00fc0848386a24f5cf1f0fe846d667838cb895864"
+      sha256 "3566ac25262203155791c6d9b27c58f3876cb90e156004b9a2ea1b146b70f568"
     end
   end
 
   on_linux do
-    url "https://github.com/subinium/agf/releases/download/v#{version}/agf-x86_64-unknown-linux-gnu.tar.gz"
-    sha256 "11d0d8e43faf051066d391a9b4c7b4dec0418a9d2921ca00bfb8396efc3fe302"
+    if Hardware::CPU.arm?
+      url "https://github.com/subinium/agf/releases/download/v#{version}/agf-aarch64-unknown-linux-gnu.tar.gz"
+      sha256 "addfbceb61ff04d6b3c56451f0e40ab009e7ec896d1f3f171139832b4da4e780"
+    else
+      url "https://github.com/subinium/agf/releases/download/v#{version}/agf-x86_64-unknown-linux-gnu.tar.gz"
+      sha256 "3b22d41063c6ea4679c59c11936b427ab7610e72b9c5b08e28d86eadae2c74a0"
+    end
   end
 
   def install


### PR DESCRIPTION
Updates the bundled Homebrew formula to the published v0.14.0 release checksums. Adds Linux ARM64 selection alongside Linux x86_64. Verified against the release checksums manifest, the downloaded Apple ARM64 asset, agf --version, and Ruby syntax. Closes #76.