### PR TITLE
chore: update Homebrew formula to v0.15.1

### DIFF
--- a/homebrew/agf.rb
+++ b/homebrew/agf.rb
@@ -1,26 +1,26 @@
 class Agf < Formula
   desc "AI Agent Session Finder TUI — find, resume, and manage AI coding agent sessions"
   homepage "https://github.com/subinium/agf"
-  version "0.15.0"
+  version "0.15.1"
   license "MIT"
 
   on_macos do
     if Hardware::CPU.arm?
       url "https://github.com/subinium/agf/releases/download/v#{version}/agf-aarch64-apple-darwin.tar.gz"
-      sha256 "361a93f5829b5dc9ffc1009879a0011436dfda295b3df4cfea3f5f3fd74027f8"
+      sha256 "7c128c8beecb08806b242022e8c2596c5723479e0892d94b4e64a2a5ce22e861"
     else
       url "https://github.com/subinium/agf/releases/download/v#{version}/agf-x86_64-apple-darwin.tar.gz"
-      sha256 "5069ac3d8d9e9f9ba6044c0c1e2ff3815fa6366172a29fd846afca189b8c7313"
+      sha256 "9094b9a981ab76b274344a1514239a57978ae36e799710be79b47c9529dfbbe1"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
       url "https://github.com/subinium/agf/releases/download/v#{version}/agf-aarch64-unknown-linux-gnu.tar.gz"
-      sha256 "2c441575efcf808562d7344d1fe1c62267fc27ab8d78a2394668af9c819ea600"
+      sha256 "671f34411c49806ccc0e9f580f0c3205f6693d8e893dc114872107c60ff2645e"
     else
       url "https://github.com/subinium/agf/releases/download/v#{version}/agf-x86_64-unknown-linux-gnu.tar.gz"
-      sha256 "e039b9278b96955378458f10b58eb840807b480dd2ddf373d4a7c832643b8896"
+      sha256 "db21c06f0a288f832879828278303cafa6d8f1e967751ee7da9962a3c0c0aeeb"
     end
   end
 


### PR DESCRIPTION
## Summary

Update only `homebrew/agf.rb` to the published 0.15.1 archives and their four
macOS/Linux SHA-256 checksums. No application source or lockfile changes.

## Release Evidence

- Release `34241484131` passed 17/17 jobs on
  `8aedb4f71f02a02d2e95b569741457ffc6569635`.
- All five public archives passed the published checksum file.
- macOS ARM64 and Linux x86_64 public archives are byte-identical to the tested
  workflow artifacts. macOS JSON/MCP smoke and isolated Linux version/capabilities
  execution passed without real provider sessions.
- Exact crates.io checksum/clean commit provenance passed. The release job also
  installed registry version 0.15.1 and ran the JSON/MCP smoke successfully.
- Ruby formula syntax is valid. Full local gates passed **19/19** on an unchanged
  source snapshot: 269 debug/release/MSRV tests, 258 minimal tests, all-target
  warning-denying Clippy, Rust 1.88, audit, docs, package and installed JSON/MCP.
- Public tap updated at `dcc7e68d296be9e35f98b08d1f85f44104720e7d`; fetched
  formula content matches this file exactly.
- Actual Homebrew `--build-from-source --skip-link` installation, `brew test`
  and the installed binary's JSON/MCP smoke passed. The temporary link required
  by `brew test` was removed afterwards; user profiles and the existing Cargo
  executable were not changed.

The existing release tag and its immutable archives are unchanged.
