### PR TITLE
release: agf v0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## [Unreleased]
 
+## [0.14.1] - 2026-08-18
+
+### Added
+
+- **Grok Build support** — discovers official xAI Grok sessions under `$GROK_HOME/sessions` (default `~/.grok/sessions`), reads durable activity/title/recap/git/worktree metadata from `summary.json`, filters hidden subagents by default, and resumes the exact selected ID with `grok --resume`.
+- **Kimi Code support** — discovers v1 ISO-timestamp and v2 epoch-ms `state.json` sessions under `$KIMI_CODE_HOME/sessions` (default `~/.kimi-code/sessions`), uses `session_index.jsonl` to recover migrated legacy working directories, and resumes with `kimi --session`.
+- **Qwen Code support** — discovers current `projects/*/chats` and legacy `tmp/*/chats` JSONL sessions, honors `QWEN_RUNTIME_DIR`, `QWEN_HOME`, and `advanced.runtimeOutputDir`, surfaces custom titles/first prompts/branches, and resumes with `qwen --resume`.
+
+### Fixed
+
+- The New Session permission picker now uses the same current flag definitions as Resume, removing a second stale Codex flag table and automatically keeping Kimi permission modes consistent.
+
+### Performance and safety
+
+- Qwen scanning reads at most a bounded head window plus 64 KiB title windows, including a safe oversized-first-prompt fallback; it never materializes whole multi-megabyte transcripts merely to render the list.
+- Grok and Kimi metadata documents have explicit size bounds, and all three scanners propagate directory/read failures so a partial scan cannot replace valid stale cache rows.
+- Direct AGF deletion is fail-closed for Grok, Kimi, and Qwen because their native tools coordinate active sessions and secondary indexes that a file-only delete would bypass; the single-delete action is hidden and bulk mode marks these rows as unavailable.
+
 ## [0.14.0] - 2026-08-15
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agf"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "agf"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2024"
 # 1.88 = let-chains (edition 2024); also covers usize::is_multiple_of (1.87).
 rust-version = "1.88"
-description = "Find and resume local AI coding-agent sessions across Claude Code, Codex, Prime Agent, Gemini, Cursor CLI, OpenCode, Kiro, pi, Hermes, Oh My Pi, and Yolop"
+description = "Find and resume local AI coding-agent sessions across Claude Code, Codex, Grok, Kimi, Qwen, Prime Agent, Gemini, Cursor CLI, OpenCode, Kiro, pi, Hermes, Oh My Pi, and Yolop"
 license = "MIT"
 repository = "https://github.com/subinium/agf"
 keywords = ["tui", "cli", "agent", "session", "claude"]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 > Find the AI coding session you meant to resume.
 
 `agf` is a local-first fuzzy finder for AI coding-agent sessions.
-Search local sessions across **Claude Code**, **Codex**, **Prime Agent**, **Gemini CLI**, **Cursor CLI**, **OpenCode**, **Kiro**, **pi**, and **Hermes** — then resume the right one in a keystroke.
+Search the sessions your terminal agents already keep locally, then resume the right one in a keystroke.
 
 ![agf demo](./assets/demo.gif)
 
