### PR TITLE
fix: v0.15.1 - refresh dependencies and correct installation docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 ## [Unreleased]
 
+## [0.15.1] - 2026-09-08
+
+### Changed
+
+- Upgrade `dirs` to 7.0.0, `rusqlite` to 0.40.2 and `sha2` to 0.11.0.
+  `libsqlite3-sys` 0.38.2 replaces the earlier incompatible build macro, allowing
+  the Rust 1.88 MSRV to remain unchanged. Refresh only the related lockfile graph.
+- Remove the transitive `generic-array` 0.14 dependency through the SHA-2 update;
+  disable unused SHA-2 allocation/OID features.
+
+### Fixed
+
+- Adapt cache/Gemini digest formatting to the new SHA-2 output type while
+  retaining identical lowercase, zero-padded SHA-256 identifiers. Add fixed
+  digest vectors, Unicode project-path coverage and exhaustive byte-hex tests.
+
+### Docs
+
+- Recommend `cargo install agf --locked`, explain dependency availability notices
+  and distinguish Rust/C build requirements from prebuilt binary installation.
+- Add Homebrew and upgrade/PATH troubleshooting, accurate OS-specific AGF config
+  locations, and explicit optional shell setup/reload behavior and limitations.
+- Correct the OpenCode upstream link and update the JSON envelope examples.
+
 ## [0.15.0] - 2026-09-06
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agf"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -105,11 +105,11 @@ checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -231,9 +231,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.17"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc",
 ]
@@ -290,12 +290,11 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
- "generic-array",
- "typenum",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -334,9 +333,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.7"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -344,9 +343,9 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "6.0.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+checksum = "8d57d423b3c82e89b9a24ca3091fee61f456a26edbd28d26c65906f4bc1dcd8f"
 dependencies = [
  "dirs-sys",
 ]
@@ -504,16 +503,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -549,14 +538,17 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash",
+]
 
 [[package]]
 name = "hashlink"
