### PR TITLE
chore: update Homebrew formula for v0.14.1

### DIFF
--- a/homebrew/agf.rb
+++ b/homebrew/agf.rb
@@ -1,26 +1,26 @@
 class Agf < Formula
   desc "AI Agent Session Finder TUI — find, resume, and manage AI coding agent sessions"
   homepage "https://github.com/subinium/agf"
-  version "0.14.0"
+  version "0.14.1"
   license "MIT"
 
   on_macos do
     if Hardware::CPU.arm?
       url "https://github.com/subinium/agf/releases/download/v#{version}/agf-aarch64-apple-darwin.tar.gz"
-      sha256 "0623218e27e508654c037343d46a043ee1e8e22ae1255426932f2d19d11ed49a"
+      sha256 "499a369fcc10a70a5eb6bc4a626340a81804ee3eaf9902b4d1838a0fb56c890a"
     else
       url "https://github.com/subinium/agf/releases/download/v#{version}/agf-x86_64-apple-darwin.tar.gz"
-      sha256 "3566ac25262203155791c6d9b27c58f3876cb90e156004b9a2ea1b146b70f568"
+      sha256 "7a41857a9c475fa493d191b8ac01d405ed56abf4014549850aa65b7ac22025a7"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
       url "https://github.com/subinium/agf/releases/download/v#{version}/agf-aarch64-unknown-linux-gnu.tar.gz"
-      sha256 "addfbceb61ff04d6b3c56451f0e40ab009e7ec896d1f3f171139832b4da4e780"
+      sha256 "78b0aed0a8c2c1f56c1987309257d4d9fa6fda28fdf140bece1e535934ddaa1d"
     else
       url "https://github.com/subinium/agf/releases/download/v#{version}/agf-x86_64-unknown-linux-gnu.tar.gz"
-      sha256 "3b22d41063c6ea4679c59c11936b427ab7610e72b9c5b08e28d86eadae2c74a0"
+      sha256 "aebd613b141852d32f23e61d34948fc53a1d633a411a52b6023bbedb562c8388"
     end
   end
 


### PR DESCRIPTION
Updates the bundled Homebrew formula to the published v0.14.1 release. All four macOS/Linux checksums come from the release checksums manifest; the Apple ARM64 asset was independently downloaded, checksum-verified, executed as agf 0.14.1, and smoke-tested against Grok, Kimi, and Qwen fixture homes.