@@ -45,6 +45,9 @@ Then you either dig through history files or start over.
 |:---|:---|:---|
 | [Claude Code](https://github.com/anthropics/claude-code) | `claude --resume <id>` | `~/.claude/history.jsonl` + `~/.claude/projects/` |
 | [Codex](https://github.com/openai/codex) | `codex resume <id>` | `~/.codex/sessions/**/*.jsonl` |
+| [Grok Build](https://github.com/xai-org/grok-build) | `grok --resume <id>` | `$GROK_HOME/sessions/` or `~/.grok/sessions/` |
+| [Kimi Code](https://github.com/MoonshotAI/kimi-code) | `kimi --session <id>` | `$KIMI_CODE_HOME/sessions/` or `~/.kimi-code/sessions/` |
+| [Qwen Code](https://github.com/QwenLM/qwen-code) | `qwen --resume <id>` | `$QWEN_RUNTIME_DIR/projects/` or `~/.qwen/projects/` |
 | [Prime Agent](https://github.com/PrimeIntellect-ai/prime-agent) | `prime-agent --resume <id>` | `~/.prime/agent/sessions/<id>.jsonl` |
 | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `gemini --resume <id>` | `~/.gemini/tmp/<project>/chats/session-*.json` |
 | [Cursor CLI](https://cursor.com/docs/cli/overview) | `cursor-agent --resume <id>` | `~/.cursor/projects/*/agent-transcripts/<id>/<id>.jsonl` (Composer 2+)<br>`~/.cursor/projects/*/agent-transcripts/<id>.txt` (legacy) |
@@ -62,6 +65,9 @@ Then you either dig through history files or start over.
 |:---|:---|:---|
 | Claude Code | JSONL | `~/.claude/history.jsonl` (sessions)<br>`~/.claude/projects/*/` (worktree detection) |
 | Codex | JSONL | `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl` |
+| Grok Build | JSON + JSONL | `$GROK_HOME/sessions/<encoded-cwd>/<id>/summary.json` (default `~/.grok`)<br>Activity, title, recap, branch, and worktree metadata come from the bounded summary document |
+| Kimi Code | JSON + JSONL | `$KIMI_CODE_HOME/sessions/<workDirKey>/<id>/state.json` (default `~/.kimi-code`)<br>`session_index.jsonl` supplies cwd fallback for migrated legacy sessions |
+| Qwen Code | JSONL | `$QWEN_RUNTIME_DIR/projects/<project>/chats/<id>.jsonl`<br>Defaults to `$QWEN_HOME` or `~/.qwen`; `advanced.runtimeOutputDir` and legacy `tmp/<project>/chats/` are also supported |
 | Prime Agent | JSONL | `~/.prime/agent/sessions/<id>.jsonl` (also honors Prime Agent environment/global settings overrides) |
 | OpenCode | SQLite | `~/.local/share/opencode/opencode.db` |
 | pi | JSONL | `~/.pi/agent/sessions/--<encoded-cwd>--/<ts>_<id>.jsonl` |
@@ -173,7 +179,7 @@ See [CHANGELOG.md](CHANGELOG.md) for release notes.
 ## Requirements
 
 - macOS, Linux, or Windows (PowerShell 5.1+ / PowerShell 7+)
-- One or more of: `claude`, `codex`, `prime-agent`, `opencode`, `pi`, `kiro-cli`, `cursor-agent`, `gemini`, `hermes`, `omp`, `yolop`
+- One or more of: `claude`, `codex`, `grok`, `kimi`, `qwen`, `prime-agent`, `opencode`, `pi`, `kiro-cli`, `cursor-agent`, `gemini`, `hermes`, `omp`, `yolop`
 
 ## Install from source
 
@@ -188,7 +194,7 @@ agf setup
 
 `agf` works best with agents that store resumable sessions locally.
 
-Prime Agent session discovery and resume are supported, but deletion is intentionally disabled: Prime Agent has no public session-delete command and direct file deletion would bypass its active-daemon guard.
+Direct deletion is intentionally disabled for Prime Agent, Grok Build, Kimi Code, and Qwen Code. Their native pickers coordinate active sessions and/or secondary indexes; deleting only the visible file from AGF could leave corrupted or stale upstream state. Discovery and exact-ID resume remain fully supported.
 
 **Amp** is not supported yet because its sessions are stored remotely, which makes it hard to reliably resolve local project paths from session metadata. We are monitoring upstream changes and will add support when feasible.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,6 +17,69 @@ pub fn codex_dir() -> Result<PathBuf, AgfError> {
     Ok(home_dir()?.join(".codex"))
 }
 
+pub fn grok_dir() -> Result<PathBuf, AgfError> {
+    if let Some(path) = std::env::var_os("GROK_HOME").filter(|path| !path.is_empty()) {
+        return resolve_configured_path(PathBuf::from(path));
+    }
+    Ok(home_dir()?.join(".grok"))
+}
+
+pub fn kimi_code_dir() -> Result<PathBuf, AgfError> {
+    if let Some(path) = std::env::var_os("KIMI_CODE_HOME").filter(|path| !path.is_empty()) {
+        return resolve_configured_path(PathBuf::from(path));
+    }
+    Ok(home_dir()?.join(".kimi-code"))
+}
+
+pub fn qwen_global_dir() -> Result<PathBuf, AgfError> {
+    if let Some(path) = std::env::var_os("QWEN_HOME").filter(|path| !path.is_empty()) {
+        return resolve_configured_path(PathBuf::from(path));
+    }
+    Ok(home_dir()?.join(".qwen"))
+}
+
+pub fn qwen_runtime_dir() -> Result<PathBuf, AgfError> {
+    if let Some(path) = std::env::var_os("QWEN_RUNTIME_DIR").filter(|path| !path.is_empty()) {
+        return resolve_configured_path(PathBuf::from(path));
+    }
+    let global = qwen_global_dir()?;
+    let cwd = std::env::current_dir()?;
+    qwen_runtime_dir_from_settings(&global, &cwd)
+}
+
+fn qwen_runtime_dir_from_settings(
+    global_dir: &std::path::Path,
+    cwd: &std::path::Path,
+) -> Result<PathBuf, AgfError> {
+    let mut configured = None;
+    for settings_path in [
+        global_dir.join("settings.json"),
+        cwd.join(".qwen/settings.json"),
+    ] {
+        let Some(path) = std::fs::read_to_string(settings_path)
+            .ok()
+            .and_then(|content| serde_json::from_str::<serde_json::Value>(&content).ok())
+            .and_then(|settings| {
+                settings
+                    .pointer("/advanced/runtimeOutputDir")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::trim)
+                    .filter(|path| !path.is_empty())
+                    .map(PathBuf::from)
+            })
+        else {
+            continue;
+        };
+        configured = Some(path);
+    }
+    match configured {
+        // Qwen resolves both user and workspace relative values from the
+        // active project root; workspace settings override user settings.
+        Some(path) => resolve_configured_path_from(path, cwd),
+        None => Ok(global_dir.to_path_buf()),
+    }
+}
+
 pub fn opencode_data_dir() -> Result<PathBuf, AgfError> {
     Ok(home_dir()?.join(".local/share/opencode"))
 }
@@ -159,6 +222,100 @@ fn sqlite_sources(path: PathBuf) -> Vec<PathBuf> {
     vec![path, wal]
 }
 
+fn grok_summary_sources() -> Vec<PathBuf> {
+    let Ok(root) = grok_dir().map(|dir| dir.join("sessions")) else {
+        return Vec::new();
+    };
+    // A non-existent marker keeps the configured root identity in the
+    // fingerprint without recursively walking every rewind/checkpoint file.
+    let mut sources = vec![root.join(".agf-session-root")];
+    let Ok(cwds) = std::fs::read_dir(&root) else {
+        return sources;
+    };
+    for cwd in cwds
+        .flatten()
+        .filter(|entry| entry.file_type().is_ok_and(|kind| kind.is_dir()))
+    {
+        let Ok(sessions) = std::fs::read_dir(cwd.path()) else {
+            continue;
+        };
+        for session in sessions
+            .flatten()
+            .filter(|entry| entry.file_type().is_ok_and(|kind| kind.is_dir()))
+        {
+            let summary = session.path().join("summary.json");
+            if summary.is_file() {
+                sources.push(summary);
+            }
+        }
+    }
+    sources
+}
+
+fn kimi_state_sources() -> Vec<PathBuf> {
+    let Ok(home) = kimi_code_dir() else {
+        return Vec::new();
+    };
+    let root = home.join("sessions");
+    let mut sources = vec![
+        home.join("session_index.jsonl"),
+        root.join(".agf-session-root"),
+    ];
+    let Ok(workspaces) = std::fs::read_dir(&root) else {
+        return sources;
+    };
+    for workspace in workspaces
+        .flatten()
+        .filter(|entry| entry.file_type().is_ok_and(|kind| kind.is_dir()))
+    {
+        let Ok(sessions) = std::fs::read_dir(workspace.path()) else {
+            continue;
+        };
+        for session in sessions
+            .flatten()
+            .filter(|entry| entry.file_type().is_ok_and(|kind| kind.is_dir()))
+        {
+            let direct = session.path().join("state.json");
+            let legacy = session.path().join("session-meta/state.json");
+            if direct.is_file() {
+                sources.push(direct);
+            } else if legacy.is_file() {
+                sources.push(legacy);
+            }
+        }
+    }
+    sources
+}
+
+fn qwen_chat_sources(root: &std::path::Path) -> Vec<PathBuf> {
+    let mut sources = vec![root.join(".agf-session-root")];
+    let Ok(projects) = std::fs::read_dir(root) else {
+        return sources;
+    };
+    for project in projects
+        .flatten()
+        .filter(|entry| entry.file_type().is_ok_and(|kind| kind.is_dir()))
+    {
+        let chats = project.path().join("chats");
+        let Ok(entries) = std::fs::read_dir(chats) else {
+            continue;
+        };
+        sources.extend(
+            entries
+                .flatten()
+                .filter_map(|entry| {
+                    entry
+                        .file_type()
+                        .ok()
+                        .filter(|kind| kind.is_file())
+                        .map(|_| entry.path())
+                })
+                .filter(|path| path.extension().and_then(|ext| ext.to_str()) == Some("jsonl")),
+        );
+    }
+    sources
+}
+
 /// Paths whose newest mtime decides whether `agent`'s cache entry is still
 /// fresh (see `cache::load_cache`).
 ///
@@ -194,6 +351,22 @@ pub fn data_sources(agent: Agent) -> Vec<PathBuf> {
                 sources
             })
             .unwrap_or_default(),
+        Agent::Grok => grok_summary_sources(),
+        Agent::Kimi => kimi_state_sources(),
+        Agent::Qwen => {
+            let mut sources = Vec::new();
+            if let Ok(global) = qwen_global_dir() {
+                sources.push(global.join("settings.json"));
+            }
+            if let Ok(cwd) = std::env::current_dir() {
+                sources.push(cwd.join(".qwen/settings.json"));
+            }
+            if let Ok(dir) = qwen_runtime_dir() {
+                sources.extend(qwen_chat_sources(&dir.join("projects")));
+                sources.extend(qwen_chat_sources(&dir.join("tmp")));
+            }
+            sources
+        }
         Agent::OpenCode => opencode_data_dir()
             .map(|d| sqlite_sources(d.join("opencode.db")))
             .unwrap_or_default(),
@@ -329,6 +502,30 @@ pub fn installed_agents() -> Vec<Agent> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn qwen_workspace_runtime_dir_overrides_user_and_resolves_from_cwd() {
+        let root = std::env::temp_dir().join(format!("agf-qwen-settings-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        let global = root.join("global");
+        let cwd = root.join("project");
+        std::fs::create_dir_all(cwd.join(".qwen")).unwrap();
+        std::fs::create_dir_all(&global).unwrap();
+        std::fs::write(
+            global.join("settings.json"),
+            r#"{"advanced":{"runtimeOutputDir":"user-runtime"}}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            cwd.join(".qwen/settings.json"),
+            r#"{"advanced":{"runtimeOutputDir":"workspace-runtime"}}"#,
+        )
+        .unwrap();
+
+        let resolved = qwen_runtime_dir_from_settings(&global, &cwd).unwrap();
+        assert_eq!(resolved, cwd.join("workspace-runtime"));
+        let _ = std::fs::remove_dir_all(root);
+    }
 
     #[test]
     fn prime_project_settings_override_global_and_resolve_from_cwd() {

--- a/src/delete.rs
+++ b/src/delete.rs
@@ -82,6 +82,18 @@ fn delete_agent_sessions(agent: Agent, ids: &HashSet<&str>) -> Result<HashSet<St
     match agent {
         Agent::ClaudeCode => delete_claude_sessions(ids),
         Agent::Codex => delete_codex_sessions(ids),
+        Agent::Grok => Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "Grok deletion is disabled: use Grok Build's session picker so its search index and active-session state stay consistent",
+        )),
+        Agent::Kimi => Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "Kimi deletion is disabled: use Kimi Code's session picker so session_index.jsonl stays consistent",
+        )),
+        Agent::Qwen => Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "Qwen deletion is disabled: use Qwen Code's /delete command so active and archived state stay consistent",
+        )),
         Agent::OpenCode => delete_opencode_sessions(ids),
         Agent::Pi => {
             delete_pi_style_sessions(&config::pi_sessions_dir().map_err(io::Error::other)?, ids)

--- a/src/model.rs
+++ b/src/model.rs
@@ -12,6 +12,9 @@ use crate::shell::CommandShell;
 pub enum Agent {
     ClaudeCode,
     Codex,
+    Grok,
+    Kimi,
+    Qwen,
     OpenCode,
     Pi,
     OhMyPi,
@@ -28,6 +31,9 @@ impl fmt::Display for Agent {
         match self {
             Agent::ClaudeCode => write!(f, "Claude Code"),
             Agent::Codex => write!(f, "Codex"),
+            Agent::Grok => write!(f, "Grok Build"),
+            Agent::Kimi => write!(f, "Kimi Code"),
+            Agent::Qwen => write!(f, "Qwen Code"),
             Agent::OpenCode => write!(f, "OpenCode"),
             Agent::Pi => write!(f, "pi"),
             Agent::OhMyPi => write!(f, "Oh My Pi"),
@@ -46,6 +52,9 @@ impl Agent {
         match self {
             Agent::ClaudeCode => (217, 119, 87), // #D97757 terra cotta (Anthropic)
             Agent::Codex => (0, 166, 126),       // #00A67E teal green (OpenAI)
+            Agent::Grok => (229, 229, 229),      // xAI monochrome
+            Agent::Kimi => (74, 120, 255),       // Kimi blue
+            Agent::Qwen => (121, 93, 255),       // Qwen violet
             Agent::OpenCode => (59, 130, 246),   // #3B82F6 blue
             Agent::Pi => (236, 72, 153),         // #EC4899 pink
             Agent::OhMyPi => (249, 115, 22),     // #F97316 orange
@@ -62,6 +71,9 @@ impl Agent {
         &[
             Agent::ClaudeCode,
             Agent::Codex,
+            Agent::Grok,
+            Agent::Kimi,
+            Agent::Qwen,
             Agent::OpenCode,
             Agent::Pi,
             Agent::OhMyPi,
@@ -79,6 +91,9 @@ impl Agent {
         match self {
             Agent::ClaudeCode => "claude",
             Agent::Codex => "codex",
+            Agent::Grok => "grok",
+            Agent::Kimi => "kimi",
+            Agent::Qwen => "qwen",
             Agent::OpenCode => "opencode",
             Agent::Pi => "pi",
             Agent::OhMyPi => "omp",
@@ -102,6 +117,9 @@ impl Agent {
         match self {
             Agent::ClaudeCode => format!("claude --resume {id}"),
             Agent::Codex => format!("codex resume {id}"),
+            Agent::Grok => format!("grok --resume {id}"),
+            Agent::Kimi => format!("kimi --session {id}"),
+            Agent::Qwen => format!("qwen --resume {id}"),
             Agent::OpenCode => format!("opencode -s {id}"),
             Agent::Pi => format!("pi --session {id}"),
             Agent::OhMyPi => format!("omp --resume {id}"),
@@ -139,6 +157,12 @@ impl Agent {
                 ("plan (read-only)", " --approval-mode plan"),
                 ("sandbox", " -s"),
             ],
+            Agent::Kimi => &[
+                ("default", ""),
+                ("auto", " --auto"),
+                ("plan (read-only)", " --plan"),
+                ("yolo (no approval)", " --yolo"),
+            ],
             _ => &[("default", "")],
         }
     }
@@ -148,6 +172,9 @@ impl Agent {
         match self {
             Agent::ClaudeCode => "claude",
             Agent::Codex => "codex",
+            Agent::Grok => "grok",
+            Agent::Kimi => "kimi",
+            Agent::Qwen => "qwen",
             Agent::OpenCode => "opencode",
             Agent::Pi => "pi",
             Agent::OhMyPi => "omp",
@@ -165,6 +192,9 @@ impl Agent {
         match self {
             Agent::ClaudeCode => "claude",
             Agent::Codex => "codex",
+            Agent::Grok => "grok",
+            Agent::Kimi => "kimi",
+            Agent::Qwen => "qwen",
             Agent::OpenCode => "opencode",
             Agent::Pi => "pi",
             Agent::OhMyPi => "oh-my-pi",
@@ -182,6 +212,9 @@ impl Agent {
         match normalized.as_str() {
             "claude" | "claude-code" => Some(Agent::ClaudeCode),
             "codex" => Some(Agent::Codex),
+            "grok" | "grok-build" | "xai" | "xai-grok" => Some(Agent::Grok),
+            "kimi" | "kimi-code" | "kimi-cli" => Some(Agent::Kimi),
+            "qwen" | "qwen-code" => Some(Agent::Qwen),
             "opencode" | "open-code" => Some(Agent::OpenCode),
             "pi" => Some(Agent::Pi),
             "omp" | "oh-my-pi" | "ohmypi" => Some(Agent::OhMyPi),
@@ -193,6 +226,13 @@ impl Agent {
             "prime" | "prime-agent" | "prime-intellect" => Some(Agent::PrimeAgent),
             _ => None,
         }
+    }
+
+    pub fn supports_delete(self) -> bool {
+        !matches!(
+            self,
+            Agent::Grok | Agent::Kimi | Agent::Qwen | Agent::PrimeAgent
+        )
     }
 }
 
@@ -481,6 +521,28 @@ mod tests {
             Agent::PrimeAgent.resume_cmd("prime-session", &shell),
             "prime-agent --resume 'prime-session'"
         );
+    }
+
+    #[test]
+    fn grok_kimi_and_qwen_resume_commands_keep_the_selected_id() {
+        let shell = CommandShell::Posix;
+        assert_eq!(
+            Agent::Grok.resume_cmd("grok-session", &shell),
+            "grok --resume 'grok-session'"
+        );
+        assert_eq!(
+            Agent::Kimi.resume_cmd("kimi-session", &shell),
+            "kimi --session 'kimi-session'"
+        );
+        assert_eq!(
+            Agent::Qwen.resume_cmd("qwen-session", &shell),
+            "qwen --resume 'qwen-session'"
+        );
+        assert!(!Agent::Grok.supports_delete());
+        assert!(!Agent::Kimi.supports_delete());
+        assert!(!Agent::Qwen.supports_delete());
+        assert!(!Agent::PrimeAgent.supports_delete());
+        assert!(Agent::Codex.supports_delete());
     }
 
     #[test]

--- a/src/scanner/grok.rs
+++ b/src/scanner/grok.rs
@@ -1,0 +1,214 @@
+use std::io::Read;
+use std::path::Path;
+
+use serde_json::Value;
+
+use crate::error::AgfError;
+use crate::model::{Agent, Session};
+
+use super::{collapse_whitespace, project_name_from_path, truncate};
+
+const MAX_SUMMARY_BYTES: u64 = 2 * 1024 * 1024;
+
+pub fn scan() -> Result<Vec<Session>, AgfError> {
+    scan_from(&crate::config::grok_dir()?.join("sessions"))
+}
+
+fn scan_from(root: &Path) -> Result<Vec<Session>, AgfError> {
+    if !root.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut sessions = Vec::new();
+    for cwd_entry in std::fs::read_dir(root)? {
+        let cwd_entry = cwd_entry?;
+        if !cwd_entry.file_type()?.is_dir() {
+            continue;
+        }
+        for session_entry in std::fs::read_dir(cwd_entry.path())? {
+            let session_entry = session_entry?;
+            if !session_entry.file_type()?.is_dir() {
+                continue;
+            }
+            let summary_path = session_entry.path().join("summary.json");
+            if !summary_path.is_file() {
+                continue;
+            }
+            if let Some(session) = parse_summary(&summary_path)? {
+                sessions.push(session);
+            }
+        }
+    }
+    sessions.sort_by(|a, b| crate::model::compare_sessions(a, b, crate::model::SortMode::Time));
+    Ok(sessions)
+}
+
+fn parse_summary(path: &Path) -> Result<Option<Session>, AgfError> {
+    let metadata = path.metadata()?;
+    if metadata.len() > MAX_SUMMARY_BYTES {
+        return Ok(None);
+    }
+    let mut content = String::with_capacity(metadata.len() as usize);
+    std::fs::File::open(path)?
+        .take(MAX_SUMMARY_BYTES + 1)
+        .read_to_string(&mut content)?;
+    let Ok(summary) = serde_json::from_str::<Value>(&content) else {
+        return Ok(None);
+    };
+
+    let Some(directory_id) = path
+        .parent()
+        .and_then(Path::file_name)
+        .and_then(|name| name.to_str())
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+    else {
+        return Ok(None);
+    };
+    let Some(stored_id) = summary
+        .pointer("/info/id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+    else {
+        return Ok(None);
+    };
+    // Grok resumes by the directory/session id. A mismatched summary is not a
+    // trustworthy resume target and must not surface under either identity.
+    if stored_id != directory_id {
+        return Ok(None);
+    }
+    let Some(project_path) = summary
+        .pointer("/info/cwd")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|cwd| !cwd.is_empty())
+        .map(str::to_string)
+    else {
+        return Ok(None);
+    };
+
+    let mut summaries = Vec::new();
+    for pointer in ["/generated_title", "/session_summary", "/last_turn_summary"] {
+        let Some(text) = summary
+            .pointer(pointer)
+            .and_then(Value::as_str)
+            .map(collapse_whitespace)
+            .filter(|text| !text.is_empty())
+            .map(|text| truncate(&text, 200))
+        else {
+            continue;
+        };
+        if !summaries.contains(&text) {
+            summaries.push(text);
+        }
+    }
+
+    let file_time = metadata
+        .modified()
+        .ok()
+        .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|duration| i64::try_from(duration.as_millis()).unwrap_or(i64::MAX))
+        .unwrap_or(0);
+    let timestamp = ["/last_active_at", "/updated_at", "/created_at"]
+        .into_iter()
+        .find_map(|pointer| parse_timestamp(summary.pointer(pointer)))
+        .unwrap_or(file_time);
+    let session_kind = summary
+        .get("session_kind")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let hidden = summary.get("hidden").and_then(Value::as_bool) == Some(true);
+
+    Ok(Some(Session {
+        agent: Agent::Grok,
+        session_id: directory_id.to_string(),
+        project_name: project_name_from_path(&project_path),
+        project_path,
+        summaries,
+        timestamp,
+        git_branch: summary
+            .get("head_branch")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        worktree: summary
+            .get("worktree_label")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        recap: summary
+            .get("last_recap")
+            .and_then(Value::as_str)
+            .map(collapse_whitespace)
+            .filter(|recap| !recap.is_empty())
+            .map(|recap| truncate(&recap, 400)),
+        interactive: !hidden && !matches!(session_kind, "subagent" | "subagent_fork"),
+    }))
+}
+
+fn parse_timestamp(value: Option<&Value>) -> Option<i64> {
+    match value? {
+        Value::String(timestamp) => chrono::DateTime::parse_from_rfc3339(timestamp)
+            .ok()
+            .map(|timestamp| timestamp.timestamp_millis()),
+        Value::Number(timestamp) => timestamp.as_i64().map(epoch_millis),
+        _ => None,
+    }
+    .filter(|timestamp| *timestamp > 0)
+}
+
+fn epoch_millis(timestamp: i64) -> i64 {
+    if timestamp.unsigned_abs() < 10_000_000_000 {
+        timestamp.saturating_mul(1000)
+    } else {
+        timestamp
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_official_summary_fields_and_activity_precedence() {
+        let root = std::env::temp_dir().join(format!("agf-grok-scan-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        let session_dir = root.join("encoded-cwd").join("019c-grok-session");
+        std::fs::create_dir_all(&session_dir).unwrap();
+        std::fs::write(
+            session_dir.join("summary.json"),
+            r#"{
+              "info":{"id":"019c-grok-session","cwd":"/work/grok-project"},
+              "session_summary":"Initial title",
+              "generated_title":"Fix cache races",
+              "created_at":"2026-08-01T00:00:00Z",
+              "updated_at":"2026-08-02T00:00:00Z",
+              "last_active_at":"2026-08-03T04:05:06Z",
+              "head_branch":"fix/cache",
+              "worktree_label":"cache-wt",
+              "last_turn_summary":"Added a regression test",
+              "last_recap":"The scanner is ready for review"
+            }"#,
+        )
+        .unwrap();
+
+        let sessions = scan_from(&root).unwrap();
+        assert_eq!(sessions.len(), 1);
+        let session = &sessions[0];
+        assert_eq!(session.agent, Agent::Grok);
+        assert_eq!(session.project_name, "grok-project");
+        assert_eq!(session.summaries[0], "Fix cache races");
+        assert_eq!(session.git_branch.as_deref(), Some("fix/cache"));
+        assert_eq!(session.worktree.as_deref(), Some("cache-wt"));
+        assert_eq!(
+            session.timestamp,
+            chrono::DateTime::parse_from_rfc3339("2026-08-03T04:05:06Z")
+                .unwrap()
+                .timestamp_millis()
+        );
+        assert_eq!(
+            session.recap.as_deref(),
+            Some("The scanner is ready for review")
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+}

--- a/src/scanner/kimi.rs
+++ b/src/scanner/kimi.rs
@@ -1,0 +1,277 @@
+use std::collections::HashMap;
+use std::io::Read;
+use std::path::Path;
+
+use serde_json::Value;
+
+use crate::error::AgfError;
+use crate::model::{Agent, Session};
+
+use super::{collapse_whitespace, for_each_bounded_line, project_name_from_path, truncate};
+
+const MAX_STATE_BYTES: u64 = 2 * 1024 * 1024;
+const MAX_INDEX_LINE_BYTES: usize = 64 * 1024;
+
+pub fn scan() -> Result<Vec<Session>, AgfError> {
+    let home = crate::config::kimi_code_dir()?;
+    scan_from(&home.join("sessions"), &home.join("session_index.jsonl"))
+}
+
+fn scan_from(sessions_root: &Path, index_path: &Path) -> Result<Vec<Session>, AgfError> {
+    if !sessions_root.exists() {
+        return Ok(Vec::new());
+    }
+    let indexed_workdirs = read_index_workdirs(index_path)?;
+    let mut sessions = Vec::new();
+    for workspace_entry in std::fs::read_dir(sessions_root)? {
+        let workspace_entry = workspace_entry?;
+        if !workspace_entry.file_type()?.is_dir() {
+            continue;
+        }
+        for session_entry in std::fs::read_dir(workspace_entry.path())? {
+            let session_entry = session_entry?;
+            if !session_entry.file_type()?.is_dir() {
+                continue;
+            }
+            let session_dir = session_entry.path();
+            let state_path = if session_dir.join("state.json").is_file() {
+                session_dir.join("state.json")
+            } else {
+                session_dir.join("session-meta/state.json")
+            };
+            if !state_path.is_file() {
+                continue;
+            }
+            let fallback_workdir = session_entry
+                .file_name()
+                .to_str()
+                .and_then(|id| indexed_workdirs.get(id));
+            if let Some(session) = parse_state(&state_path, fallback_workdir)? {
+                sessions.push(session);
+            }
+        }
+    }
+    sessions.sort_by(|a, b| crate::model::compare_sessions(a, b, crate::model::SortMode::Time));
+    Ok(sessions)
+}
+
+fn read_index_workdirs(path: &Path) -> Result<HashMap<String, String>, AgfError> {
+    let mut workdirs = HashMap::new();
+    if !path.exists() {
+        return Ok(workdirs);
+    }
+    let read_ok = for_each_bounded_line(path, usize::MAX, MAX_INDEX_LINE_BYTES, |line| {
+        let Ok(record) = serde_json::from_slice::<Value>(line) else {
+            return;
+        };
+        let Some(id) = record
+            .get("sessionId")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|id| !id.is_empty())
+        else {
+            return;
+        };
+        if record.get("deleted").and_then(Value::as_bool) == Some(true) {
+            workdirs.remove(id);
+            return;
+        }
+        if let Some(workdir) = record
+            .get("workDir")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|workdir| !workdir.is_empty())
+        {
+            workdirs.insert(id.to_string(), workdir.to_string());
+        }
+    });
+    if !read_ok {
+        return Err(std::io::Error::other(format!(
+            "failed to read Kimi session index {}",
+            path.display()
+        ))
+        .into());
+    }
+    Ok(workdirs)
+}
+
+fn parse_state(
+    path: &Path,
+    fallback_workdir: Option<&String>,
+) -> Result<Option<Session>, AgfError> {
+    let metadata = path.metadata()?;
+    if metadata.len() > MAX_STATE_BYTES {
+        return Ok(None);
+    }
+    let mut content = String::with_capacity(metadata.len() as usize);
+    std::fs::File::open(path)?
+        .take(MAX_STATE_BYTES + 1)
+        .read_to_string(&mut content)?;
+    let Ok(state) = serde_json::from_str::<Value>(&content) else {
+        return Ok(None);
+    };
+    if state.get("archived").and_then(Value::as_bool) == Some(true) {
+        return Ok(None);
+    }
+
+    let Some(session_id) = path
+        .parent()
+        .and_then(|parent| {
+            if parent.file_name().and_then(|name| name.to_str()) == Some("session-meta") {
+                parent.parent()
+            } else {
+                Some(parent)
+            }
+        })
+        .and_then(Path::file_name)
+        .and_then(|name| name.to_str())
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .map(str::to_string)
+    else {
+        return Ok(None);
+    };
+    let project_path = ["/cwd", "/workDir", "/custom/cwd"]
+        .into_iter()
+        .find_map(|pointer| state.pointer(pointer).and_then(Value::as_str))
+        .map(str::trim)
+        .filter(|cwd| !cwd.is_empty())
+        .map(str::to_string)
+        .or_else(|| fallback_workdir.cloned());
+    let Some(project_path) = project_path else {
+        return Ok(None);
+    };
+
+    let mut summaries = Vec::new();
+    for pointer in ["/title", "/lastPrompt"] {
+        let Some(text) = state
+            .pointer(pointer)
+            .and_then(Value::as_str)
+            .map(collapse_whitespace)
+            .filter(|text| !text.is_empty())
+            .map(|text| truncate(&text, 200))
+        else {
+            continue;
+        };
+        if !summaries.contains(&text) {
+            summaries.push(text);
+        }
+    }
+    let file_time = metadata
+        .modified()
+        .ok()
+        .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|duration| i64::try_from(duration.as_millis()).unwrap_or(i64::MAX))
+        .unwrap_or(0);
+    let timestamp = parse_timestamp(state.get("updatedAt"))
+        .or_else(|| parse_timestamp(state.get("createdAt")))
+        .unwrap_or(file_time);
+    let is_child = state
+        .pointer("/custom/child_session_kind")
+        .and_then(Value::as_str)
+        == Some("child");
+
+    Ok(Some(Session {
+        agent: Agent::Kimi,
+        session_id,
+        project_name: project_name_from_path(&project_path),
+        project_path,
+        summaries,
+        timestamp,
+        git_branch: state
+            .get("gitBranch")
+            .or_else(|| state.pointer("/custom/gitBranch"))
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        worktree: state
+            .get("worktreeLabel")
+            .or_else(|| state.pointer("/custom/worktreeLabel"))
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        recap: None,
+        interactive: !is_child,
+    }))
+}
+
+fn parse_timestamp(value: Option<&Value>) -> Option<i64> {
+    match value? {
+        Value::String(timestamp) => chrono::DateTime::parse_from_rfc3339(timestamp)
+            .ok()
+            .map(|timestamp| timestamp.timestamp_millis()),
+        Value::Number(timestamp) => timestamp.as_i64().map(epoch_millis),
+        _ => None,
+    }
+    .filter(|timestamp| *timestamp > 0)
+}
+
+fn epoch_millis(timestamp: i64) -> i64 {
+    if timestamp.unsigned_abs() < 10_000_000_000 {
+        timestamp.saturating_mul(1000)
+    } else {
+        timestamp
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_v2_state_and_legacy_index_workdir() {
+        let root = std::env::temp_dir().join(format!("agf-kimi-scan-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        let sessions_root = root.join("sessions");
+        let current = sessions_root.join("wd_current").join("kimi-current");
+        let legacy = sessions_root.join("wd_legacy").join("kimi-legacy");
+        std::fs::create_dir_all(&current).unwrap();
+        std::fs::create_dir_all(&legacy).unwrap();
+        std::fs::write(
+            current.join("state.json"),
+            r#"{
+              "version":2,
+              "cwd":"/work/kimi-current",
+              "createdAt":1786000000000,
+              "updatedAt":1786000123000,
+              "title":"Implement auth",
+              "lastPrompt":"Add the refresh-token tests",
+              "custom":{}
+            }"#,
+        )
+        .unwrap();
+        std::fs::write(
+            legacy.join("state.json"),
+            r#"{
+              "createdAt":"2026-08-01T00:00:00Z",
+              "updatedAt":"2026-08-02T00:00:00Z",
+              "title":"Legacy session",
+              "lastPrompt":"Recover my cwd",
+              "custom":{}
+            }"#,
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("session_index.jsonl"),
+            format!(
+                "{{\"sessionId\":\"kimi-legacy\",\"sessionDir\":{:?},\"workDir\":\"/work/kimi-legacy\"}}\n",
+                legacy.to_string_lossy()
+            ),
+        )
+        .unwrap();
+
+        let sessions = scan_from(&sessions_root, &root.join("session_index.jsonl")).unwrap();
+        assert_eq!(sessions.len(), 2);
+        let current = sessions
+            .iter()
+            .find(|session| session.session_id == "kimi-current")
+            .unwrap();
+        assert_eq!(current.agent, Agent::Kimi);
+        assert_eq!(current.project_path, "/work/kimi-current");
+        assert_eq!(current.timestamp, 1_786_000_123_000);
+        let legacy = sessions
+            .iter()
+            .find(|session| session.session_id == "kimi-legacy")
+            .unwrap();
+        assert_eq!(legacy.project_path, "/work/kimi-legacy");
+        let _ = std::fs::remove_dir_all(root);
+    }
+}

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -7,12 +7,15 @@ pub mod claude;
 pub mod codex;
 pub mod cursor_agent;
 pub mod gemini;
+pub mod grok;
 pub mod hermes;
+pub mod kimi;
 pub mod kiro;
 pub mod oh_my_pi;
 pub mod opencode;
 pub mod pi;
 pub mod prime_agent;
+pub mod qwen;
 pub mod yolop;
 
 /// Truncate a string to `max` chars, appending "..." if truncated.
@@ -314,6 +317,9 @@ pub fn scan_agent(agent: Agent) -> Result<Vec<Session>, AgfError> {
     match agent {
         Agent::ClaudeCode => claude::scan(),
         Agent::Codex => codex::scan(),
+        Agent::Grok => grok::scan(),
+        Agent::Kimi => kimi::scan(),
+        Agent::Qwen => qwen::scan(),
         Agent::OpenCode => opencode::scan(),
         Agent::Pi => pi::scan(),
         Agent::OhMyPi => oh_my_pi::scan(),

--- a/src/scanner/qwen.rs
+++ b/src/scanner/qwen.rs
@@ -1,0 +1,343 @@
+use std::collections::HashMap;
+use std::io::{BufRead, BufReader, Read};
+use std::path::Path;
+
+use serde_json::Value;
+
+use crate::error::AgfError;
+use crate::model::{Agent, Session};
+
+use super::{collapse_whitespace, project_name_from_path, read_head_tail, truncate};
+
+const MAX_HEAD_BYTES: u64 = 2 * 1024 * 1024;
+const MAX_HEAD_RECORDS: usize = 10;
+const TITLE_WINDOW_BYTES: u64 = 64 * 1024;
+
+pub fn scan() -> Result<Vec<Session>, AgfError> {
+    let root = crate::config::qwen_runtime_dir()?;
+    scan_from_roots(&[root.join("projects"), root.join("tmp")])
+}
+
+fn scan_from_roots(roots: &[std::path::PathBuf]) -> Result<Vec<Session>, AgfError> {
+    let mut by_id: HashMap<String, Session> = HashMap::new();
+    for root in roots {
+        if !root.exists() {
+            continue;
+        }
+        for project_entry in std::fs::read_dir(root)? {
+            let project_entry = project_entry?;
+            if !project_entry.file_type()?.is_dir() {
+                continue;
+            }
+            let chats = project_entry.path().join("chats");
+            if !chats.is_dir() {
+                continue;
+            }
+            for entry in std::fs::read_dir(chats)? {
+                let entry = entry?;
+                let path = entry.path();
+                if !entry.file_type()?.is_file()
+                    || path.extension().and_then(|ext| ext.to_str()) != Some("jsonl")
+                {
+                    continue;
+                }
+                let Some(stem) = path.file_stem().and_then(|name| name.to_str()) else {
+                    continue;
+                };
+                if !is_session_id(stem) {
+                    continue;
+                }
+                if let Some(session) = parse_session(&path)? {
+                    match by_id.get(&session.session_id) {
+                        Some(existing) if existing.timestamp >= session.timestamp => {}
+                        _ => {
+                            by_id.insert(session.session_id.clone(), session);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    let mut sessions: Vec<_> = by_id.into_values().collect();
+    sessions.sort_by(|a, b| crate::model::compare_sessions(a, b, crate::model::SortMode::Time));
+    Ok(sessions)
+}
+
+fn parse_session(path: &Path) -> Result<Option<Session>, AgfError> {
+    let Some(file_id) = path
+        .file_stem()
+        .and_then(|name| name.to_str())
+        .map(str::to_string)
+    else {
+        return Ok(None);
+    };
+    let Some(head) = read_head(path)? else {
+        return Ok(None);
+    };
+    if head.session_id != file_id || head.cwd.is_empty() {
+        return Ok(None);
+    }
+
+    let metadata = path.metadata()?;
+    let file_time = metadata
+        .modified()
+        .ok()
+        .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|duration| i64::try_from(duration.as_millis()).unwrap_or(i64::MAX))
+        .unwrap_or(0);
+    let title = latest_title(path)?;
+    let mut summaries = Vec::new();
+    for text in [title, head.prompt] {
+        let Some(text) = text
+            .map(|text| collapse_whitespace(&text))
+            .filter(|text| !text.is_empty())
+            .map(|text| truncate(&text, 200))
+        else {
+            continue;
+        };
+        if !summaries.contains(&text) {
+            summaries.push(text);
+        }
+    }
+    let timestamp = if file_time != 0 {
+        file_time
+    } else {
+        parse_iso(&head.start_time).unwrap_or(0)
+    };
+    let interactive = !matches!(
+        head.source_type.as_deref(),
+        Some("agent" | "subagent" | "background_agent")
+    );
+
+    Ok(Some(Session {
+        agent: Agent::Qwen,
+        session_id: file_id,
+        project_name: project_name_from_path(&head.cwd),
+        project_path: head.cwd,
+        summaries,
+        timestamp,
+        git_branch: head.git_branch,
+        worktree: None,
+        recap: None,
+        interactive,
+    }))
+}
+
+#[derive(Default)]
+struct HeadInfo {
+    session_id: String,
+    cwd: String,
+    start_time: String,
+    git_branch: Option<String>,
+    prompt: Option<String>,
+    source_type: Option<String>,
+}
+
+fn read_head(path: &Path) -> Result<Option<HeadInfo>, AgfError> {
+    let file = std::fs::File::open(path)?;
+    let mut reader = BufReader::new(file).take(MAX_HEAD_BYTES);
+    let mut line = String::new();
+    let mut info = HeadInfo::default();
+    let mut records_seen = 0usize;
+    let mut first_record_seen = false;
+
+    while records_seen < MAX_HEAD_RECORDS {
+        line.clear();
+        let bytes = reader.read_line(&mut line)?;
+        if bytes == 0 {
+            break;
+        }
+        if line.trim().is_empty() {
+            continue;
+        }
+        records_seen += 1;
+        let parsed = serde_json::from_str::<Value>(&line).ok();
+        if !first_record_seen {
+            first_record_seen = true;
+            if let Some(record) = parsed.as_ref() {
+                info.session_id = string_at(record, "/sessionId").unwrap_or_default();
+                info.cwd = string_at(record, "/cwd").unwrap_or_default();
+                info.start_time = string_at(record, "/timestamp").unwrap_or_default();
+                info.git_branch = string_at(record, "/gitBranch");
+            } else {
+                // A pasted multi-megabyte prompt may make the first JSONL row
+                // exceed our allocation budget. Qwen writes the resumable
+                // envelope before message content, so recover those bounded
+                // prefix fields without retaining the payload.
+                info.session_id = json_string_from_prefix(&line, "sessionId").unwrap_or_default();
+                info.cwd = json_string_from_prefix(&line, "cwd").unwrap_or_default();
+                info.start_time = json_string_from_prefix(&line, "timestamp").unwrap_or_default();
+                info.git_branch = json_string_from_prefix(&line, "gitBranch");
+                if info.session_id.is_empty() || info.cwd.is_empty() {
+                    return Ok(None);
+                }
+                info.prompt = Some("(large prompt)".to_string());
+            }
+        }
+        let Some(record) = parsed.as_ref() else {
+            continue;
+        };
+        if info.prompt.is_none()
+            && record.get("type").and_then(Value::as_str) == Some("user")
+            && record.get("subtype").is_none()
+        {
+            info.prompt = string_at(record, "/systemPayload/displayText").or_else(|| {
+                record
+                    .pointer("/message/parts")
+                    .and_then(Value::as_array)
+                    .and_then(|parts| {
+                        parts.iter().find_map(|part| {
+                            part.get("text").and_then(Value::as_str).map(str::to_string)
+                        })
+                    })
+            });
+        }
+        if record.get("type").and_then(Value::as_str) == Some("system")
+            && record.get("subtype").and_then(Value::as_str) == Some("session_source")
+        {
+            info.source_type = string_at(record, "/systemPayload/sourceType");
+        }
+    }
+
+    if !first_record_seen || info.session_id.is_empty() || info.cwd.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(info))
+    }
+}
+
+fn latest_title(path: &Path) -> Result<Option<String>, AgfError> {
+    let windows =
+        read_head_tail(path, TITLE_WINDOW_BYTES, TITLE_WINDOW_BYTES).ok_or_else(|| {
+            std::io::Error::other(format!("failed to read Qwen session {}", path.display()))
+        })?;
+    let mut title = None;
+    for line in windows.head.lines().chain(windows.tail.lines()) {
+        let Ok(record) = serde_json::from_str::<Value>(line) else {
+            continue;
+        };
+        if record.get("type").and_then(Value::as_str) == Some("system")
+            && record.get("subtype").and_then(Value::as_str) == Some("custom_title")
+            && let Some(current) = string_at(&record, "/systemPayload/customTitle")
+            && !current.trim().is_empty()
+        {
+            title = Some(current);
+        }
+    }
+    Ok(title)
+}
+
+fn string_at(value: &Value, pointer: &str) -> Option<String> {
+    value
+        .pointer(pointer)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|text| !text.is_empty())
+        .map(str::to_string)
+}
+
+fn parse_iso(timestamp: &str) -> Option<i64> {
+    chrono::DateTime::parse_from_rfc3339(timestamp)
+        .ok()
+        .map(|timestamp| timestamp.timestamp_millis())
+}
+
+fn is_session_id(id: &str) -> bool {
+    (32..=36).contains(&id.len())
+        && id
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit() || byte == b'-')
+}
+
+fn json_string_from_prefix(prefix: &str, field: &str) -> Option<String> {
+    let key = format!("\"{field}\"");
+    let mut search_from = 0usize;
+    while let Some(relative) = prefix.get(search_from..)?.find(&key) {
+        let after_key = search_from + relative + key.len();
+        let mut rest = prefix.get(after_key..)?.trim_start();
+        if !rest.starts_with(':') {
+            search_from = after_key;
+            continue;
+        }
+        rest = rest.get(1..)?.trim_start();
+        let encoded = rest.strip_prefix('"')?;
+        let mut escaped = false;
+        for (index, character) in encoded.char_indices() {
+            if escaped {
+                escaped = false;
+            } else if character == '\\' {
+                escaped = true;
+            } else if character == '"' {
+                return serde_json::from_str::<String>(&rest[..=index + 1]).ok();
+            }
+        }
+        return None;
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{Duration, SystemTime};
+
+    #[test]
+    fn parses_official_chat_records_and_latest_custom_title() {
+        let root =
+            std::env::temp_dir().join(format!("agf-qwen-scan-normal-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        let chats = root.join("projects/project-id/chats");
+        std::fs::create_dir_all(&chats).unwrap();
+        let id = "019d1234-1234-7234-8234-123456789abc";
+        let path = chats.join(format!("{id}.jsonl"));
+        std::fs::write(
+            &path,
+            format!(
+                "{{\"uuid\":\"u1\",\"parentUuid\":null,\"sessionId\":\"{id}\",\"timestamp\":\"2026-08-10T00:00:00Z\",\"type\":\"user\",\"cwd\":\"/work/qwen-project\",\"version\":\"1\",\"gitBranch\":\"feat/qwen\",\"message\":{{\"role\":\"user\",\"parts\":[{{\"text\":\"Implement the session picker\"}}]}}}}\n{{\"uuid\":\"u2\",\"parentUuid\":\"u1\",\"sessionId\":\"{id}\",\"timestamp\":\"2026-08-10T00:01:00Z\",\"type\":\"system\",\"subtype\":\"custom_title\",\"cwd\":\"/work/qwen-project\",\"version\":\"1\",\"systemPayload\":{{\"customTitle\":\"Qwen session support\",\"titleSource\":\"manual\"}}}}\n"
+            ),
+        )
+        .unwrap();
+        std::fs::File::options()
+            .write(true)
+            .open(&path)
+            .unwrap()
+            .set_modified(SystemTime::UNIX_EPOCH + Duration::from_millis(1_786_000_123_000))
+            .unwrap();
+
+        let sessions = scan_from_roots(&[root.join("projects")]).unwrap();
+        assert_eq!(sessions.len(), 1);
+        let session = &sessions[0];
+        assert_eq!(session.agent, Agent::Qwen);
+        assert_eq!(session.project_name, "qwen-project");
+        assert_eq!(session.summaries[0], "Qwen session support");
+        assert_eq!(session.summaries[1], "Implement the session picker");
+        assert_eq!(session.git_branch.as_deref(), Some("feat/qwen"));
+        assert_eq!(session.timestamp, 1_786_000_123_000);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn oversized_first_prompt_keeps_resume_envelope_with_bounded_memory() {
+        let root = std::env::temp_dir().join(format!("agf-qwen-scan-large-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        let chats = root.join("projects/project-id/chats");
+        std::fs::create_dir_all(&chats).unwrap();
+        let id = "019d1234-1234-7234-8234-123456789abd";
+        let path = chats.join(format!("{id}.jsonl"));
+        let large = "x".repeat(MAX_HEAD_BYTES as usize + 1024);
+        std::fs::write(
+            &path,
+            format!(
+                "{{\"uuid\":\"u1\",\"parentUuid\":null,\"sessionId\":\"{id}\",\"timestamp\":\"2026-08-10T00:00:00Z\",\"type\":\"user\",\"cwd\":\"/work/qwen-large\",\"version\":\"1\",\"message\":{{\"role\":\"user\",\"parts\":[{{\"text\":\"{large}\"}}]}}}}\n"
+            ),
+        )
+        .unwrap();
+
+        let sessions = scan_from_roots(&[root.join("projects")]).unwrap();
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].session_id, id);
+        assert_eq!(sessions[0].project_path, "/work/qwen-large");
+        assert_eq!(sessions[0].summaries, ["(large prompt)"]);
+        let _ = std::fs::remove_dir_all(root);
+    }
+}

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -372,6 +372,9 @@ impl App {
     }
 
     fn toggle_checked(&mut self, agent: Agent, session_id: &str) {
+        if !agent.supports_delete() {
+            return;
+        }
         let ids = self.selected_set.entry(agent).or_default();
         if !ids.remove(session_id) {
             ids.insert(session_id.to_string());
@@ -1326,9 +1329,22 @@ fn ui_grouped_browse(ui: &mut slt::Context, app: &mut App) {
     });
 }
 
+fn available_actions(agent: Agent) -> Vec<Action> {
+    Action::MENU
+        .into_iter()
+        .filter(|action| *action != Action::Delete || agent.supports_delete())
+        .collect()
+}
+
 fn ui_action_select(ui: &mut slt::Context, app: &mut App, result: &mut Option<String>) {
-    let actions = Action::MENU;
+    let Some(action_agent) = app.action_session().map(|session| session.agent) else {
+        app.active_session = None;
+        app.mode = Mode::Browse;
+        return;
+    };
+    let actions = available_actions(action_agent);
     let action_count = actions.len();
+    app.action_index = app.action_index.min(action_count.saturating_sub(1));
 
     if ui.key_code(slt::KeyCode::Esc) {
         app.active_session = None;
@@ -1671,31 +1687,7 @@ fn ui_agent_select(ui: &mut slt::Context, app: &mut App, result: &mut Option<Str
 }
 
 fn permission_options_for(agent: Agent) -> Vec<(&'static str, &'static str)> {
-    match agent {
-        Agent::ClaudeCode => vec![
-            ("default", ""),
-            ("acceptEdits", " --permission-mode acceptEdits"),
-            ("plan (read-only)", " --permission-mode plan"),
-            ("bypass permissions", " --dangerously-skip-permissions"),
-        ],
-        Agent::Codex => vec![
-            ("suggest (default)", ""),
-            ("auto-edit", " -a untrusted"),
-            ("full-auto", " --full-auto"),
-            (
-                "bypass sandbox",
-                " --dangerously-bypass-approvals-and-sandbox",
-            ),
-        ],
-        Agent::Gemini => vec![
-            ("default", ""),
-            ("auto_edit", " --approval-mode auto_edit"),
-            ("yolo (no approval)", " -y"),
-            ("plan (read-only)", " --approval-mode plan"),
-            ("sandbox", " -s"),
-        ],
-        _ => vec![("default", "")],
-    }
+    agent.resume_mode_options().to_vec()
 }
 
 fn dispatch_agent_option(ui: &mut slt::Context, app: &mut App, result: &mut Option<String>) {
@@ -2614,14 +2606,19 @@ fn render_session_list(ui: &mut slt::Context, app: &App, bulk_mode: bool) {
         };
 
         if bulk_mode {
+            let deletable = session.agent.supports_delete();
             let is_checked = app.is_checked(session);
-            let indicator = match (is_selected, is_checked) {
-                (true, true) => ">[x] ",
-                (true, false) => ">[ ] ",
-                (false, true) => " [x] ",
-                (false, false) => " [ ] ",
+            let indicator = match (is_selected, is_checked, deletable) {
+                (true, _, false) => ">[—] ",
+                (false, _, false) => " [—] ",
+                (true, true, true) => ">[x] ",
+                (true, false, true) => ">[ ] ",
+                (false, true, true) => " [x] ",
+                (false, false, true) => " [ ] ",
             };
-            let indicator_style = if is_checked {
+            let indicator_style = if !deletable {
+                slt::Style::new().fg(GRAY_500).bg(bg)
+            } else if is_checked {
                 slt::Style::new().fg(RED).bold().bg(bg)
             } else {
                 slt::Style::new().fg(slt::Color::White).bg(bg)
@@ -3244,6 +3241,26 @@ mod bulk_selection_tests {
         // The now-empty per-agent bucket is dropped, so `is_empty()` (which
         // drives "am I in bulk mode") stays truthful.
         assert!(app.selected_set.is_empty());
+    }
+
+    #[test]
+    fn native_managed_sessions_cannot_enter_bulk_delete_selection() {
+        let mut app = app_with(
+            vec![session(Agent::Grok, "grok", 30)],
+            crate::settings::Settings::default(),
+        );
+        app.toggle_checked(Agent::Grok, "grok");
+        assert!(app.selected_set.is_empty());
+        assert_eq!(app.selection_count(), 0);
+    }
+
+    #[test]
+    fn native_managed_sessions_hide_single_delete_action() {
+        assert!(!available_actions(Agent::Grok).contains(&Action::Delete));
+        assert!(!available_actions(Agent::Kimi).contains(&Action::Delete));
+        assert!(!available_actions(Agent::Qwen).contains(&Action::Delete));
+        assert!(!available_actions(Agent::PrimeAgent).contains(&Action::Delete));
+        assert!(available_actions(Agent::Codex).contains(&Action::Delete));
     }
 
     #[test]


### PR DESCRIPTION
## Release v0.14.1

Adds first-class local session discovery and exact-ID resume support for:

- xAI Grok Build
- Kimi Code CLI
- Qwen Code

The scanners follow the official upstream storage schemas, honor documented home/runtime overrides, preserve durable activity ordering, and use bounded metadata/head-tail reads. Direct deletion is disabled where it would bypass upstream active-session state or secondary indexes.

README and CHANGELOG document the new agents, resume commands, storage paths, and limitations without expanding the introductory marketing copy.

## Verification

- cargo fmt --all -- --check
- cargo check --all-targets --all-features --locked
- cargo clippy --all-targets --all-features --locked -- -D warnings
- 171 debug tests and 171 release tests
- Rust 1.88 MSRV check
- RustSec: 146 dependencies, 0 vulnerabilities
- release build and cargo package verification
- actual 0.14.1 release binary CLI smoke for grok, kimi, and qwen fixture homes

Closes #80