-version = "0.11.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
+checksum = "a596f1b20ed2cc5ecac41a164aaebc7258057060f06c0cf7a2ba3991ee7990fb"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -564,6 +556,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -647,9 +648,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.37.0"
+version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
+checksum = "f1d20bef17f513b9b3004532233187769cd072d790971f4e4da0e346eb6401e8"
 dependencies = [
  "cc",
  "pkg-config",
@@ -921,9 +922,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.39.0"
+version = "0.40.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
+checksum = "23f2a97da3e3873c73cb2a2e71b35c40ff95e0b1eefa8d72d8499a6928c3b5b3"
 dependencies = [
  "bitflags",
  "fallible-iterator",
@@ -1078,9 +1079,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1378,12 +1379,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agf"
-version = "0.15.0"
+version = "0.15.1"
 edition = "2024"
 # 1.88 = let-chains (edition 2024); also covers usize::is_multiple_of (1.87).
 rust-version = "1.88"
@@ -15,21 +15,20 @@ readme = "README.md"
 superlighttui = "0.24.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-# 0.40's libsqlite3-sys currently uses std::cfg_select! (Rust 1.95) without
-# declaring that MSRV. Keep the crate's tested Rust 1.88 floor honest.
-rusqlite = { version = "=0.39.0", features = ["bundled"] }
+# 0.40.2 requires libsqlite3-sys 0.38.2, which restores older-toolchain builds.
+rusqlite = { version = "0.40.2", features = ["bundled"] }
 nucleo = "0.5"
 clap = { version = "4", features = ["derive"] }
 thiserror = "2"
 anyhow = "1.0.103"
-dirs = "6"
+dirs = "7"
 chrono = { version = "0.4", features = ["serde"] }
 walkdir = "2"
 rayon = "1"
 unicode-width = "0.2"
 unicode-segmentation = "1.12"
 toml = "1"
-sha2 = "0.10"
+sha2 = { version = "0.11", default-features = false }
 rmcp = { version = "3.2.0", default-features = false, features = ["server", "macros", "transport-io"], optional = true }
 tokio = { version = "1", features = ["rt", "io-std", "sync", "time"], optional = true }
 

--- a/README.md
+++ b/README.md
@@ -15,12 +15,33 @@ Search the sessions your terminal agents already keep locally, then resume the r
 ## Install
 
 ```bash
-cargo install agf
-agf setup
+cargo install agf --locked
 agf
 ```
 
-Requires a Rust toolchain (`rustup` recommended). Prebuilt binaries for macOS, Linux, and Windows are also available on the [Releases page](https://github.com/subinium/agf/releases).
+Building with Cargo requires Rust **1.88 or newer** and a C compiler for bundled
+SQLite. `--locked` uses the dependency versions tested with the release.
+Cargo's `Adding ... (available: ...)` lines are version-selection information,
+not build failures; a newer dependency may require an API or Rust-version change.
+
+Prebuilt binaries for macOS, Linux, and Windows need no Rust toolchain and are
+available on the [Releases page](https://github.com/subinium/agf/releases).
+On macOS or Linux, Homebrew is another option:
+
+```bash
+brew install subinium/tap/agf
+```
+
+For parent-shell directory changes, run `agf setup`, then restart your shell or
+follow its reload instruction. This optional step edits your shell profile; the
+TUI, JSON commands and MCP server also work without it.
+
+### Upgrade
+
+Run `cargo install agf --locked` again, or `brew upgrade subinium/tap/agf` for a
+Homebrew installation. Check `agf --version` afterwards. If it still reports an
+older version, use `type -a agf` (PowerShell: `Get-Command agf -All`) to find a
+shell wrapper or an earlier Cargo/Homebrew executable on PATH.
 
 ### Quick Resume (no TUI)
 
@@ -34,10 +55,11 @@ agf resume project-name   # fuzzy-matches and resumes the best match directly
 agf search parser --agent codex --limit 10
 agf show SESSION_ID --agent codex --include-summaries
 agf resume-plan SESSION_ID --agent codex
+agf capabilities
 agf mcp --agent codex --project /absolute/project/path
 ```
 
-The first three commands return versioned JSON. They do not launch agents or
+The first four commands return versioned JSON. They do not launch agents or
 modify their stores; `resume-plan` returns literal arguments, working directory
 and scoped storage environment for review. The stdio MCP server uses the same
 read-only API. See [agent integration](docs/AGENT_INTEGRATION.md) for schemas,
@@ -66,7 +88,7 @@ Then you either dig through history files or start over.
 | [Prime Agent](https://github.com/PrimeIntellect-ai/prime-agent) | `prime-agent --resume <id>` | `~/.prime/agent/sessions/<id>.jsonl` |
 | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `gemini --resume <id>` | `~/.gemini/tmp/<project>/chats/session-*.json` or `.jsonl` |
 | [Cursor CLI](https://cursor.com/docs/cli/overview) | `cursor-agent --resume <id>` | `~/.cursor/projects/*/agent-transcripts/<id>/<id>.jsonl` (Composer 2+)<br>`~/.cursor/projects/*/agent-transcripts/<id>.txt` (legacy) |
-| [OpenCode](https://github.com/opencode-ai/opencode) | `opencode -s <id>` | `~/.local/share/opencode/opencode.db` |
+| [OpenCode](https://github.com/anomalyco/opencode) | `opencode -s <id>` | `~/.local/share/opencode/opencode.db` |
 | [Kiro](https://kiro.dev) | `kiro-cli chat --resume-id <id>` | Kiro v2 SQLite + Kiro v3 `~/.kiro/sessions/cli/` |
 | [pi](https://github.com/badlogic/pi-mono) | `pi --session <id>` | `~/.pi/agent/sessions/<cwd>/*.jsonl` |
 | [Hermes](https://github.com/NousResearch/hermes-agent) | `hermes --resume <id>` *(cwd-independent — resumes in your current shell directory)* | `~/.hermes/state.db` |
@@ -117,7 +139,7 @@ Pi profile/XDG extensions are not emulated; use the documented roots explicitly.
 
 - **Cross-agent search** — see all supported agents in one list
 - **Fuzzy search** — find sessions by project name, path, branch, or summary
-- **One-key resume** — resume the selected session with the right agent command
+- **Resume actions** — choose a session and launch the right agent command
 - **Quick resume** — `agf resume <query>` skips the TUI entirely
 - **Bulk delete** — `Ctrl+D` to multi-select and clean up stale sessions
 - **Project awareness** — git branches and Claude Code `--worktree` sessions surface in the UI
@@ -177,7 +199,15 @@ Also supports Unicode/CJK search, mouse navigation, agent filters, permission/ap
 
 ## Configuration
 
-Optional. Create `~/.config/agf/config.toml`:
+Optional. AGF uses the platform configuration directory:
+
+| Platform | Configuration file |
+|:---|:---|
+| Linux | `$XDG_CONFIG_HOME/agf/config.toml`, or `~/.config/agf/config.toml` |
+| macOS | `~/Library/Application Support/agf/config.toml` |
+| Windows | `%APPDATA%\agf\config.toml` |
+
+Create the file at the matching location:
 
 ```toml
 sort_by = "time"            # "time" | "name" | "agent"
@@ -191,11 +221,23 @@ You can also edit `search_scope` and `summary_search_count` interactively by pre
 
 ## Shell integration
 
-`agf setup` auto-detects your shell and installs the wrapper. Use `agf setup --shell powershell` (or another supported shell) when auto-detection is ambiguous.
+`agf setup` uses `$SHELL` when available; pass `--shell zsh`, `bash`, `fish`,
+`powershell` (Windows PowerShell 5.1), or `pwsh` (PowerShell 7) explicitly when
+detection is ambiguous.
 
-- **zsh / bash** — appends to `~/.zshrc` or `~/.bashrc`
-- **fish** — writes to `~/.config/fish/config.fish`
-- **PowerShell** (Windows or cross-platform `pwsh`) — writes to `$PROFILE.CurrentUserAllHosts` (`Documents\PowerShell\profile.ps1` on Windows, `~/.config/powershell/profile.ps1` elsewhere)
+- **zsh** — appends to `~/.zshrc`.
+- **bash** — appends to `~/.bash_profile` on macOS, `~/.bashrc` elsewhere.
+- **fish** — uses the platform configuration directory above, with
+  `fish/config.fish` instead of `agf/config.toml`.
+- **PowerShell** — on Windows, uses the Documents known folder with
+  `WindowsPowerShell/profile.ps1` for `powershell` or `PowerShell/profile.ps1`
+  for `pwsh`. Elsewhere it uses the platform configuration directory with
+  `powershell/profile.ps1`.
+
+Setup infers these paths; it does not query the active PowerShell host's
+`$PROFILE` or resolve custom zsh/fish profile locations. For a custom profile,
+including PowerShell or fish on macOS, add the matching initialization line to
+the profile your shell actually loads instead.
 
 If auto-detection misses your shell, run the matching `agf init` form manually:
 
@@ -206,7 +248,8 @@ agf init fish | source                               # fish
 agf init powershell | Out-String | Invoke-Expression # PowerShell
 ```
 
-After upgrading, run `agf setup` again (or restart your shell) to apply the latest wrapper.
+After upgrading, restart your shell or re-evaluate the matching initialization
+line to load the latest wrapper. Setup leaves an existing AGF marker unchanged.
 See [CHANGELOG.md](CHANGELOG.md) for release notes.
 
 ## Requirements
@@ -219,7 +262,7 @@ See [CHANGELOG.md](CHANGELOG.md) for release notes.
 ```bash
 git clone https://github.com/subinium/agf.git
 cd agf
-cargo install --path .
+cargo install --path . --locked
 agf setup
 ```
 
@@ -234,7 +277,8 @@ opt-in, and project scope limits returned records rather than providing an OS
 sandbox. CSV preserves source values, including spreadsheet formula prefixes;
 import it as text when opening untrusted session data in a spreadsheet.
 
-**Amp** is not supported yet because its sessions are stored remotely, which makes it hard to reliably resolve local project paths from session metadata. We are monitoring upstream changes and will add support when feasible.
+Providers outside the supported-agent table, including Amp and GitHub Copilot,
+do not currently have AGF scanners.
 
 ## Built with
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,33 +1,23 @@
-# agf 0.15.0
+# agf 0.15.1
 
-## Agent Tools
+## Dependency Refresh
 
-- Versioned, read-only JSON search, exact session metadata, resume plans and
-  capabilities. No hidden TUI or native-agent execution.
-- Local stdio MCP using the official Rust SDK, with fixed scopes, bounded
-  requests, modern/legacy interoperability tests and a portable Skill.
-- Resume plans preserve literal arguments, the selected executable, cwd and
-  storage-root environment without modifying the parent shell environment.
+- Upgrade `dirs` 6 -> 7, `rusqlite` 0.39 -> 0.40.2 and `sha2` 0.10 -> 0.11.
+- Remove the old transitive `generic-array` dependency. SHA-256 cache and Gemini
+  project identifiers keep their existing encoding, verified with fixed vectors.
+- Keep Rust 1.88 support: `libsqlite3-sys` 0.38.2 fixes the build-macro issue that
+  previously prevented the SQLite upgrade. No unsafe MSRV override is used.
 
-## Compatibility And Safety
+## Installation And Documentation
 
-- SLT 0.24.0 and current/legacy Gemini session formats.
-- Verified provider root overrides, independent Codex SQLite storage, explicit
-  Cursor executable selection and readonly source scans.
-- Configuration preservation and secret-safe diagnostics, Unicode boundary
-  fixes, bounded SQLite title queries, cache recovery and stdout error handling.
-- Correct browse viewport/click boundaries, grapheme search cursors and explicit
-  unknown process state on unsupported backends.
+Use `cargo install agf --locked` to install the release-tested dependency graph,
+or use the prebuilt release archives / `brew install subinium/tap/agf`.
+Cargo's `(available: ...)` output is version-selection information, not an error.
 
-## Boundaries
+The README now documents OS-specific configuration paths, optional shell setup,
+profile selection limitations, wrapper reloads and Cargo/Homebrew PATH conflicts.
+The OpenCode link and JSON envelope examples are refreshed.
 
-The existing 14 scanner providers remain; no new Copilot scanner or web port.
-Gemini deletion uses its native workflow. Codex user configuration is supported,
-not its full project/profile/managed stack; Oh My Pi profile/XDG extensions are
-not emulated. Physical OS IME and real provider execution are distinct from
-fixture-based protocol and terminal tests.
-
-See [Agent Integration](https://github.com/subinium/agf/blob/v0.15.0/docs/AGENT_INTEGRATION.md)
-for contracts and setup, and [the changelog](https://github.com/subinium/agf/blob/v0.15.0/CHANGELOG.md)
-for details. The release workflow gates artifact publication on quality checks
-and an exact registry-installed JSON/MCP consumer.
+No providers, permission defaults or JSON schema fields change in this patch.
+See [the changelog](https://github.com/subinium/agf/blob/v0.15.1/CHANGELOG.md)
+and [agent integration](https://github.com/subinium/agf/blob/v0.15.1/docs/AGENT_INTEGRATION.md).

--- a/docs/AGENT_INTEGRATION.md
+++ b/docs/AGENT_INTEGRATION.md
@@ -84,7 +84,7 @@ and `content` includes one text item containing the same serialized JSON.
 ```json
 {
   "schema_version": 1,
-  "agf_version": "0.15.0",
+  "agf_version": "0.15.1",
   "ok": true,
   "data": {
     "sessions": [],
@@ -99,7 +99,7 @@ and `content` includes one text item containing the same serialized JSON.
 ```json
 {
   "schema_version": 1,
-  "agf_version": "0.15.0",
+  "agf_version": "0.15.1",
   "ok": false,
   "error": { "code": "not_found", "message": "session not found within the requested scope" }
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -269,7 +269,7 @@ fn source_fingerprint(paths: &[PathBuf]) -> SourceFingerprint {
         hasher.update(device.to_le_bytes());
         hasher.update(inode.to_le_bytes());
     }
-    fingerprint.digest = format!("{:x}", hasher.finalize());
+    fingerprint.digest = crate::text::hex_lower(&hasher.finalize());
     fingerprint
 }
 
@@ -544,6 +544,16 @@ pub fn start_stale_scan(stale: &[Agent]) -> std::sync::mpsc::Receiver<ScanResult
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn empty_source_digest_preserves_legacy_cache_encoding() {
+        let fingerprint = source_fingerprint(&[]);
+        assert!(fingerprint.complete);
+        assert_eq!(
+            fingerprint.digest,
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+    }
     use std::io::Write;
     use std::time::{Duration, SystemTime};
 

--- a/src/scanner/gemini.rs
+++ b/src/scanner/gemini.rs
@@ -414,12 +414,32 @@ fn parse_iso8601_ms(s: &str) -> Option<i64> {
 fn sha256_hex(data: &[u8]) -> String {
     let mut hasher = Sha256::new();
     hasher.update(data);
-    format!("{:x}", hasher.finalize())
+    crate::text::hex_lower(&hasher.finalize())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn project_hash_remains_compatible_after_digest_upgrade() {
+        for (input, expected) in [
+            (
+                "",
+                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            ),
+            (
+                "abc",
+                "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+            ),
+            (
+                "/Users/example/\u{d55c}\u{ae00} project",
+                "68420a821cf8c1c26704898224b641ad6f46b38ecc0851e1e1eb22f66266378f",
+            ),
+        ] {
+            assert_eq!(sha256_hex(input.as_bytes()), expected);
+        }
+    }
 
     fn fixture_file(label: &str, extension: &str, bytes: &[u8]) -> std::path::PathBuf {
         let path = std::env::temp_dir().join(format!(

--- a/src/text.rs
+++ b/src/text.rs
@@ -1,4 +1,4 @@
-//! Display-width helpers shared by every renderer (TUI, `list`, `stats`, `watch`).
+//! Text encoding and display-width helpers shared by scanners and renderers.
 //!
 //! Rust's `{:<width$}` pads by `char` count, but a terminal lays text out in
 //! *display columns* — a Hangul syllable or CJK ideograph occupies two. Mixing
@@ -8,6 +8,17 @@
 
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
+
+/// Encode bytes as lowercase hex, including leading zeroes in each byte.
+pub fn hex_lower(bytes: &[u8]) -> String {
+    const DIGITS: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(bytes.len().saturating_mul(2));
+    for &byte in bytes {
+        output.push(char::from(DIGITS[usize::from(byte >> 4)]));
+        output.push(char::from(DIGITS[usize::from(byte & 0x0f)]));
+    }
+    output
+}
 
 /// Remove terminal control sequences from untrusted session metadata.
 ///
@@ -142,6 +153,15 @@ fn truncate_with(s: &str, max_width: usize, ellipsis: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn hex_encoding_matches_byte_formatting() {
+        assert_eq!(hex_lower(&[]), "");
+        assert_eq!(hex_lower(&[0, 1, 15, 16, 128, 255]), "00010f1080ff");
+        let bytes: Vec<u8> = (0..=255).collect();
+        let expected: String = bytes.iter().map(|byte| format!("{byte:02x}")).collect();
+        assert_eq!(hex_lower(&bytes), expected);
+    }
 
     #[test]
     fn fit_produces_exact_columns_for_ascii_and_cjk() {


### PR DESCRIPTION
## Summary

Release **0.15.1**, addressing the reported dependency availability messages and
checking the README against the current CLI, platform paths and shell behavior.

## Dependency Decisions

| Dependency | Decision | Compatibility evidence |
| --- | --- | --- |
| `dirs` 6.0.0 | Upgrade to 7.0.0 | Published source changes Windows `preference_dir` from local to roaming AppData. AGF does not call this function; its home/config/cache/data/document paths use unchanged APIs. |
| `rusqlite` 0.39.0 | Upgrade to 0.40.2 | Requires `libsqlite3-sys` 0.38.2; its bundled build replaces `std::cfg_select!` with an MSRV-compatible macro. Rust 1.88 remains the tested floor, with no `--ignore-rust-version`. |
| `sha2` 0.10.9 | Upgrade to 0.11.0 | New digest output no longer implements `LowerHex`; both cache and Gemini call sites use a shared zero-padded lowercase encoder. Unused new allocation/OID defaults are disabled. |
| `generic-array` 0.14.7 | Removed, not artificially pinned | It was transitive through SHA-2 0.10. SHA-2 0.11 replaces that graph; no direct generic-array dependency or override is added. |

Only the relevant dependency graph is updated. No provider, JSON schema,
permission mode, scan/delete policy or cache format is intentionally changed.
Empty/ASCII/Unicode SHA-256 fixed vectors, an empty-cache digest regression and
all-256-byte hex encoding tests protect existing identifiers.

Sources: [SHA-2 0.11.0](https://docs.rs/crate/sha2/0.11.0),
[rusqlite 0.40.2](https://docs.rs/crate/rusqlite/0.40.2),
[libsqlite3-sys 0.38.2 build source](https://docs.rs/crate/libsqlite3-sys/0.38.2/source/build.rs),
[dirs 7.0.0](https://crates.io/crates/dirs/7.0.0).

## README Corrections

- Recommend `cargo install agf --locked` for the packaged, release-tested
  lockfile. Explain that `(available: ...)` reports version selection, not a
  build failure. [Cargo install documentation](https://doc.rust-lang.org/cargo/commands/cargo-install.html#dealing-with-the-lockfile)
- Document Rust 1.88 and the C compiler for bundled SQLite; distinguish prebuilt
  binaries and Homebrew from source builds.
- Add upgrade/version/PATH troubleshooting and clarify optional profile edits.
- Correct platform-specific AGF configuration files: macOS Application Support,
  Linux XDG config and Windows roaming AppData.
- Describe actual setup paths and explicit PowerShell 5/7 selection; do not
  falsely claim active-host `$PROFILE` discovery. Explain custom-profile and
  macOS fish/PowerShell limitations, and wrapper reload behavior.
- Correct the OpenCode upstream link and avoid unsupported claims about why
  unimplemented providers store sessions remotely. Keep existing examples and
  provider coverage; update JSON envelope version examples.

## Verification

All **19 local gate stages passed** on an unchanged source snapshot:
- Rust 1.98.1: 269 debug tests, 269 release tests and 258 no-default tests.
- Rust 1.88.0: all-target/all-feature check, warning-denying Clippy and the
  complete 269-test suite, including actual PTY and JSON/MCP integration.
- Formatting, all-target checks/Clippy, RustSec, warning-denying rustdoc,
  fresh package verification and installed-binary JSON/MCP smoke.
- Registry verifier unit tests, actionlint, diff checks, and seven local README
  links resolved. No ignored tests and no dependency MSRV bypasses.

Exact-head CI `34240676636` passed **9/9** on
`072deaf9bfc46e8765ae4620fcda02da9c2ca02e`, including Linux, macOS, Windows,
Rust 1.88, no-default features, Clippy, formatting, packaging and security audit.
All tests use synthetic data; no provider-account execution, physical IME test,
user profile edit or user agent-store mutation is performed.

Release workflow will gate five platform archives and exact crates.io provenance
plus registry-installed JSON/MCP smoke. Homebrew checksums follow the actual
published assets in a separate formula-only update.
