### PR TITLE
chore: update Homebrew formula to v0.15.0

### DIFF
--- a/homebrew/agf.rb
+++ b/homebrew/agf.rb
@@ -1,26 +1,26 @@
 class Agf < Formula
   desc "AI Agent Session Finder TUI — find, resume, and manage AI coding agent sessions"
   homepage "https://github.com/subinium/agf"
-  version "0.14.1"
+  version "0.15.0"
   license "MIT"
 
   on_macos do
     if Hardware::CPU.arm?
       url "https://github.com/subinium/agf/releases/download/v#{version}/agf-aarch64-apple-darwin.tar.gz"
-      sha256 "499a369fcc10a70a5eb6bc4a626340a81804ee3eaf9902b4d1838a0fb56c890a"
+      sha256 "361a93f5829b5dc9ffc1009879a0011436dfda295b3df4cfea3f5f3fd74027f8"
     else
       url "https://github.com/subinium/agf/releases/download/v#{version}/agf-x86_64-apple-darwin.tar.gz"
-      sha256 "7a41857a9c475fa493d191b8ac01d405ed56abf4014549850aa65b7ac22025a7"
+      sha256 "5069ac3d8d9e9f9ba6044c0c1e2ff3815fa6366172a29fd846afca189b8c7313"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
       url "https://github.com/subinium/agf/releases/download/v#{version}/agf-aarch64-unknown-linux-gnu.tar.gz"
-      sha256 "78b0aed0a8c2c1f56c1987309257d4d9fa6fda28fdf140bece1e535934ddaa1d"
+      sha256 "2c441575efcf808562d7344d1fe1c62267fc27ab8d78a2394668af9c819ea600"
     else
       url "https://github.com/subinium/agf/releases/download/v#{version}/agf-x86_64-unknown-linux-gnu.tar.gz"
-      sha256 "aebd613b141852d32f23e61d34948fc53a1d633a411a52b6023bbedb562c8388"
+      sha256 "e039b9278b96955378458f10b58eb840807b480dd2ddf373d4a7c832643b8896"
     end
   end
 


### PR DESCRIPTION
## Summary

Update only `homebrew/agf.rb` to the published AGF 0.15.0 release and its four
macOS/Linux architecture-specific SHA-256 checksums. No application source,
lockfile or runtime behavior changes.

## Verification

- Release workflow `33982590150` completed successfully (17/17 jobs) on
  `7a426265b49cd9757cb111902abc8fdfa34536e9`.
- All five downloaded public release archives match `checksums.txt`.
- The published macOS ARM64 and Linux x86_64 archives are byte-identical to the
  workflow artifacts already executed independently.
- macOS ARM64 binary: isolated JSON and read-only MCP smoke passed.
- Linux x86_64 binary: version and structured capabilities passed in a
  network-disabled, read-only Ubuntu 24.04 container.
- Exact crates.io 0.15.0 checksum and clean release-commit provenance verified;
  the release workflow installed that registry version and passed JSON/MCP smoke.
- Ruby formula syntax is valid. The full 18-stage local gate passed again on an
  unchanged formula-only source snapshot: 266 debug, 266 release and 255 minimal
  tests, plus all-target warning-denying Clippy, MSRV 1.88, audit, docs, package
  and installed-binary JSON/MCP checks.
- Public tap updated at `subinium/homebrew-tap@ac4e3c272573e5151c6c294a65e3f8e29e2ae5dd`;
  the fetched remote formula matches this file exactly.
- Actual Homebrew `--build-from-source` install, formula `brew test` and the
  installed binary's JSON/MCP smoke passed. A temporary link required by
  `brew test` was removed afterwards; the previous PATH and Homebrew developer
  mode were preserved. No real provider session was executed.

The release tag remains on the original audited source commit. This follow-up
does not rebuild or replace already published archives.
